### PR TITLE
Make project headers double-clickable

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -854,7 +854,16 @@ fn board_mouse_intent(
     } else {
         crate::ui::render::QueueHitMap::default()
     };
-    let intent = crate::ui::mouse::map_board_mouse(model, &hits, mouse)?;
+    let intent = crate::ui::mouse::map_board_mouse(model, &hits, mouse);
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+        && !matches!(intent, Some(BoardIntent::SelectSectionProject(_)))
+    {
+        // A double-click is two consecutive clicks on the same project header. Any other
+        // pointer target, including inert board space, cancels the armed first click before
+        // the next event can be mistaken for its second half.
+        model.cancel_project_header_double_click();
+    }
+    let intent = intent?;
     let intent = board_intent_for_area(area, intent)?;
     resolve_board_command(model, intent)
 }
@@ -1708,6 +1717,8 @@ mod idle_store_revalidation_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     use crate::context::InvocationSnapshot;
@@ -2002,6 +2013,85 @@ mod tests {
              ConfirmCommand does"
         );
         assert_eq!(domain.get(id).expect("task").status, HumanStatus::Ready);
+    }
+
+    #[test]
+    fn intervening_task_click_cancels_an_armed_project_header_double_click() {
+        use crate::ui::board::{apply_intent, board_hit_map};
+        use crate::ui::mouse::left_click;
+        use crate::ui::render::QueueHitTarget;
+
+        let mut domain = DomainState::new();
+        let id = domain
+            .create(
+                "click between headers",
+                None,
+                TaskScope::Project {
+                    path: "/repos/app".into(),
+                },
+                None,
+                None,
+                ProvenanceOrigin::Manual,
+            )
+            .expect("create task");
+        let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/app")));
+        let area = Rect::new(0, 0, 80, 24);
+
+        fn target_mouse(
+            area: Rect,
+            model: &BoardModel,
+            target: impl Fn(QueueHitTarget) -> bool,
+        ) -> crossterm::event::MouseEvent {
+            let hits = board_hit_map(area, model);
+            let hit = hits
+                .regions
+                .iter()
+                .find(|hit| target(hit.target))
+                .unwrap_or_else(|| panic!("missing target in {hits:?}"));
+            left_click(hit.area.x, hit.area.y)
+        }
+        let drive_click = |domain: &mut DomainState,
+                           model: &mut BoardModel,
+                           mouse: crossterm::event::MouseEvent| {
+            let intent = board_mouse_intent(area, model, mouse).expect("click maps to intent");
+            apply_intent(domain, model, intent, None, None).expect("click applies");
+        };
+
+        let mouse = target_mouse(area, &model, |target| {
+            matches!(target, QueueHitTarget::SectionProject(_))
+        });
+        drive_click(&mut domain, &mut model, mouse);
+        assert_eq!(
+            model.selected_project(),
+            None,
+            "first header click only arms"
+        );
+
+        let mouse = target_mouse(
+            area,
+            &model,
+            |target| matches!(target, QueueHitTarget::Task(task_id) if task_id == id),
+        );
+        drive_click(&mut domain, &mut model, mouse);
+        let mouse = target_mouse(area, &model, |target| {
+            matches!(target, QueueHitTarget::SectionProject(_))
+        });
+        drive_click(&mut domain, &mut model, mouse);
+        assert_eq!(
+            model.selected_project(),
+            None,
+            "header click after an intervening task click must be a new first click"
+        );
+
+        let mouse = target_mouse(area, &model, |target| {
+            matches!(target, QueueHitTarget::SectionProject(_))
+        });
+        drive_click(&mut domain, &mut model, mouse);
+        assert_eq!(
+            model.selected_project(),
+            Some(Path::new("/repos/app")),
+            "only two consecutive header clicks scope the board"
+        );
     }
 
     /// live dispatch reaches the project selector by mouse and keyboard in

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -616,6 +616,37 @@ fn apply_board_intent(
             model.clear_message();
             return Ok(IntentOutcome::None);
         }
+        BoardIntent::SelectSectionProject(index) => {
+            // Mouse-only jump: an all-projects ON DECK group header names its own project.
+            // The first click only arms that path; a second click on the same header within
+            // the task-row double-click window adopts it exactly the way choosing it in the
+            // selector dropdown would. Session-only navigation: nothing durable is touched.
+            // A stale section index or a header without a project remains inert.
+            let Some(path) = model
+                .queue_view()
+                .sections
+                .get(index)
+                .and_then(|section| section.project_label.clone())
+                .map(Into::into)
+            else {
+                return Ok(IntentOutcome::None);
+            };
+            let now = Instant::now();
+            let is_double = model
+                .last_project_header_click
+                .as_ref()
+                .is_some_and(|(at, last)| {
+                    last == &path && now.duration_since(*at) <= ROW_DOUBLE_CLICK_WINDOW
+                });
+            if is_double {
+                model.last_project_header_click = None;
+                model.set_deck_scope(ProjectScopeOption::Project(path));
+                model.clear_message();
+            } else {
+                model.last_project_header_click = Some((now, path));
+            }
+            return Ok(IntentOutcome::None);
+        }
         BoardIntent::RecoveryResume => {
             let Some(attempt) = model.selected_attempt().cloned() else {
                 model.close_popup();

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -408,6 +408,7 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
         view: &queue_view,
         selection_id: model.selection_id,
         scope_label: &scope_label,
+        all_projects_scope: matches!(&model.deck_scope, OwnedDeckScope::All),
         status_message: status_owned.as_deref(),
         status_undo_offset,
         verb_items: &verbs,

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -618,6 +618,12 @@ impl BoardModel {
         }
     }
 
+    /// Cancel an armed project-header double-click when another pointer target
+    /// intervenes. Mouse-boundary state only, never persisted.
+    pub(crate) fn cancel_project_header_double_click(&mut self) {
+        self.last_project_header_click = None;
+    }
+
     /// Options the session project selector offers, in presentation order.
     ///
     /// All projects and Global are always available. Project entries are paths that really

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -388,6 +388,10 @@ pub struct BoardModel {
     /// The last task-row click (time + id), kept only to detect a double-click that opens
     /// the task page. Presentation-only, never persisted.
     pub(super) last_row_click: Option<(Instant, Uuid)>,
+    /// The last all-projects group-header click (time + project path), kept only to detect
+    /// a double-click that narrows the board to that project. Presentation-only, never
+    /// persisted.
+    pub(super) last_project_header_click: Option<(Instant, PathBuf)>,
     pub(super) input_mode: BoardInputMode,
     /// The one active board form. It is present for inline capture and task editing alike;
     /// task identity or invocation context are held inside it and never rebound after open.
@@ -451,6 +455,7 @@ impl BoardModel {
             detail_open: None,
             selection_id: None,
             last_row_click: None,
+            last_project_header_click: None,
             input_mode: BoardInputMode::Normal,
             form: None,
             message: None,

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -181,6 +181,11 @@ pub enum BoardIntent {
     /// the task list: it runs the same effect `ConfirmProjectChoice` does after enough
     /// `ProjectPickerNext`/`ProjectPickerPrev` presses reached this option.
     SelectProjectOption(usize),
+    /// Register one click on an all-projects ON DECK group header by that header's painted
+    /// section index (mouse-only). Two clicks on the same project within the double-click
+    /// window run the same session-only scope jump choosing it in the selector dropdown
+    /// would; no key produces it.
+    SelectSectionProject(usize),
     /// Continue the selected durable dispatch attempt.
     RecoveryResume,
     /// Ask for explicit confirmation before removing recorded owned receipts.
@@ -749,6 +754,7 @@ pub fn intent_primary_action(intent: &BoardIntent) -> Option<PrimaryBoardAction>
         | BoardIntent::ConfirmProjectChoice
         | BoardIntent::CancelProjectPicker
         | BoardIntent::SelectProjectOption(_)
+        | BoardIntent::SelectSectionProject(_)
         | BoardIntent::RecoveryResume
         | BoardIntent::BeginCleanup
         | BoardIntent::ConfirmCleanup

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -449,6 +449,9 @@ pub fn map_board_mouse(
         | BoardInputMode::SaveRecovery => None,
         BoardInputMode::Normal => match hit_at(hits, pos) {
             Some(QueueHitTarget::ProjectChip) => Some(BoardIntent::OpenProjectSelector),
+            Some(QueueHitTarget::SectionProject(index)) => {
+                Some(BoardIntent::SelectSectionProject(index))
+            }
             Some(QueueHitTarget::Drawer) => Some(BoardIntent::ToggleDoneDrawer),
             Some(QueueHitTarget::Task(id)) => model
                 .visible_ids()

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -431,6 +431,12 @@ pub enum QueueHitTarget {
     /// One painted row of the open project-scope dropdown, indexed exactly as
     /// `BoardModel::project_options()` orders them.
     ProjectOption(usize),
+    /// One ON DECK project-group header in the all-projects view, indexed into
+    /// `QueueFrameModel::view.sections`. A double-click narrows the session deck scope to
+    /// that header's own project: the same session-only jump choosing it in the project
+    /// selector dropdown performs. Never pushed for IN MOTION, DONE, the global group,
+    /// or any header while the board is already scoped to one project.
+    SectionProject(usize),
     /// The open help card: painted full-frame so any click inside it closes it, matching
     /// the keyboard's "any key closes".
     HelpDismiss,
@@ -570,10 +576,27 @@ pub fn draw_queue_frame(
             let y = top + offset as u16;
             match list_row {
                 ListRow::Blank => put_line(frame, y, width, Line::from("")),
-                ListRow::Header(kind, line) => {
+                ListRow::Header(kind, section_idx, line) => {
                     put_line(frame, y, width, line);
                     if kind == SectionKind::Done && base_list_interactive {
                         hits.push(QueueHitTarget::Drawer, Rect::new(0, y, width, 1));
+                    }
+                    // An all-projects ON DECK group header names the project it groups;
+                    // offer the row as that project's own scope control. Scoped views
+                    // title the section plain ON DECK, so no target is pushed there.
+                    if kind == SectionKind::OnDeck
+                        && base_list_interactive
+                        && model.scope_label == "all projects"
+                        && model
+                            .view
+                            .sections
+                            .get(section_idx)
+                            .is_some_and(|section| section.project_label.is_some())
+                    {
+                        hits.push(
+                            QueueHitTarget::SectionProject(section_idx),
+                            Rect::new(0, y, width, 1),
+                        );
                     }
                 }
                 ListRow::Hint(line) => put_line(frame, y, width, line),
@@ -1636,9 +1659,11 @@ fn paint_scope_dropdown(
 
 enum ListRow {
     Blank,
-    /// Section header row, carrying its section kind so the paint loop can offer the
-    /// DONE header as the drawer's own toggle control.
-    Header(SectionKind, Line<'static>),
+    /// Section header row, carrying its section kind plus its index into
+    /// `QueueFrameModel::view.sections`, so the paint loop can offer the DONE header as
+    /// the drawer's own toggle control and an all-projects group header as that
+    /// project's own scope control.
+    Header(SectionKind, usize, Line<'static>),
     Hint(Line<'static>),
     Task {
         id: Uuid,
@@ -1865,7 +1890,7 @@ fn build_list_rows(
     };
 
     let mut capture_inserted = false;
-    for section in &model.view.sections {
+    for (section_idx, section) in model.view.sections.iter().enumerate() {
         // A preceding section with no content already ends in its required below-header blank
         // row, which doubles as this heading's above-header row. Otherwise add one list row.
         if !matches!(out.last(), Some(&ListRow::Blank)) {
@@ -1873,6 +1898,7 @@ fn build_list_rows(
         }
         out.push(ListRow::Header(
             section.kind,
+            section_idx,
             paint_section_header(section, geo.row_width, model.scope_label == "all projects"),
         ));
         // every kind, in either tier, gets its below-header spacer before first

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -388,6 +388,10 @@ pub struct QueueFrameModel<'a> {
     pub selection_id: Option<Uuid>,
     /// Project chip label (`all projects` or a project name).
     pub scope_label: &'a str,
+    /// Whether the session deck scope is structurally the all-projects scope. Kept
+    /// separate from `scope_label`, which is display text and can collide with a real
+    /// project name.
+    pub all_projects_scope: bool,
     /// Optional status-line notice; replaces the default counts when set.
     pub status_message: Option<&'a str>,
     /// Column offset of the delete-notice `u Undo` control inside `status_message`, when
@@ -586,7 +590,7 @@ pub fn draw_queue_frame(
                     // title the section plain ON DECK, so no target is pushed there.
                     if kind == SectionKind::OnDeck
                         && base_list_interactive
-                        && model.scope_label == "all projects"
+                        && model.all_projects_scope
                         && model
                             .view
                             .sections
@@ -1899,7 +1903,7 @@ fn build_list_rows(
         out.push(ListRow::Header(
             section.kind,
             section_idx,
-            paint_section_header(section, geo.row_width, model.scope_label == "all projects"),
+            paint_section_header(section, geo.row_width, model.all_projects_scope),
         ));
         // every kind, in either tier, gets its below-header spacer before first
         // content. It is a `ListRow`, not chrome, and therefore scrolls normally.

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -317,6 +317,33 @@ fn all_projects_group_header_double_click_scopes_the_board_to_that_project() {
     );
 }
 
+#[test]
+fn scoped_project_named_all_projects_has_no_group_header_hit_target() {
+    const COLLIDING_REPO: &str = "/repos/all projects";
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "name collision",
+            None,
+            project(COLLIDING_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(COLLIDING_REPO)));
+    model.set_selected_project(Some(PathBuf::from(COLLIDING_REPO)));
+
+    let hits = board_hit_map(STANDARD, &model);
+    assert!(
+        !hits
+            .regions
+            .iter()
+            .any(|hit| matches!(hit.target, QueueHitTarget::SectionProject(_))),
+        "actual scoped state, not its colliding display label, must keep ON DECK inert: {hits:?}"
+    );
+}
+
 /// inline capture's painted fields focus the shared form, while Scope opens its
 /// dropdown. Selecting an option changes only the capture draft and closes back to it.
 #[test]

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -6,7 +6,7 @@
 //! path and the mouse path and comparing what actually happened, never by asserting a
 //! mapping table.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
@@ -265,6 +265,55 @@ fn hit_map_covers_selection_rows_verbs_drawer_selector_chip_dropdown_palette_row
             .iter()
             .any(|hit| matches!(hit.target, QueueHitTarget::HelpDismiss)),
         "no help dismiss hit region: {hits:?}"
+    );
+}
+
+#[test]
+fn all_projects_group_header_double_click_scopes_the_board_to_that_project() {
+    // All-projects view (the default): each ON DECK project group's header is that
+    // project's own scope control, resolved through the same queue view the frame
+    // painted rather than by searching rendered text.
+    let (mut domain, mut model, _id) = scoped_board();
+    assert_eq!(model.selected_project(), None, "fixture starts unscoped");
+    let hits = board_hit_map(STANDARD, &model);
+    let view = model.queue_view();
+    let header = hits
+        .regions
+        .iter()
+        .find(|hit| match hit.target {
+            QueueHitTarget::SectionProject(index) => {
+                view.sections
+                    .get(index)
+                    .and_then(|section| section.project_label.as_deref())
+                    == Some(OTHER_REPO)
+            }
+            _ => false,
+        })
+        .unwrap_or_else(|| panic!("no group header hit region for {OTHER_REPO}: {hits:?}"));
+    let intent = click(header, &model, &hits).expect("header click maps to an intent");
+    apply_intent(&mut domain, &mut model, intent.clone(), None, None)
+        .expect("apply first header click");
+    assert_eq!(
+        model.selected_project(),
+        None,
+        "one header click must leave the all-projects scope unchanged"
+    );
+    apply_intent(&mut domain, &mut model, intent, None, None).expect("apply second header click");
+    assert_eq!(
+        model.selected_project(),
+        Some(Path::new(OTHER_REPO)),
+        "header double-click narrows the session deck scope to the clicked project"
+    );
+
+    // Scoped to one project the header reads plain ON DECK, so it stops being a scope
+    // control: no SectionProject target may be pushed at all.
+    let hits = board_hit_map(STANDARD, &model);
+    assert!(
+        !hits
+            .regions
+            .iter()
+            .any(|hit| matches!(hit.target, QueueHitTarget::SectionProject(_))),
+        "scoped view must not offer group-header scope controls: {hits:?}"
     );
 }
 

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -298,6 +298,7 @@ fn fixture_model<'a>(tasks: &'a [Task], view: &'a QueueView) -> QueueFrameModel<
         view,
         selection_id: Some(Uuid::from_u128(1)),
         scope_label: "all projects",
+        all_projects_scope: true,
         status_message: None,
         status_undo_offset: None,
         verb_items: fixture_verbs(),
@@ -577,6 +578,7 @@ fn empty_hint_and_capture_first_content_keep_symmetric_spacing_and_compact_contr
     );
     let empty_model = QueueFrameModel {
         scope_label: "empty",
+        all_projects_scope: false,
         ..fixture_model(&tasks, &view)
     };
 
@@ -1830,6 +1832,8 @@ fn compact_paints_no_takeover_for_a_detail_open_task_excluded_by_the_current_sco
     );
     let model = QueueFrameModel {
         detail_open: Some(excluded_id),
+        scope_label: "herdr-tasks",
+        all_projects_scope: false,
         ..fixture_model(&tasks, &scoped_view)
     };
 


### PR DESCRIPTION
## Summary
- make project group headers clickable in the all-projects board view
- require a double-click before narrowing the board to that project
- keep project headers inert once the board is scoped

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo build --release`
- live Herdr smoke: one click stayed on all projects, double-click scoped to herdr-tasks