### PR TITLE
feat: add task threads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,10 @@ For scriptable board work, use `herdr-tasks add` and `herdr-tasks list`; read
 
 ### Board
 
-- Sections are computed, never navigated: IN MOTION · project groups when showing
-  all projects, ON DECK when scoped · global last · done drawer (`z`)
+- Sections and scoped thread headers are computed, never navigated: IN MOTION · project
+  groups when showing all projects, ON DECK when scoped · global last · done drawer (`z`).
+  Scoped ON DECK thread blocks paint dim `#name` headers with open counts; headers consume
+  row budget but are not selectable or hit-testable.
 - Standard ≥78×24, compact below, operable to 40×10
 - Human status: `ready` · `started` · `blocked` · `review` · `done`. The store
   still reads old `todo`/`doing` values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,14 @@ For scriptable board work, use `herdr-tasks add` and `herdr-tasks list`; read
   expands the draft onto the task page with a title·notes·scope stash, so Esc
   returns to the line and a second `Tab` restores what was typed. A project board
   defaults the draft to that project, a Global board defaults it to global, and All
-  keeps the invocation cwd-derived default. Scope tokens in the title: bare `!p`
-  global, `!p name` by project basename (case-insensitive),
-  `!p /path` verbatim; tokens are stripped from the saved title. A saved task
-  becomes the selection. Success has no status message: the row flash is the
-  feedback. Refusals paint while the line is open and clear when it closes.
+  keeps the invocation cwd-derived default. Capture tokens in the title: `!p` and
+  `!t` each consume one whitespace-delimited argument. Bare `!p` selects global,
+  `!p name` selects a project basename (case-insensitive), and `!p /path` uses that
+  path verbatim. Bare `!t` unthreads, while `!t name` assigns a normalized thread:
+  lowercase ASCII alphanumerics and hyphens, starting with an alphanumeric, at most
+  32 characters. Tokens are stripped from the saved title. A saved task becomes the
+  selection. Success has no status message: the row flash is the feedback. Refusals
+  paint while the line is open and clear when it closes.
 - There is no inline board capture form. Creation detail lives on the task page;
   the standalone Capture UI (`AppMode::Capture`, `src/ui/capture.rs`) is a
   separate surface reached through the host launcher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ Peek, task page, project scope, done drawer, and undo are on the board.
 
 Park, resume, linking, and dispatch-start are not board actions. Dispatch
 recovery still opens if a persisted attempt is already in the store.
+
+Tasks can carry an optional normalized thread. Headless add accepts `--thread`
+and plan item `thread`; `herdr-tasks list --thread <name>` filters within the
+selected scope, JSON rows always include `thread`, and human rows append
+` #name` only for threaded tasks.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,3 +21,9 @@ Canonical terms for this repo. No implementation detail.
 - **toggle**: flip one step's done flag. The only step state change that is not a text change.
 - **step cursor**: the task page's step-row focus. Inactive on page open; a bare ↓ activates it (again after any deactivation), ↑ from the first step deactivates it. While active, bare arrows move it and modifier-protected verbs act on it; a single click on a step row moves it.
 - **step short id**: an unambiguous prefix of a step's stable identity, the way tasks are addressed from the CLI.
+- **thread**: an optional single name a task carries, grouping it with same-named tasks in the same scope. Not an entity: no identity beyond the name, no status, no lifecycle. It presents on the board exactly while at least one open task in its scope carries it; the field itself persists on the task regardless of status.
+- **thread token**: the `!t name` capture directive, sibling of `!p`; bare `!t` means unthreaded. Stripped from the saved title.
+- **thread header**: a derived, non-selectable board row above a thread's open tasks in a scoped deck group, showing the thread name and open count. Chrome, not a task.
+- **unthreaded**: carrying no thread. Unthreaded tasks list after thread groups within their deck group.
+- **open task**: human status ready, blocked, or review, and not soft-deleted. The tasks a thread header groups and counts.
+- **thread block**: the derived unit of one thread's header plus its ordered open tasks inside a deck section. Exists only in query output, never in the store.

--- a/skills/herdr-tasks-cli/SKILL.md
+++ b/skills/herdr-tasks-cli/SKILL.md
@@ -13,24 +13,31 @@ inspect the shared board store before and after adding work.
 ```sh
 herdr-tasks add -t "Draft release notes"
 herdr-tasks add -t "Buy milk" --global
-herdr-tasks add -t "Fix widget" --project widget
+herdr-tasks add -t "Fix widget" --project widget --thread release-2026
 herdr-tasks add --title="-fix parser" --notes="-5 degrees" --project="-maintenance"
 herdr-tasks add --file plan.json
 cat plan.json | herdr-tasks add
 ```
 
 Use `--title=<value>`, `--notes=<value>`, `--project=<value>`,
-`--state-dir=<dir>`, or `--file=<path>` when a value begins with `-`. Use
-`--json` with a flag add when another tool needs one result object.
-It contains `outcome` (`created` or `existing`), `id`, trimmed `title`, and resolved
-`project` (or `null` for global).
+`--state-dir=<dir>`, or `--file=<path>` when a value begins with `-`.
+`--thread <name>` assigns the normalized thread name to a flag add. Item flags
+plus `--file` are usage (exit 2, nothing persists). Piped stdin with item flags
+is ignored and not read. Use `--json` with a flag add when another
+tool needs one result object. It contains `outcome` (`created` or `existing`),
+`id`, trimmed `title`, and resolved `project` (or `null` for global).
+
+Plan JSON accepts a per-item `thread` string or `null`, for example
+`[{"title":"Release notes","thread":"release-2026"}]`. Invalid plan thread
+values are item refusals with code `invalid-thread`; valid sibling items still
+persist and the command exits 1.
 
 ## Exit and retry contract
 
 - exit 0: every item was created or already existed.
-- exit 1: one or more plan items were refused. Retry only the `failed` subset.
-  `created` and `existing` items both succeeded, so you must never whole-plan-retry an
-  exit 1 run.
+- exit 1: one or more plan items were refused, including `invalid-thread`.
+  Valid siblings still persist. Retry only the `failed` subset. `created` and
+  `existing` items both succeeded, so you must never whole-plan-retry an exit 1 run.
 - exit 2: usage or parse error, nothing persisted. Correct the invocation, then run it.
 - exit 3: store I/O, commit indeterminate. Run `herdr-tasks list --all --json` to
   check every scope, then retry only missing work. You must never whole-plan-retry an exit 3 run.
@@ -44,10 +51,13 @@ reports it in `existing` with its `i`, `id`, and `title`.
 `herdr-tasks list` defaults to ready, started, blocked, and review tasks in the
 invocation project, or global scope outside a repository. Use `-p`/`--project <scope>`
 for the same basename-or-path resolution as add, `--global` for global tasks, or `--all`
-for every scope. Use `--project=<scope>` or `--state-dir=<dir>` when either list value
-begins with `-`, `-p -maintenance` is usage. `--done` lists done tasks only; `--deleted` lists soft-deleted tasks only,
-regardless of stored status. Scope selectors are mutually exclusive, as are `--done` and
-`--deleted`.
+for every scope. `--thread <name>` normalizes then filters tasks after scope
+selection. An invalid thread name is a usage error (exit 2), not an empty result.
+JSON rows always include `thread`, with `null` for unthreaded tasks. Use
+`--project=<scope>` or `--state-dir=<dir>` when either value begins with `-`,
+`-p -maintenance` is usage. `--done` lists done tasks only; `--deleted` lists
+soft-deleted tasks only, regardless of stored status. Scope selectors are mutually
+exclusive, as are `--done` and `--deleted`.
 
 A typo in a project name silently files the task under a new scope. Use
 `herdr-tasks list --all --json` to recover the resulting scope.

--- a/src/app.rs
+++ b/src/app.rs
@@ -3244,7 +3244,13 @@ mod tests {
         thread::sleep(Duration::from_millis(5));
         let mut other = store.load().unwrap();
         other
-            .edit(id, "Newer title from other board", None, TaskScope::Global)
+            .edit(
+                id,
+                "Newer title from other board",
+                None,
+                TaskScope::Global,
+                None,
+            )
             .unwrap();
         store.save(&other).unwrap();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -651,6 +651,7 @@ fn board_keyboard_intent(
         mode,
         BoardInputMode::EditTitle
             | BoardInputMode::EditNotes
+            | BoardInputMode::EditThread
             | BoardInputMode::EditScope
             | BoardInputMode::FormScopeDropdown
     );
@@ -693,6 +694,7 @@ pub fn apply_board_intent_with_save_recovery(
                 model.close_command_surface();
                 if let Some(working) = recovery.retry(|working| persist(working)) {
                     *domain = working;
+                    model.release_task_edit_save();
                     model.sync_from_domain(domain);
                     model.end_save_recovery(SaveResolution::Retried);
                     if !model.has_saved_task() {
@@ -757,8 +759,26 @@ pub fn apply_board_intent_with_save_recovery(
         }
     }
 
-    let outcome = apply_intent(domain, model, intent, snapshot, host)?;
+    let holds_task_edit = matches!(
+        intent,
+        BoardIntent::ConfirmEdit | BoardIntent::ConfirmEditNext
+    ) && model.edit_target().is_some();
+    if holds_task_edit {
+        model.hold_task_edit_save();
+    }
+    let outcome = match apply_intent(domain, model, intent, snapshot, host) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            if holds_task_edit {
+                model.release_task_edit_save();
+            }
+            return Err(error);
+        }
+    };
     if outcome != IntentOutcome::Persist {
+        if holds_task_edit {
+            model.release_task_edit_save();
+        }
         return Ok(outcome);
     }
     if let Err(error) = persist(domain) {
@@ -767,6 +787,7 @@ pub fn apply_board_intent_with_save_recovery(
         model.begin_save_recovery(recovery.error().unwrap_or("save failed"));
         return Ok(IntentOutcome::None);
     }
+    model.release_task_edit_save();
     model.sync_from_domain(domain);
     Ok(IntentOutcome::Persisted)
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -762,14 +762,10 @@ pub fn apply_board_intent_with_save_recovery(
     let holds_task_edit = matches!(
         intent,
         BoardIntent::ConfirmEdit | BoardIntent::ConfirmEditNext
-    ) && matches!(
-        model.input_mode(),
-        BoardInputMode::TaskPage
-            | BoardInputMode::EditTitle
-            | BoardInputMode::EditNotes
-            | BoardInputMode::EditThread
-            | BoardInputMode::EditScope
-    );
+    ) && model.edit_target().is_some()
+        // Step saves use the same intent but their own pending-save state. Holding the task
+        // form here would retain stale task-edit state that was never created.
+        && model.input_mode() != BoardInputMode::EditStep;
     if holds_task_edit {
         model.hold_task_edit_save();
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -764,7 +764,8 @@ pub fn apply_board_intent_with_save_recovery(
         BoardIntent::ConfirmEdit | BoardIntent::ConfirmEditNext
     ) && matches!(
         model.input_mode(),
-        BoardInputMode::EditTitle
+        BoardInputMode::TaskPage
+            | BoardInputMode::EditTitle
             | BoardInputMode::EditNotes
             | BoardInputMode::EditThread
             | BoardInputMode::EditScope

--- a/src/app.rs
+++ b/src/app.rs
@@ -762,7 +762,13 @@ pub fn apply_board_intent_with_save_recovery(
     let holds_task_edit = matches!(
         intent,
         BoardIntent::ConfirmEdit | BoardIntent::ConfirmEditNext
-    ) && model.edit_target().is_some();
+    ) && matches!(
+        model.input_mode(),
+        BoardInputMode::EditTitle
+            | BoardInputMode::EditNotes
+            | BoardInputMode::EditThread
+            | BoardInputMode::EditScope
+    );
     if holds_task_edit {
         model.hold_task_edit_save();
     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -53,6 +53,7 @@ impl From<StoreError> for CaptureError {
 ///
 /// - Scope: `scope_override` when set, else `snapshot.default_scope`.
 /// - Capsule, agent meta, and provenance origin come from the snapshot.
+/// - `thread`, when supplied, is already normalized and enters the same create mutation.
 /// - Empty/whitespace title is rejected by the domain; no task is created.
 /// - When `store` is `Some`, persists domain state after a successful create.
 pub fn capture_save(
@@ -62,15 +63,17 @@ pub fn capture_save(
     title: impl AsRef<str>,
     notes: Option<String>,
     scope_override: Option<TaskScope>,
+    thread: Option<String>,
 ) -> Result<TaskId, CaptureError> {
     let scope = scope_override.unwrap_or_else(|| snapshot.default_scope.clone());
-    let id = state.create(
+    let id = state.create_with_thread(
         title,
         notes,
         scope,
         snapshot.capsule.clone(),
         snapshot.agent_meta.clone(),
         snapshot.provenance,
+        thread,
     )?;
     if let Some(store) = store {
         // Merge with any concurrent writer before persist (board + capture).
@@ -83,7 +86,7 @@ pub fn capture_save(
 mod tests {
     use super::*;
     use crate::context::{build_snapshot, RawHostContext};
-    use crate::domain::{AgentMeta, ContextCapsule, HumanStatus, ProvenanceOrigin};
+    use crate::domain::{AgentMeta, ContextCapsule, HumanStatus, ProvenanceOrigin, TaskEventKind};
     use std::env;
     use std::fs;
     use std::path::PathBuf;
@@ -148,7 +151,8 @@ mod tests {
     fn default_create_uses_snapshot_project_scope() {
         let snap = project_snapshot("/repos/app");
         let mut state = DomainState::new();
-        let id = capture_save(&mut state, None, &snap, "Ship capture", None, None).expect("create");
+        let id = capture_save(&mut state, None, &snap, "Ship capture", None, None, None)
+            .expect("create");
 
         let task = state.get(id).expect("task");
         assert_eq!(
@@ -172,10 +176,38 @@ mod tests {
     }
 
     #[test]
+    fn capture_creation_carries_supplied_normalized_thread() {
+        let snap = project_snapshot("/repos/app");
+        let mut state = DomainState::new();
+
+        let id = capture_save(
+            &mut state,
+            None,
+            &snap,
+            "Threaded capture",
+            None,
+            None,
+            Some("release-2026".into()),
+        )
+        .expect("create threaded capture");
+
+        let task = state.get(id).expect("task");
+        assert_eq!(task.thread.as_deref(), Some("release-2026"));
+        assert_eq!(
+            task.history
+                .iter()
+                .map(|event| event.kind)
+                .collect::<Vec<_>>(),
+            vec![TaskEventKind::Created]
+        );
+    }
+
+    #[test]
     fn default_create_uses_snapshot_global_when_no_repo() {
         let snap = global_snapshot();
         let mut state = DomainState::new();
-        let id = capture_save(&mut state, None, &snap, "Loose note", None, None).expect("create");
+        let id =
+            capture_save(&mut state, None, &snap, "Loose note", None, None, None).expect("create");
         assert_eq!(state.get(id).expect("task").scope, TaskScope::Global);
     }
 
@@ -190,6 +222,7 @@ mod tests {
             "Global instead",
             Some("notes".into()),
             Some(TaskScope::Global),
+            None,
         )
         .expect("create");
 
@@ -217,6 +250,7 @@ mod tests {
             "Other project",
             None,
             Some(other.clone()),
+            None,
         )
         .expect("create");
 
@@ -227,7 +261,7 @@ mod tests {
     fn empty_title_rejected_at_domain_boundary() {
         let snap = project_snapshot("/repos/app");
         let mut state = DomainState::new();
-        let err = capture_save(&mut state, None, &snap, "   \t  ", None, None)
+        let err = capture_save(&mut state, None, &snap, "   \t  ", None, None, None)
             .expect_err("empty title must fail");
         match err {
             CaptureError::Domain(DomainError::EmptyTitle) => {}
@@ -248,8 +282,8 @@ mod tests {
 
         let mut state = DomainState::new();
         // Title may still be user-edited; prefill is UI concern. Provenance stays Selection.
-        let id =
-            capture_save(&mut state, None, &snap, "from selection", None, None).expect("create");
+        let id = capture_save(&mut state, None, &snap, "from selection", None, None, None)
+            .expect("create");
         let task = state.get(id).expect("task");
         assert_eq!(task.provenance, ProvenanceOrigin::Selection);
         assert_eq!(
@@ -269,8 +303,16 @@ mod tests {
 
         let snap = project_snapshot("/repos/app");
         let mut state = DomainState::new();
-        let id = capture_save(&mut state, Some(&store), &snap, "Persisted", None, None)
-            .expect("create+save");
+        let id = capture_save(
+            &mut state,
+            Some(&store),
+            &snap,
+            "Persisted",
+            None,
+            None,
+            None,
+        )
+        .expect("create+save");
 
         let reloaded = store.load().expect("load");
         let task = reloaded.get(id).expect("task on disk");

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::cli::parser::FlagAdd;
 use crate::context::snapshot_from_env;
-use crate::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use crate::domain::{normalize_thread, DomainState, ProvenanceOrigin, TaskScope};
 use crate::scope::{resolve_flag_scope, resolve_project_path};
 use crate::store::{default_state_dir, TaskStore};
 
@@ -71,6 +71,8 @@ struct PlanItem {
     notes: Option<String>,
     /// `None` is omitted, `Some(None)` is JSON null/global.
     project: Option<Option<String>>,
+    /// Missing and JSON null both leave the item unthreaded.
+    thread: Option<String>,
 }
 
 struct ResolvedPlanItem {
@@ -78,6 +80,7 @@ struct ResolvedPlanItem {
     title: String,
     notes: Option<String>,
     scope: TaskScope,
+    thread: Option<String>,
 }
 
 /// Result of one accepted flag add.
@@ -112,10 +115,11 @@ pub fn run(input: FlagAdd) -> Result<FlagAddResult, AddError> {
     let project = input.project;
     let global = input.global;
     let notes = input.notes.filter(|notes| !notes.trim().is_empty());
+    let thread = input.thread;
     store
         .locked_transition_if_changed(|domain| {
             let scope = resolve_flag_scope(project.as_deref(), global, domain, &snapshot);
-            if let Some(task) = existing_task(domain, &title, &scope) {
+            if let Some(task) = existing_task(domain, &title, &scope, thread.as_deref()) {
                 return Ok((
                     FlagAddResult::Existing {
                         id: task.id,
@@ -127,7 +131,15 @@ pub fn run(input: FlagAdd) -> Result<FlagAddResult, AddError> {
             }
             let project = scope_project(&scope);
             let id = domain
-                .create(&title, notes, scope, None, None, ProvenanceOrigin::Capture)
+                .create_with_thread(
+                    &title,
+                    notes,
+                    scope,
+                    None,
+                    None,
+                    ProvenanceOrigin::Capture,
+                    thread,
+                )
                 .map_err(|error| error.to_string())?;
             Ok((FlagAddResult::Created { id, title, project }, true))
         })
@@ -164,7 +176,9 @@ pub fn run_plan(
             let mut created = Vec::with_capacity(resolved.len());
             let mut existing = Vec::new();
             for item in resolved {
-                if let Some(task) = existing_task(domain, &item.title, &item.scope) {
+                if let Some(task) =
+                    existing_task(domain, &item.title, &item.scope, item.thread.as_deref())
+                {
                     existing.push(Existing {
                         i: item.i,
                         id: task.id,
@@ -173,15 +187,16 @@ pub fn run_plan(
                     continue;
                 }
                 let id = domain
-                    .create(
+                    .create_with_thread(
                         &item.title,
                         item.notes,
                         item.scope,
                         None,
                         None,
                         ProvenanceOrigin::Capture,
+                        item.thread,
                     )
-                    .expect("plan item titles are validated before domain creation");
+                    .expect("plan item titles and threads are validated before domain creation");
                 created.push(Created {
                     i: item.i,
                     id,
@@ -219,6 +234,7 @@ fn resolve_plan_items(
                 },
                 None => snapshot.default_scope.clone(),
             },
+            thread: item.thread,
         })
         .collect()
 }
@@ -234,11 +250,14 @@ fn existing_task<'a>(
     domain: &'a DomainState,
     title: &str,
     scope: &TaskScope,
+    thread: Option<&str>,
 ) -> Option<&'a crate::domain::Task> {
-    domain
-        .tasks()
-        .iter()
-        .find(|task| !task.soft_deleted && task.title == title && &task.scope == scope)
+    domain.tasks().iter().find(|task| {
+        !task.soft_deleted
+            && task.title == title
+            && &task.scope == scope
+            && task.thread.as_deref() == thread
+    })
 }
 
 fn parse_plan_item(i: usize, value: Value) -> Result<PlanItem, Failed> {
@@ -294,12 +313,32 @@ fn parse_plan_item(i: usize, value: Value) -> Result<PlanItem, Failed> {
             ));
         }
     };
+    let thread = match object.get("thread") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(thread)) => normalize_thread(thread).map(Some).map_err(|_| {
+            failed(
+                i,
+                Some(trimmed_title.clone()),
+                "invalid-thread",
+                "thread is invalid",
+            )
+        })?,
+        Some(_) => {
+            return Err(failed(
+                i,
+                Some(trimmed_title),
+                "invalid-thread",
+                "thread must be a string or null",
+            ));
+        }
+    };
 
     Ok(PlanItem {
         i,
         title: trimmed_title,
         notes,
         project,
+        thread,
     })
 }
 
@@ -327,6 +366,7 @@ mod tests {
             title: Some("hello\n".into()),
             notes: None,
             project: None,
+            thread: None,
             global: false,
             json: false,
             state_dir: None,

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::context::snapshot_from_env;
-use crate::domain::{HumanStatus, TaskScope};
+use crate::domain::{normalize_thread, HumanStatus, TaskScope};
 use crate::scope::resolve_flag_scope;
 use crate::store::{default_state_dir, TaskStore};
 
@@ -19,6 +19,8 @@ pub struct ListInput {
     pub all: bool,
     pub done: bool,
     pub deleted: bool,
+    /// Normalized at the argv boundary so filtering only compares valid names.
+    pub thread: Option<String>,
     /// One task addressed by id: single-task listing with step lines.
     pub task: Option<Uuid>,
     pub state_dir: Option<PathBuf>,
@@ -48,6 +50,7 @@ pub(crate) struct ListRow {
     pub(crate) title: String,
     pub(crate) status: HumanStatus,
     pub(crate) project: Option<String>,
+    pub(crate) thread: Option<String>,
 }
 
 /// Read-only result for the list command.
@@ -73,6 +76,7 @@ pub fn parse(args: &[String]) -> Result<ListInput, String> {
         all: false,
         done: false,
         deleted: false,
+        thread: None,
         task: None,
         state_dir: None,
         help: false,
@@ -88,12 +92,26 @@ pub fn parse(args: &[String]) -> Result<ListInput, String> {
                 input.project = Some(flag["--project=".len()..].to_owned());
                 index += 1;
             }
+            flag if flag.starts_with("--thread=") => {
+                input.thread = Some(
+                    normalize_thread(&flag["--thread=".len()..])
+                        .map_err(|_| "invalid thread name".to_owned())?,
+                );
+                index += 1;
+            }
             "--json" => {
                 input.json = true;
                 index += 1;
             }
             "-p" | "--project" => {
                 input.project = Some(value(flag)?);
+                index += 2;
+            }
+            "--thread" => {
+                input.thread = Some(
+                    normalize_thread(&value(flag)?)
+                        .map_err(|_| "invalid thread name".to_owned())?,
+                );
                 index += 2;
             }
             "--global" => {
@@ -136,8 +154,10 @@ pub fn parse(args: &[String]) -> Result<ListInput, String> {
         }
     }
 
-    if input.task.is_some() && (input.all || input.global || input.project.is_some()) {
-        return Err("task id cannot be used with --project, --global, or --all".into());
+    if input.task.is_some()
+        && (input.all || input.global || input.project.is_some() || input.thread.is_some())
+    {
+        return Err("task id cannot be used with --project, --global, --all, or --thread".into());
     }
     if input.task.is_some() && (input.done || input.deleted) {
         return Err("task id cannot be used with --done or --deleted".into());
@@ -200,6 +220,12 @@ pub fn run(input: ListInput) -> Result<ListResult, ListError> {
         .tasks()
         .iter()
         .filter(|task| scope.as_ref().is_none_or(|scope| task.scope == *scope))
+        .filter(|task| {
+            input
+                .thread
+                .as_deref()
+                .is_none_or(|thread| task.thread.as_deref() == Some(thread))
+        })
         .filter(|task| match view {
             ListView::Open => !task.soft_deleted && is_open(task.status),
             ListView::Done => !task.soft_deleted && task.status == HumanStatus::Done,
@@ -225,6 +251,7 @@ fn row_for(task: &crate::domain::Task) -> ListRow {
             TaskScope::Global => None,
             TaskScope::Project { path } => Some(path.clone()),
         },
+        thread: task.thread.clone(),
     }
 }
 

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use super::steps::StepsAction;
+use crate::domain::normalize_thread;
 
 /// Parsed add input. A plan source is selected by `file` or piped stdin.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,6 +13,8 @@ pub struct FlagAdd {
     pub title: Option<String>,
     pub notes: Option<String>,
     pub project: Option<String>,
+    /// Normalized at the argv boundary so add only receives valid thread names.
+    pub thread: Option<String>,
     pub global: bool,
     pub json: bool,
     pub state_dir: Option<PathBuf>,
@@ -30,6 +33,7 @@ pub fn parse_flag_add(args: &[String]) -> Result<FlagAdd, String> {
         title: None,
         notes: None,
         project: None,
+        thread: None,
         global: false,
         json: false,
         state_dir: None,
@@ -63,6 +67,14 @@ pub fn parse_flag_add(args: &[String]) -> Result<FlagAdd, String> {
                 parsed.has_item_flags = true;
                 index += 1;
             }
+            flag if flag.starts_with("--thread=") => {
+                parsed.thread = Some(
+                    normalize_thread(&flag["--thread=".len()..])
+                        .map_err(|_| "invalid thread name".to_owned())?,
+                );
+                parsed.has_item_flags = true;
+                index += 1;
+            }
             "-t" | "--title" => {
                 parsed.title = Some(value(flag)?);
                 parsed.has_item_flags = true;
@@ -75,6 +87,14 @@ pub fn parse_flag_add(args: &[String]) -> Result<FlagAdd, String> {
             }
             "-p" | "--project" => {
                 parsed.project = Some(value(flag)?);
+                parsed.has_item_flags = true;
+                index += 2;
+            }
+            "--thread" => {
+                parsed.thread = Some(
+                    normalize_thread(&value(flag)?)
+                        .map_err(|_| "invalid thread name".to_owned())?,
+                );
                 parsed.has_item_flags = true;
                 index += 2;
             }

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -11,7 +11,7 @@ use crate::ui::terminal_text;
 
 pub fn add_help() -> CliOutput {
     help_output(
-        "usage: herdr-tasks add -t <title> [-n <notes>] [-p <project> | --global] [--json] [--state-dir <dir>]\n       herdr-tasks add [--file <path|->] [--state-dir <dir>]",
+        "usage: herdr-tasks add -t <title> [-n <notes>] [-p <project> | --global] [--thread <name>] [--json] [--state-dir <dir>]\n       herdr-tasks add [--file <path|->] [--state-dir <dir>]",
     )
 }
 
@@ -39,7 +39,7 @@ pub fn list_help() -> CliOutput {
 fn help_output(usage: &str) -> CliOutput {
     CliOutput {
         stdout: format!(
-            "{usage}\n\nExamples:\n  herdr-tasks add -t \"Draft release notes\"\n  herdr-tasks add -t \"Buy milk\" --global\n  herdr-tasks add -t \"Fix widget\" --project widget\n  herdr-tasks add --title=\"-fix parser\" --notes=\"-5 degrees\" --project=\"-maintenance\"\n  herdr-tasks add --file plan.json\n  cat plan.json | herdr-tasks add\n\nValues beginning with - must use --title=<value>, --notes=<value>, --project=<value>, --state-dir=<dir>, or --file=<path>.\nAn add whose trimmed title and resolved project scope already exist succeeds without changing the task. With --json, flag add emits one object with outcome, id, title, and project (or null).\nPlan JSON: [{{\"title\": \"...\", \"notes\": \"...\", \"project\": \"...\"}}]\nPlan result: {{\"created\": [...], \"existing\": [...], \"failed\": [...]}}\n\nExit contract:\n  exit 0: every item was created or already existed\n  exit 1: one or more items were refused, retry failed only\n  exit 2: usage or parse error, nothing persisted\n  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
+            "{usage}\n\nExamples:\n  herdr-tasks add -t \"Draft release notes\"\n  herdr-tasks add -t \"Buy milk\" --global\n  herdr-tasks add -t \"Fix widget\" --project widget --thread release-2026\n  herdr-tasks add --title=\"-fix parser\" --notes=\"-5 degrees\" --project=\"-maintenance\"\n  herdr-tasks add --file plan.json\n  cat plan.json | herdr-tasks add\n\nValues beginning with - must use --title=<value>, --notes=<value>, --project=<value>, --thread=<value>, --state-dir=<dir>, or --file=<path>.\n--thread is an item flag and cannot be combined with plan input. An add whose trimmed title, resolved project scope, and normalized thread already exist succeeds without changing the task. With --json, flag add emits one object with outcome, id, title, and project (or null).\nPlan JSON: [{{\"title\": \"...\", \"notes\": \"...\", \"project\": \"...\", \"thread\": \"...\"}}] (thread may also be null)\nPlan result: {{\"created\": [...], \"existing\": [...], \"failed\": [...]}}\n\nExit contract:\n  exit 0: every item was created or already existed\n  exit 1: one or more items were refused, retry failed only\n  exit 2: usage or parse error, nothing persisted\n  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
         ),
         stderr: String::new(),
         code: 0,
@@ -92,7 +92,7 @@ pub fn usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "herdr-tasks add: {reason}\nusage: herdr-tasks add -t <title> [-n <notes>] [-p <project> | --global] [--json] [--state-dir <dir>]\n"
+            "herdr-tasks add: {reason}\nusage: herdr-tasks add -t <title> [-n <notes>] [-p <project> | --global] [--thread <name>] [--json] [--state-dir <dir>]\n"
         ),
         code: 2,
     }

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -18,13 +18,13 @@ pub fn add_help() -> CliOutput {
 pub fn list_help() -> CliOutput {
     CliOutput {
         stdout: concat!(
-            "usage: herdr-tasks list [<task-id>] [-p <project> | --global | --all] [--done | --deleted] [--json] [--state-dir <dir>]\n\n",
+            "usage: herdr-tasks list [<task-id>] [-p <project> | --global | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n\n",
             "Lists ready, started, blocked, and review tasks in the invocation project by default, or global scope outside a repository.\n",
-            "With a task id (a task UUID from add --json or list --json), lists that one task alone and prints its steps: one line per step with its [x]/[ ] state and step short id. A task id cannot be combined with scope or status filters.\n",
-            "--project uses the same basename-or-path scope resolution as add; --global selects global tasks; --all selects every scope. For dash-leading project and state-directory values, use --project=<scope> and --state-dir=<dir>.\n",
+            "With a task id (a task UUID from add --json or list --json), lists that one task alone and prints its steps: one line per step with its [x]/[ ] state and step short id. A task id cannot be combined with scope, thread, or status filters.\n",
+            "--project uses the same basename-or-path scope resolution as add; --global selects global tasks; --all selects every scope. --thread normalizes a thread name and filters within the selected scope; an invalid name is a usage error (exit 2). For dash-leading project and state-directory values, use --project=<scope> and --state-dir=<dir>.\n",
             "--done lists done tasks only. --deleted lists soft-deleted tasks only, regardless of status.\n",
             "To recover a typo scope, use herdr-tasks list --all --json.\n",
-            "--json emits a flat array of id, title, status, and project in displayed group order. Human --all groups rows by status, then project scope, using a unique concise trailing path or global.\n\n",
+            "--json emits a flat array of id, title, status, project, and thread (or null) in displayed group order. Human --all groups rows by status, then project scope, using a unique concise trailing path or global.\n\n",
             "Exit contract:\n",
             "  exit 0: tasks were listed\n",
             "  exit 2: usage or parse error, nothing persisted\n",
@@ -39,7 +39,7 @@ pub fn list_help() -> CliOutput {
 fn help_output(usage: &str) -> CliOutput {
     CliOutput {
         stdout: format!(
-            "{usage}\n\nExamples:\n  herdr-tasks add -t \"Draft release notes\"\n  herdr-tasks add -t \"Buy milk\" --global\n  herdr-tasks add -t \"Fix widget\" --project widget --thread release-2026\n  herdr-tasks add --title=\"-fix parser\" --notes=\"-5 degrees\" --project=\"-maintenance\"\n  herdr-tasks add --file plan.json\n  cat plan.json | herdr-tasks add\n\nValues beginning with - must use --title=<value>, --notes=<value>, --project=<value>, --thread=<value>, --state-dir=<dir>, or --file=<path>.\n--thread is an item flag and cannot be combined with plan input. An add whose trimmed title, resolved project scope, and normalized thread already exist succeeds without changing the task. With --json, flag add emits one object with outcome, id, title, and project (or null).\nPlan JSON: [{{\"title\": \"...\", \"notes\": \"...\", \"project\": \"...\", \"thread\": \"...\"}}] (thread may also be null)\nPlan result: {{\"created\": [...], \"existing\": [...], \"failed\": [...]}}\n\nExit contract:\n  exit 0: every item was created or already existed\n  exit 1: one or more items were refused, retry failed only\n  exit 2: usage or parse error, nothing persisted\n  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
+            "{usage}\n\nExamples:\n  herdr-tasks add -t \"Draft release notes\"\n  herdr-tasks add -t \"Buy milk\" --global\n  herdr-tasks add -t \"Fix widget\" --project widget --thread release-2026\n  herdr-tasks add --title=\"-fix parser\" --notes=\"-5 degrees\" --project=\"-maintenance\"\n  herdr-tasks add --file plan.json\n  cat plan.json | herdr-tasks add\n\nValues beginning with - must use --title=<value>, --notes=<value>, --project=<value>, --state-dir=<dir>, or --file=<path>.\nItem flags plus --file are usage (exit 2, nothing persists). Piped stdin with item flags is ignored and not read. An add whose trimmed title, resolved project scope, and normalized thread already exist succeeds without changing the task. With --json, flag add emits one object with outcome, id, title, and project (or null).\nPlan JSON: [{{\"title\": \"...\", \"notes\": \"...\", \"project\": \"...\", \"thread\": \"...\"}}] (thread may also be null)\nPlan result: {{\"created\": [...], \"existing\": [...], \"failed\": [...]}}\n\nExit contract:\n  exit 0: every item was created or already existed\n  exit 1: one or more items were refused, retry failed only\n  exit 2: usage or parse error, nothing persisted\n  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
         ),
         stderr: String::new(),
         code: 0,
@@ -205,6 +205,10 @@ fn append_rows(output: &mut String, rows: &[&ListRow], indent: &str) {
         output.push_str(indent);
         output.push_str("- ");
         output.push_str(&terminal_text(&row.title));
+        if let Some(thread) = row.thread.as_deref() {
+            output.push_str(" #");
+            output.push_str(&terminal_text(thread));
+        }
         output.push('\n');
     }
 }
@@ -428,7 +432,7 @@ pub fn list_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "herdr-tasks list: {reason}\nusage: herdr-tasks list [<task-id>] [-p <project> | --global | --all] [--done | --deleted] [--json] [--state-dir <dir>]\n"
+            "herdr-tasks list: {reason}\nusage: herdr-tasks list [<task-id>] [-p <project> | --global | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n"
         ),
         code: 2,
     }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -3,10 +3,12 @@
 mod dispatch_attempt;
 mod events;
 mod task;
+mod thread;
 mod time_serde;
 mod undo;
 
 pub use dispatch_attempt::*;
 pub use events::*;
 pub use task::*;
+pub use thread::*;
 pub use undo::*;

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -151,6 +151,9 @@ pub struct Task {
     pub merge_base_revision: Option<Uuid>,
     pub title: String,
     pub notes: Option<String>,
+    /// Optional normalized thread name. Missing fields in older stores decode as unthreaded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread: Option<String>,
     pub status: HumanStatus,
     pub scope: TaskScope,
     pub capsule: Option<ContextCapsule>,
@@ -426,6 +429,7 @@ impl DomainState {
             merge_base_revision: None,
             title: title.to_string(),
             notes,
+            thread: None,
             status: HumanStatus::Ready,
             scope,
             capsule,
@@ -489,13 +493,14 @@ impl DomainState {
         Ok(())
     }
 
-    /// Edit title, notes, and scope. Title uses the same non-empty trim rule as create.
+    /// Edit title, notes, scope, and thread together. Title uses the same non-empty trim rule as create.
     pub fn edit(
         &mut self,
         id: Uuid,
         title: impl AsRef<str>,
         notes: Option<String>,
         scope: TaskScope,
+        thread: Option<String>,
     ) -> Result<(), DomainError> {
         let title = title.as_ref().trim();
         if title.is_empty() {
@@ -505,6 +510,7 @@ impl DomainState {
         task.title = title.to_string();
         task.notes = notes;
         task.scope = scope;
+        task.thread = thread;
         record_mutation(task, TaskEventKind::Edited);
         Ok(())
     }
@@ -949,7 +955,7 @@ mod tests {
         assert_eq!(kinds(&state), vec![TaskEventKind::Created]);
 
         state
-            .edit(id, "Edited title", None, TaskScope::Global)
+            .edit(id, "Edited title", None, TaskScope::Global, None)
             .expect("edit");
         assert!(kinds(&state).contains(&TaskEventKind::Edited));
 
@@ -1011,7 +1017,7 @@ mod tests {
         };
 
         state
-            .edit(id, "Edited", None, TaskScope::Global)
+            .edit(id, "Edited", None, TaskScope::Global, None)
             .expect("edit");
         assert_refreshed(&state);
         state.set_status(id, HumanStatus::Started).expect("status");
@@ -1130,12 +1136,49 @@ mod tests {
                 "  New title  ",
                 Some("updated notes".into()),
                 project.clone(),
+                None,
             )
             .expect("edit known id");
         let task = state.get(id).expect("task exists");
         assert_eq!(task.title, "New title");
         assert_eq!(task.notes.as_deref(), Some("updated notes"));
         assert_eq!(task.scope, project);
+    }
+
+    #[test]
+    fn edit_carrying_thread_journals_one_event_and_bumps_revision_once() {
+        let mut state = DomainState::new();
+        let id = create_sample(&mut state);
+        let before = state.get(id).expect("task").clone();
+
+        state
+            .edit(
+                id,
+                "Edited title",
+                Some("edited notes".into()),
+                TaskScope::Project {
+                    path: "/repos/threads".into(),
+                },
+                Some("release-2026".into()),
+            )
+            .expect("edit carrying thread");
+
+        let task = state.get(id).expect("task");
+        assert_eq!(task.title, "Edited title");
+        assert_eq!(task.notes.as_deref(), Some("edited notes"));
+        assert_eq!(task.thread.as_deref(), Some("release-2026"));
+        assert_eq!(
+            task.scope,
+            TaskScope::Project {
+                path: "/repos/threads".into(),
+            }
+        );
+        assert_eq!(task.history.len(), before.history.len() + 1);
+        assert_eq!(
+            task.history.last().map(|event| event.kind),
+            Some(TaskEventKind::Edited)
+        );
+        assert_ne!(task.revision, before.revision);
     }
 
     #[test]
@@ -1157,7 +1200,7 @@ mod tests {
         );
         assert_eq!(state.restore(missing), Err(DomainError::UnknownId(missing)));
         assert_eq!(
-            state.edit(missing, "x", None, TaskScope::Global),
+            state.edit(missing, "x", None, TaskScope::Global, None),
             Err(DomainError::UnknownId(missing))
         );
         assert_eq!(

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -414,6 +414,23 @@ impl DomainState {
         agent_meta: Option<AgentMeta>,
         provenance: ProvenanceOrigin,
     ) -> Result<Uuid, DomainError> {
+        self.create_with_thread(title, notes, scope, capsule, agent_meta, provenance, None)
+    }
+
+    /// Create a task with an already-normalized optional thread in its initial mutation.
+    ///
+    /// [`Self::create`] remains the unthreaded compatibility path for existing callers.
+    #[allow(clippy::too_many_arguments)] // Mirrors the stable `create` field list plus thread.
+    pub fn create_with_thread(
+        &mut self,
+        title: impl AsRef<str>,
+        notes: Option<String>,
+        scope: TaskScope,
+        capsule: Option<ContextCapsule>,
+        agent_meta: Option<AgentMeta>,
+        provenance: ProvenanceOrigin,
+        thread: Option<String>,
+    ) -> Result<Uuid, DomainError> {
         let title = title.as_ref().trim();
         if title.is_empty() {
             return Err(DomainError::EmptyTitle);
@@ -429,7 +446,7 @@ impl DomainState {
             merge_base_revision: None,
             title: title.to_string(),
             notes,
-            thread: None,
+            thread,
             status: HumanStatus::Ready,
             scope,
             capsule,

--- a/src/domain/thread.rs
+++ b/src/domain/thread.rs
@@ -1,0 +1,60 @@
+//! Normalization rules for task thread names.
+
+/// Shape errors returned when a thread name cannot be normalized.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadError {
+    Empty,
+    BadCharacter(char),
+    BadFirstCharacter(char),
+    OverLength { max: usize },
+}
+
+/// Normalize one task thread name.
+pub fn normalize_thread(input: &str) -> Result<String, ThreadError> {
+    let mut characters = input.chars();
+    let Some(first) = characters.next() else {
+        return Err(ThreadError::Empty);
+    };
+    if !first.is_ascii_alphanumeric() {
+        return Err(ThreadError::BadFirstCharacter(first));
+    }
+    if let Some(character) =
+        characters.find(|character| !character.is_ascii_alphanumeric() && *character != '-')
+    {
+        return Err(ThreadError::BadCharacter(character));
+    }
+    if input.chars().count() > 32 {
+        return Err(ThreadError::OverLength { max: 32 });
+    }
+    Ok(input.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_case_and_accepts_valid_shapes() {
+        assert_eq!(normalize_thread("Release-2026"), Ok("release-2026".into()));
+        assert_eq!(normalize_thread("a"), Ok("a".into()));
+        assert_eq!(normalize_thread("9-start"), Ok("9-start".into()));
+    }
+
+    #[test]
+    fn refuses_bad_chars_over_length_and_bad_first_char() {
+        assert_eq!(normalize_thread(""), Err(ThreadError::Empty));
+        assert_eq!(
+            normalize_thread("-start"),
+            Err(ThreadError::BadFirstCharacter('-'))
+        );
+        assert_eq!(
+            normalize_thread("start_name"),
+            Err(ThreadError::BadCharacter('_'))
+        );
+        assert_eq!(normalize_thread(&"a".repeat(32)), Ok("a".repeat(32)));
+        assert_eq!(
+            normalize_thread(&"a".repeat(33)),
+            Err(ThreadError::OverLength { max: 32 })
+        );
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -609,7 +609,7 @@ mod tests {
         // Disk side creates the revision the stale local writer will base its mutation on.
         let mut disk_side = store.load().expect("load");
         disk_side
-            .edit(id, "From disk", None, TaskScope::Global)
+            .edit(id, "From disk", None, TaskScope::Global, None)
             .expect("edit disk");
         store.save(&disk_side).expect("save disk edit");
 
@@ -617,7 +617,7 @@ mod tests {
         // save precondition instead of relying on wall-clock ordering.
         let mut local = store.load().expect("load local base");
         local
-            .edit(id, "From local", None, TaskScope::Global)
+            .edit(id, "From local", None, TaskScope::Global, None)
             .expect("edit local");
 
         // The disk still has the base revision local changed from.
@@ -653,7 +653,7 @@ mod tests {
 
         let mut local = store.load().expect("load legacy task");
         local
-            .edit(id, "first mutation", None, TaskScope::Global)
+            .edit(id, "first mutation", None, TaskScope::Global, None)
             .expect("edit legacy task");
         store
             .reload_merge_save(&mut local)
@@ -690,9 +690,11 @@ mod tests {
         store.save(&seed).unwrap();
         let mut local = store.load().unwrap();
         let mut concurrent = store.load().unwrap();
-        local.edit(id, "local", None, TaskScope::Global).unwrap();
+        local
+            .edit(id, "local", None, TaskScope::Global, None)
+            .unwrap();
         concurrent
-            .edit(id, "concurrent", None, TaskScope::Global)
+            .edit(id, "concurrent", None, TaskScope::Global, None)
             .unwrap();
         store.save(&concurrent).unwrap();
 

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -643,7 +643,10 @@ fn apply_board_intent(
             // fields survive; the second Esc closes the page.
             if matches!(
                 model.input_mode,
-                BoardInputMode::EditTitle | BoardInputMode::EditNotes | BoardInputMode::EditScope
+                BoardInputMode::EditTitle
+                    | BoardInputMode::EditNotes
+                    | BoardInputMode::EditThread
+                    | BoardInputMode::EditScope
             ) && model.form.as_ref().is_some_and(BoardForm::is_task)
             {
                 let field = model

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::config::{default_config_dir, SettingsRecord};
 use crate::context::InvocationSnapshot;
 use crate::dispatch::DispatchRecoveryResult;
-use crate::domain::{DomainError, DomainState, HumanStatus, TaskScope};
+use crate::domain::{normalize_thread, DomainError, DomainState, HumanStatus, TaskScope};
 use crate::host::HostPorts;
 use crate::ui::capture::{CaptureField, TITLE_REQUIRED_MESSAGE};
 use crate::ui::edit::{flatten_line_breaks, EditBuffer};
@@ -371,20 +371,23 @@ fn apply_board_intent(
                 model.focus_form_field(CaptureField::Notes);
                 return Ok(IntentOutcome::None);
             }
-            let (title, token_scope) = quick_add_title_and_scope(
+            let lifted = match lift_quick_add_tokens(
                 quick_add.title.value(),
                 domain,
                 quick_add.snapshot.as_ref().as_ref(),
-            );
-            let scope = token_scope.unwrap_or_else(|| quick_add.scope.clone());
+            ) {
+                Ok(lifted) => lifted,
+                Err(message) => {
+                    model.set_message(message);
+                    return Ok(IntentOutcome::None);
+                }
+            };
+            let scope = lifted.scope.unwrap_or_else(|| quick_add.scope.clone());
             let snapshot = quick_add.snapshot.as_ref().clone();
-            if let Some(quick_add) = model.quick_add.as_mut() {
-                quick_add.title = crate::ui::edit::seeded_draft(&title);
-                quick_add.scope = scope.clone();
-            }
             let mut form = BoardForm::capture(snapshot, model.this_repo.as_deref(), &model.tasks);
-            form.title = crate::ui::edit::seeded_draft(&title);
+            form.title = crate::ui::edit::seeded_draft(&lifted.title);
             form.scope = scope;
+            form.thread = lifted.thread;
             form.focus = CaptureField::Notes;
             form.select_current_scope();
             model.form = Some(form);
@@ -708,6 +711,7 @@ fn apply_board_intent(
                 let notes =
                     (!form.notes.value().trim().is_empty()).then(|| form.notes.value().to_string());
                 let scope_override = Some(form.scope.clone());
+                let thread = form.thread.clone();
                 return match crate::capture::capture_save(
                     domain,
                     None,
@@ -715,6 +719,7 @@ fn apply_board_intent(
                     title,
                     notes,
                     scope_override,
+                    thread,
                 ) {
                     Ok(id) => {
                         let expanded_quick_add = model.quick_add.is_some();
@@ -1332,13 +1337,27 @@ fn quick_add_save(
         model.set_message("capture context unavailable; press Esc and try again");
         return Ok(IntentOutcome::None);
     };
-    let (title, token_scope) = quick_add_title_and_scope(
+    let lifted = match lift_quick_add_tokens(
         quick_add.title.value(),
         domain,
         quick_add.snapshot.as_ref().as_ref(),
-    );
-    let scope = token_scope.unwrap_or_else(|| quick_add.scope.clone());
-    match crate::capture::capture_save(domain, None, &snapshot, title, None, Some(scope.clone())) {
+    ) {
+        Ok(lifted) => lifted,
+        Err(message) => {
+            model.set_message(message);
+            return Ok(IntentOutcome::None);
+        }
+    };
+    let scope = lifted.scope.unwrap_or_else(|| quick_add.scope.clone());
+    match crate::capture::capture_save(
+        domain,
+        None,
+        &snapshot,
+        lifted.title,
+        None,
+        Some(scope.clone()),
+        lifted.thread,
+    ) {
         Ok(id) => {
             // Do not discard the draft until the app save boundary confirms persistence. A
             // failed save keeps this exact state behind SaveRecovery for retry or cancel.
@@ -1357,26 +1376,74 @@ fn quick_add_save(
     }
 }
 
-/// Parse whitespace-delimited quick-add scope directives before creating a task.
-fn quick_add_title_and_scope(
+/// Directives lifted from a quick-add title before capture.
+///
+/// This parser is deliberately private to quick-add. Title, notes, and checklist editors retain
+/// their literal text, while the status-row capture can apply scope and thread together.
+struct QuickAddTokens {
+    title: String,
+    scope: Option<TaskScope>,
+    thread: Option<String>,
+}
+
+/// Lift whitespace-delimited `!p` and `!t` directives in either order.
+///
+/// A directive consumes only its immediate non-directive argument. Parsing completes before any
+/// value is returned, so a malformed thread cannot partially apply a preceding scope override.
+fn lift_quick_add_tokens(
     value: &str,
     domain: &DomainState,
     snapshot: Option<&InvocationSnapshot>,
-) -> (String, Option<TaskScope>) {
+) -> Result<QuickAddTokens, String> {
     let words: Vec<&str> = value.split_whitespace().collect();
-    if let Some(index) = words.iter().position(|word| *word == "!p") {
-        let title = words[..index].join(" ");
-        let path = words[index + 1..].join(" ");
-        let scope = if path.is_empty() {
-            TaskScope::Global
-        } else {
-            TaskScope::Project {
-                path: crate::scope::resolve_project_path(&path, domain, snapshot),
+    let mut title = Vec::new();
+    let mut scope = None;
+    let mut thread = None;
+    let mut index = 0;
+
+    while let Some(word) = words.get(index) {
+        match *word {
+            "!p" => {
+                let argument = quick_add_token_argument(&words, index);
+                scope = Some(match argument {
+                    Some(path) => TaskScope::Project {
+                        path: crate::scope::resolve_project_path(path, domain, snapshot),
+                    },
+                    None => TaskScope::Global,
+                });
+                index += usize::from(argument.is_some()) + 1;
             }
-        };
-        return (title, Some(scope));
+            "!t" => {
+                let argument = quick_add_token_argument(&words, index);
+                thread = match argument {
+                    Some(name) => Some(
+                        normalize_thread(name).map_err(|_| "invalid thread name".to_string())?,
+                    ),
+                    None => None,
+                };
+                index += usize::from(argument.is_some()) + 1;
+            }
+            _ => {
+                title.push(*word);
+                index += 1;
+            }
+        }
     }
-    (words.join(" "), None)
+
+    Ok(QuickAddTokens {
+        title: title.join(" "),
+        scope,
+        thread,
+    })
+}
+
+/// A directive consumes one argument only when the next word is neither another directive nor
+/// a literal `#` title word.
+fn quick_add_token_argument<'a>(words: &'a [&str], index: usize) -> Option<&'a str> {
+    words
+        .get(index + 1)
+        .copied()
+        .filter(|word| *word != "!p" && *word != "!t" && !word.starts_with('#'))
 }
 
 fn confirm_edit(

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -1399,8 +1399,8 @@ fn confirm_edit(
         return Err(DomainError::SoftDeleted(id));
     }
 
-    // One existing DomainState::edit call updates title, Notes, and scope together.
-    domain.edit(id, &title, notes, scope)?;
+    // One existing DomainState::edit call updates title, Notes, scope, and thread together.
+    domain.edit(id, &title, notes, scope, task.thread.clone())?;
 
     // Only a successful atomic domain edit releases the form. Validation and stale-task
     // refusals leave its buffers, focus, scope choice, and immutable id untouched.

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -17,7 +17,7 @@ use crate::ui::mouse::BoardPopup;
 use super::commands::{resolve_board_command, CommandSurface};
 use super::model::{
     owned_resource_summary, BoardForm, BoardInputMode, BoardModel, IntentOutcome, OwnedDeckScope,
-    ProjectPickerState, ProjectScopeOption, StepEditor, StepEditorSave,
+    ProjectPickerState, ProjectScopeOption, StepEditor, StepEditorSave, TaskEditSave,
 };
 
 /// What the row says when an action that aims at the selection is asked for on a board that
@@ -387,7 +387,8 @@ fn apply_board_intent(
             let mut form = BoardForm::capture(snapshot, model.this_repo.as_deref(), &model.tasks);
             form.title = crate::ui::edit::seeded_draft(&lifted.title);
             form.scope = scope;
-            form.thread = lifted.thread;
+            form.thread =
+                crate::ui::edit::seeded_draft(lifted.thread.as_deref().unwrap_or_default());
             form.focus = CaptureField::Notes;
             form.select_current_scope();
             model.form = Some(form);
@@ -711,7 +712,15 @@ fn apply_board_intent(
                 let notes =
                     (!form.notes.value().trim().is_empty()).then(|| form.notes.value().to_string());
                 let scope_override = Some(form.scope.clone());
-                let thread = form.thread.clone();
+                let thread = match normalize_optional_thread(form.thread.value()) {
+                    Ok(thread) => thread,
+                    Err(()) => {
+                        if let Some(form) = model.form.as_mut() {
+                            form.thread_refusal = Some("invalid thread name".into());
+                        }
+                        return Ok(IntentOutcome::None);
+                    }
+                };
                 return match crate::capture::capture_save(
                     domain,
                     None,
@@ -1295,6 +1304,10 @@ fn edit_draft(model: &mut BoardModel, operation: impl FnOnce(&mut EditBuffer)) {
     match form.focus {
         CaptureField::Title => operation(&mut form.title),
         CaptureField::Notes => operation(&mut form.notes),
+        CaptureField::Thread => {
+            form.thread_refusal = None;
+            operation(&mut form.thread);
+        }
         CaptureField::Scope => {}
     }
 }
@@ -1446,6 +1459,15 @@ fn quick_add_token_argument<'a>(words: &'a [&str], index: usize) -> Option<&'a s
         .filter(|word| *word != "!p" && *word != "!t" && !word.starts_with('#'))
 }
 
+fn normalize_optional_thread(value: &str) -> Result<Option<String>, ()> {
+    let value = value.trim();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        normalize_thread(value).map(Some).map_err(|_| ())
+    }
+}
+
 fn confirm_edit(
     domain: &mut DomainState,
     model: &mut BoardModel,
@@ -1456,9 +1478,18 @@ fn confirm_edit(
         return Ok(IntentOutcome::None);
     };
     let id = form.task_id().expect("task form has immutable id");
-    let title = form.title.value().to_string();
+    let title = form.title.value().trim().to_string();
     let notes = (!form.notes.value().trim().is_empty()).then(|| form.notes.value().to_string());
     let scope = form.scope.clone();
+    let thread = match normalize_optional_thread(form.thread.value()) {
+        Ok(thread) => thread,
+        Err(()) => {
+            if let Some(form) = model.form.as_mut() {
+                form.thread_refusal = Some("invalid thread name".into());
+            }
+            return Ok(IntentOutcome::None);
+        }
+    };
     let task = domain.get(id).ok_or(DomainError::UnknownId(id))?.clone();
     // `DomainState::edit` does not reject a soft-deleted task itself. Refuse before touching
     // the form so's bound-task and draft-recovery guarantees remain intact.
@@ -1467,13 +1498,17 @@ fn confirm_edit(
     }
 
     // One existing DomainState::edit call updates title, Notes, scope, and thread together.
-    domain.edit(id, &title, notes, scope, task.thread.clone())?;
+    domain.edit(id, &title, notes.clone(), scope.clone(), thread.clone())?;
 
-    // Only a successful atomic domain edit releases the form. Validation and stale-task
-    // refusals leave its buffers, focus, scope choice, and immutable id untouched.
-    model.input_mode = BoardInputMode::Normal;
-    model.form = None;
-    model.clear_message();
+    // Retain the complete form and mode until the persistence boundary confirms this exact
+    // atomic edit. A failed save can then Retry or Cancel without orphaning the input state.
+    model.task_edit_save = Some(TaskEditSave {
+        id,
+        title,
+        notes,
+        scope,
+        thread,
+    });
     Ok(IntentOutcome::Persist)
 }
 

--- a/src/ui/board/chrome.rs
+++ b/src/ui/board/chrome.rs
@@ -49,6 +49,7 @@ fn edit_chrome_legends(mode: BoardInputMode) -> [&'static str; 3] {
             "Enter choose · Esc",
         ],
         BoardInputMode::EditTitle
+        | BoardInputMode::EditThread
         | BoardInputMode::EditStep
         | BoardInputMode::QuickAdd
         | BoardInputMode::FormScopeDropdown

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -419,7 +419,7 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
             input: crate::ui::render::BottomInputSlot {
                 text: title,
                 cursor_col: title_cursor,
-                placeholder: "title…   !p global · !p name project · tab details",
+                placeholder: "title…   !p global · !p name project · !t thread · tab details",
                 refusal: None,
                 // Save recovery owns the verb row; ordinary quick-add refusals
                 // use the shared slot's reserved row above the cursor.

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -278,6 +278,16 @@ fn build_task_page_overlay<'a>(
     if let Some(task) = bound_task {
         if let Some(thread) = task.thread.as_deref() {
             meta.push_str(&format!(" · #{thread}"));
+        } else if matches!(
+            model.input_mode(),
+            BoardInputMode::EditTitle
+                | BoardInputMode::EditNotes
+                | BoardInputMode::EditScope
+                | BoardInputMode::FormScopeDropdown
+        ) {
+            // An empty thread still needs a visible field-sized footer target while the form
+            // is editing, otherwise mouse users can only reach Thread after it already exists.
+            meta.push_str(" · #");
         }
         let now = SystemTime::now();
         meta.push_str(&format!(

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -282,12 +282,13 @@ fn build_task_page_overlay<'a>(
             model.input_mode(),
             BoardInputMode::EditTitle
                 | BoardInputMode::EditNotes
+                | BoardInputMode::EditThread
                 | BoardInputMode::EditScope
                 | BoardInputMode::FormScopeDropdown
         ) {
             // An empty thread still needs a visible field-sized footer target while the form
             // is editing, otherwise mouse users can only reach Thread after it already exists.
-            meta.push_str(" · #");
+            meta.push_str(" · thread");
         }
         let now = SystemTime::now();
         meta.push_str(&format!(

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -270,14 +270,19 @@ fn build_task_page_overlay<'a>(
     form.notes_max_scroll.set(content.max_scroll);
     form.steps.content_start.set(content.steps_start);
 
-    // Meta footer: scope · created · updated (ages only while the bound task is present).
-    let mut meta = match &form.scope {
+    // Meta footer: scope · thread · created · updated (ages only while the bound task is
+    // present). Keep its clickable pieces separate from the painted string: a project basename
+    // is user-controlled and may contain the same separator or label text.
+    let meta_scope = match &form.scope {
         TaskScope::Project { path } => render::short_project(path).to_string(),
         TaskScope::Global => "global".to_string(),
     };
+    let meta_scope_width = u16::try_from(render::display_width(&meta_scope)).unwrap_or(u16::MAX);
+    let mut meta = meta_scope.clone();
+    let mut thread_slot = None;
     if let Some(task) = bound_task {
-        if let Some(thread) = task.thread.as_deref() {
-            meta.push_str(&format!(" · #{thread}"));
+        thread_slot = if let Some(thread) = task.thread.as_deref() {
+            Some(format!(" · #{thread}"))
         } else if matches!(
             model.input_mode(),
             BoardInputMode::EditTitle
@@ -288,7 +293,12 @@ fn build_task_page_overlay<'a>(
         ) {
             // An empty thread still needs a visible field-sized footer target while the form
             // is editing, otherwise mouse users can only reach Thread after it already exists.
-            meta.push_str(" · thread");
+            Some(" · thread".to_string())
+        } else {
+            None
+        };
+        if let Some(slot) = &thread_slot {
+            meta.push_str(slot);
         }
         let now = SystemTime::now();
         meta.push_str(&format!(
@@ -297,6 +307,10 @@ fn build_task_page_overlay<'a>(
             render::format_age(now, task.updated_at)
         ));
     }
+    let thread_slot_width = thread_slot
+        .as_deref()
+        .map(render::display_width)
+        .map(|width| u16::try_from(width).unwrap_or(u16::MAX));
 
     let focus = match model.input_mode() {
         BoardInputMode::EditTitle => Some(CaptureField::Title),
@@ -319,6 +333,8 @@ fn build_task_page_overlay<'a>(
         step_marked: form.steps.delete_mark,
         step_editor,
         meta,
+        meta_scope_width,
+        thread_slot_width,
         focus,
         scope_dropdown,
     }

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -184,19 +184,38 @@ fn build_task_page_overlay<'a>(
     let step_views = bound_task.map(super::model::step_views).unwrap_or_default();
     // A step draft is windowed for the shared bottom input slot: the row less
     // the two-cell `▎ ` prompt that owns the terminal cursor.
-    let step_editor = form.steps.editor.as_ref().map(|editor| {
-        let avail = (geo.row_width as usize).saturating_sub(2);
-        let (text, cursor_col) = escaped_line_window(&editor.buffer, avail);
-        crate::ui::render::BottomInputSlot {
-            text,
-            cursor_col,
-            placeholder: "step…   enter save · ctrl+enter save+next · esc cancel",
-            refusal: editor.refusal.as_deref(),
-            // The bottom input replaces the shared status row. Forward recovery
-            // and record-refusal feedback to the surface that is actually visible.
-            message: model.message(),
-        }
-    });
+    let step_editor = form
+        .steps
+        .editor
+        .as_ref()
+        .map(|editor| {
+            let avail = (geo.row_width as usize).saturating_sub(2);
+            let (text, cursor_col) = escaped_line_window(&editor.buffer, avail);
+            crate::ui::render::BottomInputSlot {
+                text,
+                cursor_col,
+                placeholder: "step…   enter save · ctrl+enter save+next · esc cancel",
+                refusal: editor.refusal.as_deref(),
+                // The bottom input replaces the shared status row. Forward recovery
+                // and record-refusal feedback to the surface that is actually visible.
+                message: model.message(),
+            }
+        })
+        .or_else(|| {
+            (model.input_mode() == BoardInputMode::EditThread).then(|| {
+                let avail = (geo.row_width as usize).saturating_sub(2);
+                let (text, cursor_col) = escaped_line_window(&form.thread, avail);
+                crate::ui::render::BottomInputSlot {
+                    text,
+                    cursor_col,
+                    placeholder: "thread…   enter save · esc cancel",
+                    refusal: None,
+                    // The shared bottom slot owns this refusal while it is visible, so it
+                    // never leaks through the status row and remains legible at 40x10.
+                    message: form.thread_refusal.as_deref(),
+                }
+            })
+        });
     // A notes edit always keeps one row: the layout reserves it (the section caps
     // around it), so an active edit can never be scrolled/clamped out of the frame
     // entirely. The step editor uses the shared bottom slot, so steps alone
@@ -257,6 +276,9 @@ fn build_task_page_overlay<'a>(
         TaskScope::Global => "global".to_string(),
     };
     if let Some(task) = bound_task {
+        if let Some(thread) = task.thread.as_deref() {
+            meta.push_str(&format!(" · #{thread}"));
+        }
         let now = SystemTime::now();
         meta.push_str(&format!(
             " · created {} ago · updated {} ago",
@@ -268,6 +290,7 @@ fn build_task_page_overlay<'a>(
     let focus = match model.input_mode() {
         BoardInputMode::EditTitle => Some(CaptureField::Title),
         BoardInputMode::EditNotes => Some(CaptureField::Notes),
+        BoardInputMode::EditThread => Some(CaptureField::Thread),
         BoardInputMode::EditScope | BoardInputMode::FormScopeDropdown => Some(CaptureField::Scope),
         _ => None,
     };

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -35,6 +35,8 @@ pub enum BoardInputMode {
     Normal,
     EditTitle,
     EditNotes,
+    /// The task page footer's optional thread name owns focus.
+    EditThread,
     /// The scope row of an open task form owns focus. The renderer adaptation remains
     /// deliberately thin until, but its keyboard state is a first-class form field.
     EditScope,
@@ -178,13 +180,25 @@ pub(super) struct QuickAddSave {
     keep_open: bool,
 }
 
+/// A task form mutation staged in the domain but not yet confirmed at the persistence boundary.
+#[derive(Debug, Clone)]
+pub(super) struct TaskEditSave {
+    pub(super) id: Uuid,
+    pub(super) title: String,
+    pub(super) notes: Option<String>,
+    pub(super) scope: TaskScope,
+    pub(super) thread: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct BoardForm {
     pub(super) title: EditBuffer,
     pub(super) notes: EditBuffer,
     pub(super) scope: TaskScope,
-    /// Parsed from the quick-add line only. Task title and note editors treat `!t` literally.
-    pub(super) thread: Option<String>,
+    /// Optional thread draft shared by task-page and expanded-capture forms.
+    pub(super) thread: EditBuffer,
+    /// Field-local validation feedback, painted by the footer input rather than status chrome.
+    pub(super) thread_refusal: Option<String>,
     pub(super) focus: CaptureField,
     pub(super) scope_options: Vec<TaskScope>,
     pub(super) scope_selected: usize,
@@ -213,7 +227,7 @@ impl BoardForm {
         tasks: &[Task],
         focus: CaptureField,
     ) -> Self {
-        Self::new(
+        let mut form = Self::new(
             &task.title,
             task.notes.as_deref().unwrap_or_default(),
             task.scope.clone(),
@@ -221,7 +235,9 @@ impl BoardForm {
             BoardFormBinding::Task(task.id),
             this_repo,
             tasks,
-        )
+        );
+        form.thread = seeded_draft(task.thread.as_deref().unwrap_or_default());
+        form
     }
 
     pub(super) fn capture(
@@ -267,7 +283,8 @@ impl BoardForm {
             title: seeded_draft(title),
             notes: seeded_draft(notes),
             scope,
-            thread: None,
+            thread: seeded_draft(""),
+            thread_refusal: None,
             focus,
             scope_options,
             scope_selected,
@@ -300,6 +317,7 @@ impl BoardForm {
         match self.focus {
             CaptureField::Title => BoardInputMode::EditTitle,
             CaptureField::Notes => BoardInputMode::EditNotes,
+            CaptureField::Thread => BoardInputMode::EditThread,
             CaptureField::Scope => BoardInputMode::EditScope,
         }
     }
@@ -311,6 +329,10 @@ impl BoardForm {
             CaptureField::Notes => {
                 self.notes = seeded_draft(task.notes.as_deref().unwrap_or_default());
             }
+            CaptureField::Thread => {
+                self.thread = seeded_draft(task.thread.as_deref().unwrap_or_default());
+                self.thread_refusal = None;
+            }
             CaptureField::Scope => {
                 self.scope = task.scope.clone();
                 self.select_current_scope();
@@ -321,7 +343,8 @@ impl BoardForm {
     pub(super) fn focus_next(&mut self) {
         self.focus = match self.focus {
             CaptureField::Title => CaptureField::Notes,
-            CaptureField::Notes => CaptureField::Scope,
+            CaptureField::Notes => CaptureField::Thread,
+            CaptureField::Thread => CaptureField::Scope,
             CaptureField::Scope => CaptureField::Title,
         };
     }
@@ -330,7 +353,8 @@ impl BoardForm {
         self.focus = match self.focus {
             CaptureField::Title => CaptureField::Scope,
             CaptureField::Notes => CaptureField::Title,
-            CaptureField::Scope => CaptureField::Notes,
+            CaptureField::Thread => CaptureField::Notes,
+            CaptureField::Scope => CaptureField::Thread,
         };
     }
 
@@ -513,6 +537,10 @@ pub struct BoardModel {
     pub(super) saved_task: Option<Uuid>,
     /// A quick-add create waiting for the app save boundary to confirm persistence.
     pub(super) quick_add_save: Option<QuickAddSave>,
+    /// A task-form edit waiting for the app save boundary to confirm persistence.
+    pub(super) task_edit_save: Option<TaskEditSave>,
+    /// The app save boundary holds task-form release across its inner reducer sync.
+    pub(super) hold_task_edit_save: bool,
     /// Last board action feedback or empty-selection chrome message.
     pub(super) message: Option<String>,
     /// Title of the task the last soft-delete removed, captured at delete time.
@@ -578,6 +606,8 @@ impl BoardModel {
             quick_add: None,
             saved_task: None,
             quick_add_save: None,
+            task_edit_save: None,
+            hold_task_edit_save: false,
             message: None,
             delete_notice: None,
             suspended_delete_notice: None,
@@ -671,6 +701,28 @@ impl BoardModel {
             self.input_mode = BoardInputMode::QuickAdd;
             self.clear_message();
         }
+        // The restored baseline discards the staged task edit, but its task-page form remains
+        // open in view mode with every draft reset to the durable task.
+        if resolution == SaveResolution::Cancelled {
+            if let Some(pending) = self.task_edit_save.take() {
+                let task = self
+                    .tasks
+                    .iter()
+                    .find(|task| task.id == pending.id)
+                    .cloned();
+                if let (Some(form), Some(task)) = (self.form.as_mut(), task) {
+                    form.title = seeded_draft(&task.title);
+                    form.notes = seeded_draft(task.notes.as_deref().unwrap_or_default());
+                    form.thread = seeded_draft(task.thread.as_deref().unwrap_or_default());
+                    form.thread_refusal = None;
+                    form.scope = task.scope.clone();
+                    form.select_current_scope();
+                }
+                self.hold_task_edit_save = false;
+                self.input_mode = BoardInputMode::TaskPage;
+                self.clear_message();
+            }
+        }
         // A held step line editor unwinds to page view on Cancel (AC-14): the
         // baseline Cancel just restored rolled its mutation back, so nothing is left
         // to hold the line for, and an edit mode whose editor is gone is the orphan
@@ -712,6 +764,7 @@ impl BoardModel {
         });
         self.attempts = state.active_attempts().to_vec();
         self.finish_quick_add_save();
+        self.finish_task_edit_save();
         self.finish_step_editor_save();
         self.reanchor_selection(self.selection_id, &previous_visible);
         if self.attempts.is_empty()
@@ -933,6 +986,7 @@ impl BoardModel {
         match form.focus {
             CaptureField::Title | CaptureField::Scope => form.title.value(),
             CaptureField::Notes => form.notes.value(),
+            CaptureField::Thread => form.thread.value(),
         }
     }
 
@@ -944,6 +998,7 @@ impl BoardModel {
         match form.focus {
             CaptureField::Title | CaptureField::Scope => form.title.cursor(),
             CaptureField::Notes => form.notes.cursor(),
+            CaptureField::Thread => form.thread.cursor(),
         }
     }
 
@@ -1012,6 +1067,39 @@ impl BoardModel {
             self.input_mode = BoardInputMode::Normal;
         }
         self.clear_message();
+    }
+
+    fn finish_task_edit_save(&mut self) {
+        if self.hold_task_edit_save {
+            return;
+        }
+        let Some(pending) = self.task_edit_save.as_ref() else {
+            return;
+        };
+        let landed = self.tasks.iter().any(|task| {
+            task.id == pending.id
+                && task.title == pending.title
+                && task.notes == pending.notes
+                && task.scope == pending.scope
+                && task.thread == pending.thread
+        });
+        if !landed {
+            return;
+        }
+        self.task_edit_save = None;
+        self.form = None;
+        self.input_mode = BoardInputMode::Normal;
+        self.clear_message();
+    }
+
+    /// Hold a task form through the reducer's pre-persist sync.
+    pub fn hold_task_edit_save(&mut self) {
+        self.hold_task_edit_save = true;
+    }
+
+    /// Release a held form only after Retry or the initial persistence succeeds.
+    pub fn release_task_edit_save(&mut self) {
+        self.hold_task_edit_save = false;
     }
 
     /// Release a held step line editor once persistence has confirmed its mutation
@@ -1124,7 +1212,10 @@ impl BoardModel {
         let Some(form) = self.form.as_mut() else {
             return;
         };
-        if self.input_mode == BoardInputMode::FormScopeDropdown {
+        if matches!(
+            self.input_mode,
+            BoardInputMode::FormScopeDropdown | BoardInputMode::EditStep
+        ) {
             return;
         }
         Self::set_form_focus(form, focus);
@@ -1286,6 +1377,7 @@ impl BoardModel {
         match self.input_mode {
             mode @ (BoardInputMode::EditTitle
             | BoardInputMode::EditNotes
+            | BoardInputMode::EditThread
             | BoardInputMode::EditScope) => Some(mode),
             _ => None,
         }

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -183,6 +183,8 @@ pub(super) struct BoardForm {
     pub(super) title: EditBuffer,
     pub(super) notes: EditBuffer,
     pub(super) scope: TaskScope,
+    /// Parsed from the quick-add line only. Task title and note editors treat `!t` literally.
+    pub(super) thread: Option<String>,
     pub(super) focus: CaptureField,
     pub(super) scope_options: Vec<TaskScope>,
     pub(super) scope_selected: usize,
@@ -265,6 +267,7 @@ impl BoardForm {
             title: seeded_draft(title),
             notes: seeded_draft(notes),
             scope,
+            thread: None,
             focus,
             scope_options,
             scope_selected,

--- a/src/ui/capture.rs
+++ b/src/ui/capture.rs
@@ -33,6 +33,7 @@ pub enum CaptureField {
     #[default]
     Title,
     Notes,
+    Thread,
     Scope,
 }
 
@@ -98,6 +99,10 @@ pub struct CaptureModel {
     /// across focus changes.
     title: EditBuffer,
     notes: EditBuffer,
+    /// Optional task thread, normalized with the shared domain rule at save time.
+    thread: EditBuffer,
+    /// Field-local thread validation feedback, painted on the Thread row.
+    thread_refusal: Option<String>,
     /// Scope that will be saved (starts as snapshot default; user may override).
     scope: TaskScope,
     this_repo: Option<PathBuf>,
@@ -126,6 +131,8 @@ impl CaptureModel {
         Self {
             title: seeded_draft(snapshot.title_prefill.as_deref().unwrap_or_default()),
             notes: seeded_draft(""),
+            thread: seeded_draft(""),
+            thread_refusal: None,
             scope: Self::default_scope(snapshot),
             this_repo: snapshot.this_repo.clone(),
             focused: CaptureField::Title,
@@ -142,6 +149,10 @@ impl CaptureModel {
 
     pub fn notes(&self) -> &str {
         self.notes.value()
+    }
+
+    pub fn thread(&self) -> &str {
+        self.thread.value()
     }
 
     pub fn scope(&self) -> &TaskScope {
@@ -253,6 +264,7 @@ impl CaptureModel {
         match self.focused {
             CaptureField::Title => Some(&mut self.title),
             CaptureField::Notes => Some(&mut self.notes),
+            CaptureField::Thread => Some(&mut self.thread),
             CaptureField::Scope => None,
         }
     }
@@ -261,7 +273,8 @@ impl CaptureModel {
         self.abandon_path_edit();
         self.focused = match self.focused {
             CaptureField::Title => CaptureField::Notes,
-            CaptureField::Notes => CaptureField::Scope,
+            CaptureField::Notes => CaptureField::Thread,
+            CaptureField::Thread => CaptureField::Scope,
             CaptureField::Scope => CaptureField::Title,
         };
     }
@@ -271,7 +284,8 @@ impl CaptureModel {
         self.focused = match self.focused {
             CaptureField::Title => CaptureField::Scope,
             CaptureField::Notes => CaptureField::Title,
-            CaptureField::Scope => CaptureField::Notes,
+            CaptureField::Thread => CaptureField::Notes,
+            CaptureField::Scope => CaptureField::Thread,
         };
     }
 
@@ -396,6 +410,7 @@ pub fn apply_capture_intent(
                 return Ok(CaptureOutcome::None);
             }
             model.message = None;
+            model.thread_refusal = None;
             Ok(CaptureOutcome::Cancelled)
         }
         CaptureIntent::FocusNext => {
@@ -435,7 +450,7 @@ pub fn apply_capture_intent(
                         model.message = None;
                     }
                 }
-                CaptureField::Title | CaptureField::Notes => {
+                CaptureField::Title | CaptureField::Notes | CaptureField::Thread => {
                     edit_draft(model, |draft| draft.insert_char(c));
                 }
             }
@@ -449,7 +464,7 @@ pub fn apply_capture_intent(
                         model.message = None;
                     }
                 }
-                CaptureField::Title | CaptureField::Notes => {
+                CaptureField::Title | CaptureField::Notes | CaptureField::Thread => {
                     edit_draft(model, EditBuffer::backspace);
                 }
             }
@@ -467,7 +482,7 @@ pub fn apply_capture_intent(
                         model.message = None;
                     }
                 }
-                CaptureField::Title => {
+                CaptureField::Title | CaptureField::Thread => {
                     edit_draft(model, |draft| {
                         draft.insert_text(&flatten_line_breaks(&text))
                     });
@@ -525,6 +540,19 @@ pub fn apply_capture_intent(
             } else {
                 Some(model.notes().to_string())
             };
+            let thread_value = model.thread().trim();
+            let thread = if thread_value.is_empty() {
+                None
+            } else {
+                match crate::domain::normalize_thread(thread_value) {
+                    Ok(thread) => Some(thread),
+                    Err(_) => {
+                        model.thread_refusal = Some("invalid thread name".into());
+                        model.message = None;
+                        return Ok(CaptureOutcome::None);
+                    }
+                }
+            };
             // The controller owns independent baseline and working snapshots, so an error
             // cannot leak a staged task into the active domain or close this form.
             let baseline =
@@ -538,7 +566,7 @@ pub fn apply_capture_intent(
                 model.title(),
                 notes,
                 Some(model.scope.clone()),
-                None,
+                thread,
             ) {
                 Ok(id) => id,
                 Err(error) => {
@@ -573,9 +601,13 @@ pub fn apply_capture_intent(
 /// Inert on the scope row: its path buffer is not one of the pinned editable text fields
 /// and keeps its plain-`String` handling, so every cursor intent is a no-op there.
 fn edit_draft(model: &mut CaptureModel, operation: impl FnOnce(&mut EditBuffer)) {
+    let editing_thread = model.focused == CaptureField::Thread;
     if let Some(draft) = model.focused_draft_mut() {
         operation(draft);
         model.message = None;
+        if editing_thread {
+            model.thread_refusal = None;
+        }
     }
 }
 
@@ -734,11 +766,14 @@ pub fn draw_capture(frame: &mut Frame, model: &CaptureModel) {
 
     let title_focused = model.focused == CaptureField::Title;
     let notes_focused = model.focused == CaptureField::Notes;
+    let thread_focused = model.focused == CaptureField::Thread;
     let (title_lines, title_cursor) =
         text_field_block("Title:", &model.title, layout.title_area, title_focused);
     // a multiline Notes draft occupies the whole Notes field, one line per row.
     let (notes_lines, notes_cursor) =
         text_field_block("Notes:", &model.notes, layout.notes_area, notes_focused);
+    let (thread_lines, thread_cursor) =
+        text_field_block("Thread:", &model.thread, layout.thread_area, thread_focused);
 
     // Keep "Title:" / "Notes:" / "Scope:" tokens for render tests and screen readers.
     frame.render_widget(
@@ -749,13 +784,42 @@ pub fn draw_capture(frame: &mut Frame, model: &CaptureModel) {
         Paragraph::new(notes_lines).style(field_style(notes_focused)),
         layout.notes_area,
     );
+    frame.render_widget(
+        Paragraph::new(thread_lines).style(field_style(thread_focused)),
+        layout.thread_area,
+    );
     // The terminal's own cursor carries the edit position; only the focused field has one,
     // and only while the field actually accepts input: every editing intent is inert until
     // a failed save is retried or cancelled, so no cursor is offered there.
     if !model.is_save_recovery() {
-        if let Some((region, row, column)) = title_cursor.or(notes_cursor) {
+        if let Some((region, row, column)) = title_cursor.or(notes_cursor).or(thread_cursor) {
             place_edit_cursor_at(frame, region, row, column);
         }
+    }
+
+    if let Some(refusal) = model.thread_refusal.as_deref() {
+        frame.render_widget(
+            Paragraph::new(present_line(
+                refusal,
+                layout
+                    .thread_area
+                    .width
+                    .saturating_sub(CAPTURE_FIELD_LABEL_WIDTH) as usize,
+            ))
+            .style(render::style_reverse_bold()),
+            ratatui::layout::Rect::new(
+                layout
+                    .thread_area
+                    .x
+                    .saturating_add(CAPTURE_FIELD_LABEL_WIDTH),
+                layout.thread_area.y,
+                layout
+                    .thread_area
+                    .width
+                    .saturating_sub(CAPTURE_FIELD_LABEL_WIDTH),
+                1,
+            ),
+        );
     }
 
     // Scope row: label, then one explicit control per choice.
@@ -1909,7 +1973,8 @@ mod tests {
         // Park the Notes cursor at its start; this must not disturb Title's own cursor.
         apply(&mut domain, &snap, &mut model, CaptureIntent::MoveLineStart);
 
-        // Back to Title the long way round (Notes → Scope → Title).
+        // Back to Title the long way round (Notes → Thread → Scope → Title).
+        apply(&mut domain, &snap, &mut model, CaptureIntent::FocusNext);
         apply(&mut domain, &snap, &mut model, CaptureIntent::FocusNext);
         apply(&mut domain, &snap, &mut model, CaptureIntent::FocusNext);
         assert_eq!(model.focused(), CaptureField::Title);
@@ -2176,9 +2241,14 @@ mod tests {
                 "the Notes field vanished at {width}x{height}"
             );
             assert_eq!(
-                layout.scope_area.y,
+                layout.thread_area.y,
                 notes_area.y + notes_area.height,
-                "Notes and Scope disagree about the row after the field at {width}x{height}"
+                "Notes and Thread disagree about the row after the field at {width}x{height}"
+            );
+            assert_eq!(
+                layout.scope_area.y,
+                layout.thread_area.y + layout.thread_area.height,
+                "Thread and Scope disagree about their shared layout at {width}x{height}"
             );
             assert!(
                 layout.help_area.y > layout.save_chip.rect.y && layout.help_area.y < height,
@@ -2187,7 +2257,7 @@ mod tests {
 
             let rows = render_rows(&model, width, height);
             let plain = rows.join("\n");
-            for token in ["Title:", "Notes:", "Scope:", "Save", "Cancel"] {
+            for token in ["Title:", "Notes:", "Thread:", "Scope:", "Save", "Cancel"] {
                 assert!(
                     plain.contains(token),
                     "missing {token:?} at {width}x{height}: {plain}"
@@ -2265,5 +2335,61 @@ mod tests {
                 || plain.contains("Esc"),
             "missing help: {plain}"
         );
+    }
+
+    #[test]
+    fn capture_form_accepts_optional_thread_with_shared_validation() {
+        let snapshot = project_snapshot("/repos/app");
+        let mut domain = DomainState::new();
+        let mut model = CaptureModel::from_snapshot(&snapshot);
+        apply(
+            &mut domain,
+            &snapshot,
+            &mut model,
+            CaptureIntent::InsertText("Threaded capture".into()),
+        );
+        model.focused = CaptureField::Thread;
+        apply(
+            &mut domain,
+            &snapshot,
+            &mut model,
+            CaptureIntent::InsertText("Release-2026".into()),
+        );
+        let CaptureOutcome::Saved(id) =
+            apply(&mut domain, &snapshot, &mut model, CaptureIntent::Save)
+        else {
+            panic!("threaded capture did not save");
+        };
+        assert_eq!(
+            domain.get(id).expect("task").thread.as_deref(),
+            Some("release-2026")
+        );
+    }
+
+    #[test]
+    fn capture_form_refuses_invalid_thread_without_persisting() {
+        let snapshot = project_snapshot("/repos/app");
+        let mut domain = DomainState::new();
+        let mut model = CaptureModel::from_snapshot(&snapshot);
+        apply(
+            &mut domain,
+            &snapshot,
+            &mut model,
+            CaptureIntent::InsertText("Invalid threaded capture".into()),
+        );
+        model.focused = CaptureField::Thread;
+        apply(
+            &mut domain,
+            &snapshot,
+            &mut model,
+            CaptureIntent::InsertText("bad_name".into()),
+        );
+        assert_eq!(
+            apply(&mut domain, &snapshot, &mut model, CaptureIntent::Save),
+            CaptureOutcome::None
+        );
+        assert!(domain.tasks().is_empty());
+        assert_eq!(model.thread_refusal.as_deref(), Some("invalid thread name"));
+        assert!(render_plain(&model, 80, 16).contains("invalid thread name"));
     }
 }

--- a/src/ui/capture.rs
+++ b/src/ui/capture.rs
@@ -538,6 +538,7 @@ pub fn apply_capture_intent(
                 model.title(),
                 notes,
                 Some(model.scope.clone()),
+                None,
             ) {
                 Ok(id) => id,
                 Err(error) => {

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -556,6 +556,7 @@ pub fn map_key_with(
         BoardInputMode::QuickAdd => map_quick_add_key(key),
         BoardInputMode::FormScopeDropdown => map_board_form_key(CaptureField::Scope, true, key),
         BoardInputMode::EditScope => map_board_form_key(CaptureField::Scope, false, key),
+        BoardInputMode::EditThread => map_board_form_key(CaptureField::Thread, false, key),
         BoardInputMode::EditTitle | BoardInputMode::EditNotes | BoardInputMode::EditStep => {
             map_edit(mode, key)
         }
@@ -709,7 +710,7 @@ fn map_form_edit_key(
             }
             _ => None,
         },
-        CaptureField::Title | CaptureField::Notes => match key.code {
+        CaptureField::Title | CaptureField::Notes | CaptureField::Thread => match key.code {
             KeyCode::Enter if focused == CaptureField::Notes => {
                 Some(BoardIntent::EditInsertLineBreak)
             }
@@ -738,9 +739,10 @@ fn map_form_edit_key(
 pub fn map_edit_paste(mode: BoardInputMode, text: &str) -> Option<BoardIntent> {
     match mode {
         BoardInputMode::QuickAdd => Some(BoardIntent::QuickAddInsertText(text.to_string())),
-        BoardInputMode::EditTitle | BoardInputMode::EditNotes | BoardInputMode::EditStep => {
-            Some(BoardIntent::EditInsertText(text.to_string()))
-        }
+        BoardInputMode::EditTitle
+        | BoardInputMode::EditNotes
+        | BoardInputMode::EditThread
+        | BoardInputMode::EditStep => Some(BoardIntent::EditInsertText(text.to_string())),
         BoardInputMode::EditScope
         | BoardInputMode::FormScopeDropdown
         | BoardInputMode::TaskPage => None,
@@ -1055,6 +1057,7 @@ fn map_edit(mode: BoardInputMode, key: KeyEvent) -> Option<BoardIntent> {
     let focused = match mode {
         BoardInputMode::EditTitle | BoardInputMode::EditStep => CaptureField::Title,
         BoardInputMode::EditNotes => CaptureField::Notes,
+        BoardInputMode::EditThread => CaptureField::Thread,
         _ => return None,
     };
     map_form_edit_key(focused, FormEditNavigation::None, key)
@@ -1102,7 +1105,10 @@ pub fn map_capture_key_state(
     }
     // The two text fields carry the board's editing chords, so their table runs before the
     // modified-chord rejection below; the scope row is deliberately not part of it.
-    if matches!(focused, CaptureField::Title | CaptureField::Notes) {
+    if matches!(
+        focused,
+        CaptureField::Title | CaptureField::Notes | CaptureField::Thread
+    ) {
         if let Some(intent) = map_capture_edit_chord(key) {
             return Some(intent);
         }
@@ -1124,7 +1130,7 @@ pub fn map_capture_key_state(
     match focused {
         // Title is one line, so Enter saves the draft; Notes is multi-line, so Enter opens
         // a line and the chord pair above saves instead (ADR 0006).
-        CaptureField::Title | CaptureField::Notes => match key.code {
+        CaptureField::Title | CaptureField::Notes | CaptureField::Thread => match key.code {
             KeyCode::Enter => Some(match focused {
                 CaptureField::Notes => CaptureIntent::InsertLineBreak,
                 _ => CaptureIntent::Save,
@@ -1201,7 +1207,7 @@ pub fn map_capture_paste_state(
     text: &str,
 ) -> Option<CaptureIntent> {
     match focused {
-        CaptureField::Title | CaptureField::Notes => {
+        CaptureField::Title | CaptureField::Notes | CaptureField::Thread => {
             Some(CaptureIntent::InsertText(text.to_string()))
         }
         CaptureField::Scope if path_editing => Some(CaptureIntent::InsertText(text.to_string())),
@@ -1229,9 +1235,9 @@ pub fn intent_primary_capture_action(intent: &CaptureIntent) -> Option<PrimaryCa
         | CaptureIntent::MoveWordRight
         | CaptureIntent::FocusNext
         | CaptureIntent::FocusPrev
-        | CaptureIntent::FocusField(CaptureField::Title | CaptureField::Notes) => {
-            Some(PrimaryCaptureAction::EditField)
-        }
+        | CaptureIntent::FocusField(
+            CaptureField::Title | CaptureField::Notes | CaptureField::Thread,
+        ) => Some(PrimaryCaptureAction::EditField),
         // Scope row click cycles; path edit and focusing scope are scope interaction.
         CaptureIntent::FocusField(CaptureField::Scope)
         | CaptureIntent::CycleScope

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -54,6 +54,7 @@ pub struct CaptureLayout {
     pub subtitle_area: Rect,
     pub title_area: Rect,
     pub notes_area: Rect,
+    pub thread_area: Rect,
     pub scope_area: Rect,
     pub scope_chips: Vec<Chip<CaptureScopeChoice>>,
     pub this_project_available: bool,
@@ -188,12 +189,13 @@ pub fn capture_layout_state(
         1,
         notes_height,
         1,
+        1,
         u16::from(show_path),
         1,
         1,
         inner
             .height
-            .saturating_sub(6 + notes_height + u16::from(show_path)),
+            .saturating_sub(7 + notes_height + u16::from(show_path)),
         1,
     ];
     let mut y = inner.y;
@@ -203,10 +205,10 @@ pub fn capture_layout_state(
         areas.push(Rect::new(inner.x, y, inner.width, height));
         y = y.saturating_add(height);
     }
-    let scope_row = areas[3];
+    let scope_row = areas[4];
     let scope_chips = place_scope_chips(scope_row);
-    let scope_path_area = if show_path { areas[4] } else { Rect::default() };
-    let buttons = areas[6];
+    let scope_path_area = if show_path { areas[5] } else { Rect::default() };
+    let buttons = areas[7];
     let save_label = if save_recovery { " Retry " } else { " Save " };
     let cancel_label = " Cancel ";
     let save_width = save_label.chars().count() as u16;
@@ -235,11 +237,12 @@ pub fn capture_layout_state(
         subtitle_area: areas[0],
         title_area: areas[1],
         notes_area: areas[2],
+        thread_area: areas[3],
         scope_area: scope_row,
         scope_chips,
         this_project_available,
         scope_path_area,
-        message_area: areas[5],
+        message_area: areas[6],
         save_chip: Chip {
             rect: save_rect,
             label: save_label,
@@ -250,12 +253,12 @@ pub fn capture_layout_state(
             label: cancel_label,
             value: (),
         },
-        help_area: areas[8],
+        help_area: areas[9],
     }
 }
 
 pub const CAPTURE_NOTES_MAX_ROWS: u16 = 3;
-const CAPTURE_FIXED_ROWS: u16 = 6;
+const CAPTURE_FIXED_ROWS: u16 = 7;
 
 fn capture_notes_rows(inner_height: u16, show_path: bool) -> u16 {
     inner_height
@@ -445,21 +448,25 @@ pub fn map_board_mouse(
             // triggering a second board action behind the capture surface.
             _ => Some(BoardIntent::CancelQuickAdd),
         },
-        BoardInputMode::EditTitle | BoardInputMode::EditNotes | BoardInputMode::EditScope => {
-            match hit_at(hits, pos) {
-                Some(QueueHitTarget::FormTitle) => {
-                    Some(BoardIntent::FocusFormField(CaptureField::Title))
-                }
-                Some(QueueHitTarget::FormNotes(_)) => {
-                    Some(BoardIntent::FocusFormField(CaptureField::Notes))
-                }
-                Some(QueueHitTarget::FormScope) => Some(BoardIntent::OpenFormScopeDropdown),
-                Some(QueueHitTarget::Verb(index)) => form_verb_intent(model, index),
-                _ => None,
+        BoardInputMode::EditTitle
+        | BoardInputMode::EditNotes
+        | BoardInputMode::EditThread
+        | BoardInputMode::EditScope => match hit_at(hits, pos) {
+            Some(QueueHitTarget::FormTitle) => {
+                Some(BoardIntent::FocusFormField(CaptureField::Title))
             }
-        }
+            Some(QueueHitTarget::FormNotes(_)) => {
+                Some(BoardIntent::FocusFormField(CaptureField::Notes))
+            }
+            Some(QueueHitTarget::FormScope) => Some(BoardIntent::OpenFormScopeDropdown),
+            Some(QueueHitTarget::FormThread) => {
+                Some(BoardIntent::FocusFormField(CaptureField::Thread))
+            }
+            Some(QueueHitTarget::Verb(index)) => form_verb_intent(model, index),
+            _ => None,
+        },
         BoardInputMode::TaskPage => match hit_at(hits, pos) {
-            Some(QueueHitTarget::FormScope) => None,
+            Some(QueueHitTarget::FormScope) | Some(QueueHitTarget::FormThread) => None,
             // A click on an step row selects it (AC-21) — the board's click
             // convention: a click selects, never mutates.
             Some(QueueHitTarget::Step(index)) => Some(BoardIntent::SelectStep(index)),

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -534,6 +534,9 @@ pub fn map_capture_mouse(layout: &CaptureLayout, mouse: MouseEvent) -> Option<Ca
     if layout.notes_area.contains(pos) {
         return Some(CaptureIntent::FocusField(CaptureField::Notes));
     }
+    if layout.thread_area.contains(pos) {
+        return Some(CaptureIntent::FocusField(CaptureField::Thread));
+    }
     for chip in &layout.scope_chips {
         if chip.rect.contains(pos) {
             if chip.value == CaptureScopeChoice::ThisProject && !layout.this_project_available {

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -29,12 +29,25 @@ pub enum DeckScope<'a> {
     Project(&'a Path),
 }
 
+/// Ordered open tasks sharing a normalized thread name in a scoped ON DECK section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadBlock {
+    pub name: String,
+    pub open_count: usize,
+    pub task_ids: Vec<Uuid>,
+}
+
 /// One ordered section of the queue board.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueueSection {
     pub kind: SectionKind,
     /// Project path for an ON DECK project group. `None` for IN MOTION, DONE, and the global ON DECK group.
     pub project_label: Option<String>,
+    /// Thread groups for scoped ON DECK sections only, newest group first.
+    pub thread_blocks: Vec<ThreadBlock>,
+    /// Unthreaded scoped ON DECK tasks, after every thread block.
+    pub loose_task_ids: Vec<Uuid>,
+    /// Exact thread-blocks-then-loose flattening, retained for task-only consumers.
     pub task_ids: Vec<Uuid>,
     pub count: usize,
     /// True when a scoped deck group has zero open tasks (renderer paints the empty hint; no invented ids).
@@ -185,6 +198,8 @@ fn section_from(kind: SectionKind, project_label: Option<String>, tasks: &[&Task
     QueueSection {
         kind,
         project_label,
+        thread_blocks: Vec::new(),
+        loose_task_ids: Vec::new(),
         task_ids,
         count,
         empty_hint: false,
@@ -193,11 +208,49 @@ fn section_from(kind: SectionKind, project_label: Option<String>, tasks: &[&Task
 
 /// ON DECK section for a scoped group: empty groups keep the header and set `empty_hint`.
 fn deck_section(project_label: Option<String>, tasks: &[&Task]) -> QueueSection {
-    let task_ids: Vec<Uuid> = tasks.iter().map(|t| t.id).collect();
-    let count = task_ids.len();
+    let mut grouped: BTreeMap<String, Vec<&Task>> = BTreeMap::new();
+    let mut loose = Vec::new();
+    for task in tasks {
+        if let Some(name) = task.thread.as_deref() {
+            grouped
+                .entry(name.to_ascii_lowercase())
+                .or_default()
+                .push(*task);
+        } else {
+            loose.push(*task);
+        }
+    }
+
+    let mut thread_blocks: Vec<ThreadBlock> = grouped
+        .into_iter()
+        .map(|(name, tasks)| ThreadBlock {
+            name,
+            open_count: tasks.len(),
+            task_ids: tasks.iter().map(|task| task.id).collect(),
+        })
+        .collect();
+    thread_blocks.sort_by_key(|block| {
+        Reverse(
+            tasks
+                .iter()
+                .find(|task| task.id == block.task_ids[0])
+                .expect("thread block task comes from deck tasks")
+                .updated_at,
+        )
+    });
+
+    let loose_task_ids: Vec<Uuid> = loose.iter().map(|task| task.id).collect();
+    let task_ids = thread_blocks
+        .iter()
+        .flat_map(|block| block.task_ids.iter().copied())
+        .chain(loose_task_ids.iter().copied())
+        .collect();
+    let count = tasks.len();
     QueueSection {
         kind: SectionKind::OnDeck,
         project_label,
+        thread_blocks,
+        loose_task_ids,
         task_ids,
         count,
         empty_hint: count == 0,

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -226,6 +226,7 @@ mod tests {
             merge_base_revision: None,
             title: format!("task-{id}"),
             notes: None,
+            thread: None,
             status,
             scope,
             capsule: None,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1956,6 +1956,7 @@ fn build_list_rows(
                         true,
                     );
                 }
+                out.push(ListRow::Blank);
             }
             for id in section.loose_task_ids.iter().copied() {
                 push_task(

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -340,8 +340,13 @@ pub enum QueueOverlay<'a> {
         /// The page's add/rename step draft. When present it uses the shared
         /// bottom input slot, leaving the meta footer visible in the page above.
         step_editor: Option<BottomInputSlot<'a>>,
-        /// Footer: scope · created · updated.
+        /// Footer: scope · thread · created · updated.
         meta: String,
+        /// Display width of scope inside `meta`, carried separately so mouse geometry never
+        /// parses user-controlled project names from rendered text.
+        meta_scope_width: u16,
+        /// Display width of the rendered Thread segment, including its separator.
+        thread_slot_width: Option<u16>,
         /// Which field owns the cursor, if any (view mode: none).
         focus: Option<CaptureField>,
         scope_dropdown: Option<FormScopeDropdown<'a>>,
@@ -945,6 +950,8 @@ fn paint_overlay(
             step_marked,
             ref step_editor,
             ref meta,
+            meta_scope_width,
+            thread_slot_width,
             focus,
             scope_dropdown,
         } => {
@@ -962,6 +969,8 @@ fn paint_overlay(
                 *step_scroll,
                 *step_marked,
                 meta,
+                *meta_scope_width,
+                *thread_slot_width,
                 *focus,
                 step_editor.is_some(),
                 hits,
@@ -1408,6 +1417,8 @@ fn paint_task_page(
     step_scroll: usize,
     step_marked: Option<usize>,
     meta: &str,
+    meta_scope_width: u16,
+    thread_slot_width: Option<u16>,
     focus: Option<CaptureField>,
     footer_input_open: bool,
     hits: &mut QueueHitMap,
@@ -1586,29 +1597,13 @@ fn paint_task_page(
             paint_bounded_line(&format!("  {meta}"), width, style_dim()),
         );
 
-        let (scope, thread_slot_width) = match meta.split_once(" · #") {
-            Some((scope, tail)) => {
-                let thread = tail
-                    .split_once(" · created")
-                    .map_or(tail, |(thread, _)| thread);
-                (scope, Some(display_width(" · #") + display_width(thread)))
-            }
-            None => match meta.split_once(" · thread") {
-                Some((scope, _)) => (scope, Some(display_width(" · thread"))),
-                None => (meta, None),
-            },
-        };
-        let thread_x = u16::try_from(2 + display_width(scope))
-            .unwrap_or(u16::MAX)
-            .min(width);
+        let thread_x = 2u16.saturating_add(meta_scope_width).min(width);
         if footer_input_open {
             return;
         }
         hits.push(QueueHitTarget::FormScope, Rect::new(0, y, thread_x, 1));
         if let Some(thread_slot_width) = thread_slot_width.filter(|_| thread_x < width) {
-            let thread_width = u16::try_from(thread_slot_width)
-                .unwrap_or(u16::MAX)
-                .min(width.saturating_sub(thread_x));
+            let thread_width = thread_slot_width.min(width.saturating_sub(thread_x));
             hits.push(
                 QueueHitTarget::FormThread,
                 Rect::new(thread_x, y, thread_width, 1),
@@ -2345,7 +2340,7 @@ fn put_line(frame: &mut Frame<'_>, row: u16, width: u16, line: Line<'static>) {
     frame.render_widget(Paragraph::new(padded), area);
 }
 
-fn display_width(s: &str) -> usize {
+pub(crate) fn display_width(s: &str) -> usize {
     Line::from(s).width()
 }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -423,6 +423,8 @@ pub enum QueueHitTarget {
     FormNotes(usize),
     /// Shared-form scope row. A click opens the pending scope dropdown, never cycles scope.
     FormScope,
+    /// Shared-form thread portion of the task-page footer.
+    FormThread,
     /// One painted steps step row on the open task page, indexed by the step's
     /// absolute position in the task's steps (storage order), whatever window
     /// scroll painted it — the same absolute-index discipline [`Command`] follows.
@@ -769,6 +771,20 @@ const FORM_NOTES_VERBS: &[VerbEntry<'static>] = &[
         label: "cancel",
     },
 ];
+const FORM_THREAD_VERBS: &[VerbEntry<'static>] = &[
+    VerbEntry {
+        key: "enter",
+        label: "save",
+    },
+    VerbEntry {
+        key: "tab",
+        label: "scope",
+    },
+    VerbEntry {
+        key: "esc",
+        label: "cancel",
+    },
+];
 const FORM_SCOPE_VERBS: &[VerbEntry<'static>] = &[
     VerbEntry {
         key: "enter",
@@ -808,6 +824,7 @@ pub(crate) fn form_verb_items(
     match focus {
         CaptureField::Title => FORM_TITLE_VERBS,
         CaptureField::Notes => FORM_NOTES_VERBS,
+        CaptureField::Thread => FORM_THREAD_VERBS,
         CaptureField::Scope => FORM_SCOPE_VERBS,
     }
 }
@@ -917,10 +934,10 @@ fn paint_overlay(
             step_cursor,
             step_scroll,
             step_marked,
+            ref step_editor,
             ref meta,
             focus,
             scope_dropdown,
-            ..
         } => {
             paint_task_page(
                 frame,
@@ -937,6 +954,7 @@ fn paint_overlay(
                 *step_marked,
                 meta,
                 *focus,
+                step_editor.is_some(),
                 hits,
             );
             if let Some(dropdown) = scope_dropdown {
@@ -1382,6 +1400,7 @@ fn paint_task_page(
     step_marked: Option<usize>,
     meta: &str,
     focus: Option<CaptureField>,
+    footer_input_open: bool,
     hits: &mut QueueHitMap,
 ) {
     let width = geo.row_width;
@@ -1548,7 +1567,7 @@ fn paint_task_page(
         paint_page_scrollbar(frame, &lay, width, scroll, content.total_rows);
     }
 
-    // Meta footer: scope · created · updated. It remains available while a step
+    // Meta footer: scope · thread · created · updated. It remains available while a step
     // draft uses the board's separate shared bottom input slot.
     if let Some(y) = lay.meta_y {
         put_line(
@@ -1557,7 +1576,30 @@ fn paint_task_page(
             width,
             paint_bounded_line(&format!("  {meta}"), width, style_dim()),
         );
-        hits.push(QueueHitTarget::FormScope, Rect::new(0, y, width, 1));
+        let (scope, thread) = match meta.split_once(" · #") {
+            Some((scope, tail)) => (
+                scope,
+                tail.split_once(" · created")
+                    .map_or(tail, |(thread, _)| thread),
+            ),
+            None => (meta, ""),
+        };
+        let thread_x = u16::try_from(2 + display_width(scope))
+            .unwrap_or(u16::MAX)
+            .min(width);
+        if footer_input_open {
+            return;
+        }
+        hits.push(QueueHitTarget::FormScope, Rect::new(0, y, thread_x, 1));
+        if !thread.is_empty() && thread_x < width {
+            let thread_width = u16::try_from(display_width(" · #") + display_width(thread))
+                .unwrap_or(u16::MAX)
+                .min(width.saturating_sub(thread_x));
+            hits.push(
+                QueueHitTarget::FormThread,
+                Rect::new(thread_x, y, thread_width, 1),
+            );
+        }
     }
 }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -563,7 +563,9 @@ pub fn draw_queue_frame(
                         );
                     }
                 }
-                ListRow::Hint(line) => put_line(frame, y, width, line),
+                ListRow::Hint(line) | ListRow::ThreadHeader(line) => {
+                    put_line(frame, y, width, line)
+                }
                 ListRow::Task { id, line } => {
                     put_line(frame, y, width, line);
                     if base_list_interactive {
@@ -1729,6 +1731,9 @@ enum ListRow {
     /// project's own scope control.
     Header(SectionKind, usize, Line<'static>),
     Hint(Line<'static>),
+    /// Decorative scoped ON DECK thread-block label. It consumes a viewport row but
+    /// deliberately has no identity or mouse target, so selection remains task-only.
+    ThreadHeader(Line<'static>),
     Task {
         id: Uuid,
         line: Line<'static>,
@@ -1778,6 +1783,13 @@ fn detail_lines_for_task(task: &Task, now: SystemTime, width: u16) -> Vec<Line<'
             ));
         }
     }
+    if let Some(thread) = task.thread.as_deref() {
+        lines.push(paint_bounded_line(
+            &format!("{indent}thread #{thread}"),
+            width,
+            style_dim(),
+        ));
+    }
     let scope_text = match &task.scope {
         TaskScope::Project { path } => short_project(path).to_string(),
         TaskScope::Global => "global".to_string(),
@@ -1821,6 +1833,39 @@ fn build_list_rows(
         None
     };
 
+    let push_task = |id: Uuid,
+                     out: &mut Vec<ListRow>,
+                     selected_idx: &mut Option<usize>,
+                     anchor_last_idx: &mut Option<usize>,
+                     in_project_section: bool| {
+        let Some(task) = model.tasks.iter().find(|task| task.id == id) else {
+            // Stale ids may outlive a snapshot refresh. Skip them without inventing a row.
+            return;
+        };
+        let meta = row_meta(task, model.now, in_project_section);
+        let line = paint_task_row(
+            &TaskRowPaint {
+                glyph: status_glyph(task.status),
+                title: &task.title,
+                meta: &meta,
+                selected: model.selection_id == Some(task.id)
+                    && !matches!(model.overlay, QueueOverlay::ScopeDropdown { .. }),
+                title_bold: false,
+            },
+            geo,
+        );
+        if model.selection_id == Some(task.id) {
+            *selected_idx = Some(out.len());
+        }
+        out.push(ListRow::Task { id: task.id, line });
+        if detail_target == Some(task.id) {
+            for line in detail_lines_for_task(task, model.now, geo.row_width) {
+                out.push(ListRow::Detail(line));
+            }
+            *anchor_last_idx = Some(out.len() - 1);
+        }
+    };
+
     for (section_idx, section) in model.view.sections.iter().enumerate() {
         // A preceding section with no content already ends in its required below-header blank
         // row, which doubles as this heading's above-header row. Otherwise add one list row.
@@ -1841,36 +1886,56 @@ fn build_list_rows(
         }
         let in_project_section =
             section.kind == SectionKind::OnDeck && section.project_label.is_some();
-        for id in &section.task_ids {
-            let Some(task) = model.tasks.iter().find(|t| t.id == *id) else {
-                // Stale id: skip without panicking (Selection Anchor's problem).
-                continue;
-            };
-            let meta = row_meta(task, model.now, in_project_section);
-            let line = paint_task_row(
-                &TaskRowPaint {
-                    glyph: status_glyph(task.status),
-                    title: &task.title,
-                    meta: &meta,
-                    selected: model.selection_id == Some(task.id)
-                        && !matches!(model.overlay, QueueOverlay::ScopeDropdown { .. }),
-                    title_bold: false,
-                },
-                geo,
-            );
-            if model.selection_id == Some(task.id) {
-                selected_idx = Some(out.len());
-            }
-            out.push(ListRow::Task { id: task.id, line });
-            if detail_target == Some(task.id) {
-                for line in detail_lines_for_task(task, model.now, geo.row_width) {
-                    out.push(ListRow::Detail(line));
+        if !section.thread_blocks.is_empty() {
+            for block in &section.thread_blocks {
+                out.push(ListRow::ThreadHeader(paint_thread_header(
+                    &block.name,
+                    block.open_count,
+                    geo,
+                )));
+                for id in block.task_ids.iter().copied() {
+                    push_task(
+                        id,
+                        &mut out,
+                        &mut selected_idx,
+                        &mut anchor_last_idx,
+                        in_project_section,
+                    );
                 }
-                anchor_last_idx = Some(out.len() - 1);
+            }
+            for id in section.loose_task_ids.iter().copied() {
+                push_task(
+                    id,
+                    &mut out,
+                    &mut selected_idx,
+                    &mut anchor_last_idx,
+                    in_project_section,
+                );
+            }
+        } else {
+            for id in section.task_ids.iter().copied() {
+                push_task(
+                    id,
+                    &mut out,
+                    &mut selected_idx,
+                    &mut anchor_last_idx,
+                    in_project_section,
+                );
             }
         }
     }
     (out, anchor_last_idx, selected_idx)
+}
+
+/// Paint one scoped ON DECK thread block label. Headers are presentation-only: their
+/// associated ids stay in the task-only queue stream, so neither keyboard selection nor
+/// mouse hit testing can land on this row.
+fn paint_thread_header(name: &str, open_count: usize, geo: &TierGeometry) -> Line<'static> {
+    let text = match geo.tier {
+        Tier::Standard => format!("  #{name} · {open_count} open"),
+        Tier::Compact => format!("  #{name} {open_count}"),
+    };
+    paint_bounded_line(&text, geo.row_width, style_dim())
 }
 
 fn paint_section_header(section: &QueueSection, width: u16, all_projects: bool) -> Line<'static> {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -107,6 +107,15 @@ pub struct TaskRowPaint<'a> {
 /// [`present_line`] so truncation always shows `…`. Compact geometry
 /// (`meta_column_width == 0`) drops meta and gives the title the full row.
 pub fn paint_task_row(row: &TaskRowPaint<'_>, geo: &TierGeometry) -> Line<'static> {
+    paint_task_row_with_indent(row, geo, 0)
+}
+
+/// Paint a task row with extra leading cells reserved for a containing visual group.
+fn paint_task_row_with_indent(
+    row: &TaskRowPaint<'_>,
+    geo: &TierGeometry,
+    leading_indent: usize,
+) -> Line<'static> {
     let row_w = geo.row_width as usize;
     let meta_budget = geo.meta_column_width as usize;
     let title_budget = if meta_budget == 0 {
@@ -116,7 +125,7 @@ pub fn paint_task_row(row: &TaskRowPaint<'_>, geo: &TierGeometry) -> Line<'stati
     };
 
     let glyph = super::terminal_text(row.glyph);
-    let prefix = format!("  {glyph} ");
+    let prefix = format!("{}  {glyph} ", " ".repeat(leading_indent));
     let title_room = title_budget.saturating_sub(display_width(&prefix));
     let title = present_line(row.title, title_room);
     let left = fit_left(&format!("{prefix}{title}"), title_budget);
@@ -1879,13 +1888,14 @@ fn build_list_rows(
                      out: &mut Vec<ListRow>,
                      selected_idx: &mut Option<usize>,
                      anchor_last_idx: &mut Option<usize>,
-                     in_project_section: bool| {
+                     in_project_section: bool,
+                     indented_under_thread: bool| {
         let Some(task) = model.tasks.iter().find(|task| task.id == id) else {
             // Stale ids may outlive a snapshot refresh. Skip them without inventing a row.
             return;
         };
         let meta = row_meta(task, model.now, in_project_section);
-        let line = paint_task_row(
+        let line = paint_task_row_with_indent(
             &TaskRowPaint {
                 glyph: status_glyph(task.status),
                 title: &task.title,
@@ -1895,6 +1905,7 @@ fn build_list_rows(
                 title_bold: false,
             },
             geo,
+            usize::from(indented_under_thread) * 2,
         );
         if model.selection_id == Some(task.id) {
             *selected_idx = Some(out.len());
@@ -1942,6 +1953,7 @@ fn build_list_rows(
                         &mut selected_idx,
                         &mut anchor_last_idx,
                         in_project_section,
+                        true,
                     );
                 }
             }
@@ -1952,6 +1964,7 @@ fn build_list_rows(
                     &mut selected_idx,
                     &mut anchor_last_idx,
                     in_project_section,
+                    false,
                 );
             }
         } else {
@@ -1962,6 +1975,7 @@ fn build_list_rows(
                     &mut selected_idx,
                     &mut anchor_last_idx,
                     in_project_section,
+                    false,
                 );
             }
         }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1585,13 +1585,14 @@ fn paint_task_page(
             width,
             paint_bounded_line(&format!("  {meta}"), width, style_dim()),
         );
-        let (scope, thread) = match meta.split_once(" · #") {
+        let (scope, thread, has_thread_slot) = match meta.split_once(" · #") {
             Some((scope, tail)) => (
                 scope,
                 tail.split_once(" · created")
                     .map_or(tail, |(thread, _)| thread),
+                true,
             ),
-            None => (meta, ""),
+            None => (meta, "", false),
         };
         let thread_x = u16::try_from(2 + display_width(scope))
             .unwrap_or(u16::MAX)
@@ -1600,7 +1601,7 @@ fn paint_task_page(
             return;
         }
         hits.push(QueueHitTarget::FormScope, Rect::new(0, y, thread_x, 1));
-        if !thread.is_empty() && thread_x < width {
+        if has_thread_slot && thread_x < width {
             let thread_width = u16::try_from(display_width(" · #") + display_width(thread))
                 .unwrap_or(u16::MAX)
                 .min(width.saturating_sub(thread_x));

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1585,14 +1585,18 @@ fn paint_task_page(
             width,
             paint_bounded_line(&format!("  {meta}"), width, style_dim()),
         );
-        let (scope, thread, has_thread_slot) = match meta.split_once(" · #") {
-            Some((scope, tail)) => (
-                scope,
-                tail.split_once(" · created")
-                    .map_or(tail, |(thread, _)| thread),
-                true,
-            ),
-            None => (meta, "", false),
+
+        let (scope, thread_slot_width) = match meta.split_once(" · #") {
+            Some((scope, tail)) => {
+                let thread = tail
+                    .split_once(" · created")
+                    .map_or(tail, |(thread, _)| thread);
+                (scope, Some(display_width(" · #") + display_width(thread)))
+            }
+            None => match meta.split_once(" · thread") {
+                Some((scope, _)) => (scope, Some(display_width(" · thread"))),
+                None => (meta, None),
+            },
         };
         let thread_x = u16::try_from(2 + display_width(scope))
             .unwrap_or(u16::MAX)
@@ -1601,8 +1605,8 @@ fn paint_task_page(
             return;
         }
         hits.push(QueueHitTarget::FormScope, Rect::new(0, y, thread_x, 1));
-        if has_thread_slot && thread_x < width {
-            let thread_width = u16::try_from(display_width(" · #") + display_width(thread))
+        if let Some(thread_slot_width) = thread_slot_width.filter(|_| thread_x < width) {
+            let thread_width = u16::try_from(thread_slot_width)
                 .unwrap_or(u16::MAX)
                 .min(width.saturating_sub(thread_x));
             hits.push(

--- a/src/views.rs
+++ b/src/views.rs
@@ -103,6 +103,7 @@ mod tests {
             merge_base_revision: None,
             title: format!("task-{id}"),
             notes: None,
+            thread: None,
             status,
             scope,
             capsule: None,

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -44,7 +44,7 @@ struct PanicOnRead;
 
 impl Read for PanicOnRead {
     fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
-        panic!("flag add must not read stdin")
+        panic!("stdin must not be read")
     }
 }
 
@@ -80,17 +80,17 @@ fn add_thread_flag_applies_to_every_item_and_round_trips() {
 }
 
 #[test]
-fn thread_flag_with_plan_input_is_usage_error_exit_2() {
+fn thread_flag_with_file_is_usage_error_exit_2() {
     let _env = env_lock();
-    let file_dir = temp_state_dir("thread-file-plan");
-    let plan = file_dir.join("plan.json");
+    let dir = temp_state_dir("thread-file-plan");
+    let plan = dir.join("plan.json");
     std::fs::write(&plan, r#"[{"title":"from file"}]"#).expect("write plan");
-    let file = add(
+    let output = add(
         &[
             "herdr-tasks".into(),
             "add".into(),
             "--state-dir".into(),
-            state_dir_arg(&file_dir),
+            state_dir_arg(&dir),
             "--thread".into(),
             "release".into(),
             "--file".into(),
@@ -98,40 +98,48 @@ fn thread_flag_with_plan_input_is_usage_error_exit_2() {
         ],
         true,
     );
-    assert_eq!(file.code, 2);
-    assert!(file.stdout.is_empty());
-    assert!(file
+    assert_eq!(output.code, 2);
+    assert!(output.stdout.is_empty());
+    assert!(output
         .stderr
         .contains("item flags cannot be used with --file"));
-    assert!(task_store(&file_dir)
+    assert!(task_store(&dir)
         .load()
         .expect("load file state")
         .tasks()
         .is_empty());
 
-    let stdin_dir = temp_state_dir("thread-stdin-plan");
-    let stdin = run_with(
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn thread_flag_ignores_piped_plan_and_creates_only_flag_task() {
+    let _env = env_lock();
+    let dir = temp_state_dir("thread-stdin-plan");
+    let output = run_with(
         [
             "herdr-tasks",
             "add",
             "--state-dir",
-            &state_dir_arg(&stdin_dir),
+            &state_dir_arg(&dir),
             "--thread",
             "release",
+            "-t",
+            "flag title",
         ],
         Cursor::new(r#"[{"title":"from stdin"}]"#),
         false,
     );
-    assert_eq!(stdin.code, 2);
-    assert!(stdin.stdout.is_empty());
-    assert!(task_store(&stdin_dir)
-        .load()
-        .expect("load stdin state")
-        .tasks()
-        .is_empty());
 
-    let _ = std::fs::remove_dir_all(file_dir);
-    let _ = std::fs::remove_dir_all(stdin_dir);
+    assert_eq!(output.code, 0);
+    assert_eq!(output.stdout, "added flag title\n");
+    let state = task_store(&dir).load().expect("load stdin state");
+    assert_eq!(state.tasks().len(), 1);
+    assert_eq!(state.tasks()[0].title, "flag title");
+    assert_eq!(state.tasks()[0].thread.as_deref(), Some("release"));
+    assert!(state.tasks().iter().all(|task| task.title != "from stdin"));
+
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -52,6 +52,333 @@ fn task_store(dir: &std::path::Path) -> TaskStore {
     TaskStore::new(dir)
 }
 
+#[test]
+fn add_thread_flag_applies_to_every_item_and_round_trips() {
+    let _env = env_lock();
+    let dir = temp_state_dir("thread-flag");
+    let output = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&dir),
+            "--title".into(),
+            "threaded task".into(),
+            "--thread".into(),
+            "Release-2026".into(),
+        ],
+        true,
+    );
+
+    assert_eq!(output.code, 0);
+    assert_eq!(output.stdout, "added threaded task\n");
+    let state = task_store(&dir).load().expect("reload threaded task");
+    assert_eq!(state.tasks().len(), 1);
+    assert_eq!(state.tasks()[0].thread.as_deref(), Some("release-2026"));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn thread_flag_with_plan_input_is_usage_error_exit_2() {
+    let _env = env_lock();
+    let file_dir = temp_state_dir("thread-file-plan");
+    let plan = file_dir.join("plan.json");
+    std::fs::write(&plan, r#"[{"title":"from file"}]"#).expect("write plan");
+    let file = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&file_dir),
+            "--thread".into(),
+            "release".into(),
+            "--file".into(),
+            state_dir_arg(&plan),
+        ],
+        true,
+    );
+    assert_eq!(file.code, 2);
+    assert!(file.stdout.is_empty());
+    assert!(file
+        .stderr
+        .contains("item flags cannot be used with --file"));
+    assert!(task_store(&file_dir)
+        .load()
+        .expect("load file state")
+        .tasks()
+        .is_empty());
+
+    let stdin_dir = temp_state_dir("thread-stdin-plan");
+    let stdin = run_with(
+        [
+            "herdr-tasks",
+            "add",
+            "--state-dir",
+            &state_dir_arg(&stdin_dir),
+            "--thread",
+            "release",
+        ],
+        Cursor::new(r#"[{"title":"from stdin"}]"#),
+        false,
+    );
+    assert_eq!(stdin.code, 2);
+    assert!(stdin.stdout.is_empty());
+    assert!(task_store(&stdin_dir)
+        .load()
+        .expect("load stdin state")
+        .tasks()
+        .is_empty());
+
+    let _ = std::fs::remove_dir_all(file_dir);
+    let _ = std::fs::remove_dir_all(stdin_dir);
+}
+
+#[test]
+fn plan_item_thread_applies_per_item() {
+    let _env = env_lock();
+    let dir = temp_state_dir("plan-item-thread");
+    let plan = dir.join("plan.json");
+    std::fs::write(
+        &plan,
+        r#"[{"title":"threaded from file","thread":"Release-2026"},{"title":"unthreaded from file","thread":null}]"#,
+    )
+    .expect("write plan");
+    let output = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&dir),
+            "--file".into(),
+            state_dir_arg(&plan),
+        ],
+        true,
+    );
+
+    assert_eq!(output.code, 0);
+    let state = task_store(&dir).load().expect("load file plan state");
+    assert_eq!(state.tasks().len(), 2);
+    assert_eq!(state.tasks()[0].thread.as_deref(), Some("release-2026"));
+    assert_eq!(state.tasks()[1].thread, None);
+
+    let stdin_dir = temp_state_dir("plan-item-thread-stdin");
+    let stdin = run_with(
+        [
+            "herdr-tasks",
+            "add",
+            "--state-dir",
+            &state_dir_arg(&stdin_dir),
+        ],
+        Cursor::new(r#"[{"title":"threaded from stdin","thread":"ops"}]"#),
+        false,
+    );
+    assert_eq!(stdin.code, 0);
+    assert_eq!(
+        task_store(&stdin_dir)
+            .load()
+            .expect("load stdin plan state")
+            .tasks()[0]
+            .thread
+            .as_deref(),
+        Some("ops")
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+    let _ = std::fs::remove_dir_all(stdin_dir);
+}
+
+#[test]
+fn invalid_thread_flag_is_usage_error_exit_2_nothing_persisted() {
+    let _env = env_lock();
+    let dir = temp_state_dir("invalid-thread-flag");
+    let output = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&dir),
+            "--title".into(),
+            "valid title".into(),
+            "--thread".into(),
+            "not_valid".into(),
+        ],
+        true,
+    );
+
+    assert_eq!(output.code, 2);
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.contains("invalid thread"));
+    assert!(task_store(&dir)
+        .load()
+        .expect("load state")
+        .tasks()
+        .is_empty());
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn invalid_plan_item_thread_fails_item_exit_1_others_persist() {
+    let _env = env_lock();
+    let dir = temp_state_dir("invalid-plan-thread");
+    let output = run_with(
+        [
+            "herdr-tasks",
+            "add",
+            "--state-dir",
+            &state_dir_arg(&dir),
+            "--file",
+            "-",
+        ],
+        Cursor::new(
+            r#"[{"title":"valid thread","thread":"release"},{"title":"invalid thread","thread":"bad_name"},{"title":"valid unthreaded","thread":null}]"#,
+        ),
+        true,
+    );
+
+    assert_eq!(output.code, 1);
+    let result: serde_json::Value = serde_json::from_str(&output.stdout).expect("plan result");
+    assert_eq!(result["created"].as_array().expect("created").len(), 2);
+    assert_eq!(result["failed"][0]["i"], 1);
+    assert_eq!(result["failed"][0]["title"], "invalid thread");
+    assert_eq!(result["failed"][0]["code"], "invalid-thread");
+    let state = task_store(&dir).load().expect("load state");
+    assert_eq!(state.tasks().len(), 2);
+    assert_eq!(state.tasks()[0].thread.as_deref(), Some("release"));
+    assert_eq!(state.tasks()[1].thread, None);
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn idempotency_key_includes_thread_both_directions() {
+    let _env = env_lock();
+    let threaded_first_dir = temp_state_dir("thread-idempotency-threaded-first");
+    let threaded_first = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&threaded_first_dir),
+            "--title".into(),
+            "same title".into(),
+            "--global".into(),
+            "--thread".into(),
+            "Release".into(),
+        ],
+        true,
+    );
+    assert_eq!(threaded_first.code, 0);
+    let unthreaded_second = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&threaded_first_dir),
+            "--title".into(),
+            "same title".into(),
+            "--global".into(),
+        ],
+        true,
+    );
+    assert_eq!(unthreaded_second.code, 0);
+    assert_eq!(
+        task_store(&threaded_first_dir)
+            .load()
+            .expect("load threaded-first state")
+            .tasks()
+            .len(),
+        2
+    );
+
+    let unthreaded_first_dir = temp_state_dir("thread-idempotency-unthreaded-first");
+    let unthreaded_first = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&unthreaded_first_dir),
+            "--title".into(),
+            "same title".into(),
+            "--global".into(),
+        ],
+        true,
+    );
+    assert_eq!(unthreaded_first.code, 0);
+    let threaded_second = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&unthreaded_first_dir),
+            "--title".into(),
+            "same title".into(),
+            "--global".into(),
+            "--thread".into(),
+            "release".into(),
+        ],
+        true,
+    );
+    assert_eq!(threaded_second.code, 0);
+    let normalized_duplicate = add(
+        &[
+            "herdr-tasks".into(),
+            "add".into(),
+            "--state-dir".into(),
+            state_dir_arg(&unthreaded_first_dir),
+            "--title".into(),
+            "same title".into(),
+            "--global".into(),
+            "--thread".into(),
+            "RELEASE".into(),
+        ],
+        true,
+    );
+    assert_eq!(normalized_duplicate.code, 0);
+    assert_eq!(normalized_duplicate.stdout, "task already exists\n");
+    assert_eq!(
+        task_store(&unthreaded_first_dir)
+            .load()
+            .expect("load unthreaded-first state")
+            .tasks()
+            .len(),
+        2
+    );
+
+    let plan_dir = temp_state_dir("thread-plan-idempotency");
+    let plan = run_with(
+        [
+            "herdr-tasks",
+            "add",
+            "--state-dir",
+            &state_dir_arg(&plan_dir),
+            "--file",
+            "-",
+        ],
+        Cursor::new(
+            r#"[{"title":"plan title","project":null,"thread":null},{"title":"plan title","project":null,"thread":"Release"},{"title":"plan title","project":null,"thread":"release"}]"#,
+        ),
+        true,
+    );
+    assert_eq!(plan.code, 0);
+    let result: serde_json::Value = serde_json::from_str(&plan.stdout).expect("plan result");
+    assert_eq!(result["created"].as_array().expect("created").len(), 2);
+    assert_eq!(result["existing"][0]["i"], 2);
+    assert_eq!(
+        task_store(&plan_dir)
+            .load()
+            .expect("load plan state")
+            .tasks()
+            .len(),
+        2
+    );
+
+    let _ = std::fs::remove_dir_all(threaded_first_dir);
+    let _ = std::fs::remove_dir_all(unthreaded_first_dir);
+    let _ = std::fs::remove_dir_all(plan_dir);
+}
+
 #[cfg(unix)]
 struct ReadOnlyDir {
     path: PathBuf,

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -88,6 +88,28 @@ fn create_task(state: &mut DomainState, title: &str, scope: TaskScope, status: H
     state.set_status(id, status).expect("set status");
 }
 
+fn create_task_with_thread(
+    state: &mut DomainState,
+    title: &str,
+    scope: TaskScope,
+    status: HumanStatus,
+    thread: Option<&str>,
+) -> uuid::Uuid {
+    let id = state
+        .create_with_thread(
+            title,
+            None,
+            scope,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            thread.map(str::to_owned),
+        )
+        .expect("create task");
+    state.set_status(id, status).expect("set status");
+    id
+}
+
 #[test]
 fn list_defaults_to_invocation_project_open_tasks_in_human_and_json_group_order() {
     let _env = env_lock();
@@ -507,7 +529,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
                 .keys()
                 .map(String::as_str)
                 .collect::<Vec<_>>(),
-            vec!["id", "project", "status", "title"]
+            vec!["id", "project", "status", "thread", "title"]
         );
     }
     let done_human = list(&[
@@ -825,6 +847,49 @@ fn human_list_escapes_terminal_control_titles_without_changing_json() {
 }
 
 #[test]
+fn human_list_escapes_terminal_control_thread_markers_without_changing_json() {
+    let _env = env_lock();
+    let dir = temp_state_dir("terminal-control-thread");
+    let thread = "release\u{001b}]52;c;clipboard\u{0007}";
+    let escaped = "release\\u{001b}]52;c;clipboard\\u{0007}";
+    let mut state = DomainState::new();
+    create_task_with_thread(
+        &mut state,
+        "threaded task",
+        TaskScope::Global,
+        HumanStatus::Ready,
+        Some(thread),
+    );
+    TaskStore::new(&dir).save(&state).expect("seed store");
+
+    let human = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        "--global".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(human.code, 0);
+    assert!(human.stdout.contains(escaped));
+    assert!(!human.stdout.contains('\u{001b}'));
+    assert!(!human.stdout.contains('\u{0007}'));
+
+    let json = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        "--global".into(),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(json.code, 0);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json.stdout).expect("JSON rows");
+    assert_eq!(rows[0]["thread"], thread);
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn list_equals_state_dir_form_accepts_dash_leading_value() {
     let cwd = temp_state_dir("equals-dash-state");
     let state_dir = cwd.join("-state");
@@ -961,6 +1026,26 @@ fn list_rejects_conflicting_scope_and_filter_flags_and_missing_project_values() 
 }
 
 #[test]
+fn list_thread_parse_rejects_invalid_space_and_equals_forms() {
+    let _env = env_lock();
+    let dir = temp_state_dir("invalid-thread");
+
+    for thread in ["--thread", "--thread=bad_name"] {
+        let mut args = vec!["herdr-tasks".into(), "list".into(), thread.into()];
+        if thread == "--thread" {
+            args.push("bad_name".into());
+        }
+        args.extend(["--state-dir".into(), state_dir_arg(&dir)]);
+        let output = list(&args);
+        assert_eq!(output.code, 2, "{thread}");
+        assert!(output.stdout.is_empty(), "{thread}");
+        assert!(output.stderr.contains("invalid thread name"), "{thread}");
+    }
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn list_equals_project_form_accepts_dash_leading_scope() {
     let _env = env_lock();
     let dir = temp_state_dir("equals-project");
@@ -992,6 +1077,7 @@ fn list_equals_project_form_accepts_dash_leading_scope() {
             "title": "maintenance task",
             "status": "ready",
             "project": "-maintenance",
+            "thread": null,
         })]
     );
 
@@ -1170,7 +1256,7 @@ fn list_task_prints_step_lines_with_state_and_short_id() {
     assert_eq!(json.code, 0);
     let rows: Vec<serde_json::Value> = serde_json::from_str(&json.stdout).expect("JSON rows");
     assert_eq!(rows.len(), 1);
-    for key in ["id", "project", "status", "title"] {
+    for key in ["id", "project", "status", "thread", "title"] {
         assert!(rows[0].get(key).is_some(), "single-task row keeps {key}");
     }
     assert_eq!(
@@ -1236,7 +1322,7 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
             .keys()
             .map(String::as_str)
             .collect::<Vec<_>>(),
-        vec!["id", "project", "status", "title"],
+        vec!["id", "project", "status", "thread", "title"],
         "a task without steps keeps today's exact JSON row shape"
     );
 
@@ -1253,6 +1339,18 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
         assert!(output.stdout.is_empty());
         assert!(output.stderr.contains("usage: herdr-tasks list"));
     }
+    let threaded = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        task.to_string(),
+        "--thread".into(),
+        "release".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(threaded.code, 2, "task id with --thread is usage");
+    assert!(threaded.stdout.is_empty());
+    assert!(threaded.stderr.contains("usage: herdr-tasks list"));
 
     let invalid = list(&[
         "herdr-tasks".into(),
@@ -1265,5 +1363,206 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
     assert!(invalid.stdout.is_empty());
     assert!(invalid.stderr.contains("invalid task id"));
 
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn list_thread_filters_after_scope_selection() {
+    let _env = env_lock();
+    let dir = temp_state_dir("thread-filter");
+    let mut state = DomainState::new();
+    create_task_with_thread(
+        &mut state,
+        "selected thread",
+        TaskScope::Project {
+            path: "/projects/selected".into(),
+        },
+        HumanStatus::Ready,
+        Some("release"),
+    );
+    create_task_with_thread(
+        &mut state,
+        "selected other thread",
+        TaskScope::Project {
+            path: "/projects/selected".into(),
+        },
+        HumanStatus::Ready,
+        Some("ops"),
+    );
+    create_task_with_thread(
+        &mut state,
+        "other scope same thread",
+        TaskScope::Project {
+            path: "/projects/other".into(),
+        },
+        HumanStatus::Ready,
+        Some("release"),
+    );
+    TaskStore::new(&dir).save(&state).expect("seed store");
+
+    let scoped = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        "--project".into(),
+        "selected".into(),
+        "--thread".into(),
+        "Release".into(),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+
+    assert_eq!(scoped.code, 0, "{}", scoped.stderr);
+    assert_eq!(
+        serde_json::from_str::<Vec<serde_json::Value>>(&scoped.stdout)
+            .expect("scoped JSON rows")
+            .iter()
+            .map(|row| row["title"].as_str().expect("title"))
+            .collect::<Vec<_>>(),
+        vec!["selected thread"]
+    );
+
+    let all = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        "--all".into(),
+        "--thread=RELEASE".into(),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(all.code, 0, "{}", all.stderr);
+    assert_eq!(
+        serde_json::from_str::<Vec<serde_json::Value>>(&all.stdout)
+            .expect("all JSON rows")
+            .iter()
+            .map(|row| row["title"].as_str().expect("title"))
+            .collect::<Vec<_>>(),
+        vec!["selected thread", "other scope same thread"]
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn json_rows_always_carry_thread_field() {
+    let _env = env_lock();
+    let dir = temp_state_dir("thread-json");
+    let mut state = DomainState::new();
+    create_task_with_thread(
+        &mut state,
+        "threaded",
+        TaskScope::Global,
+        HumanStatus::Ready,
+        Some("release"),
+    );
+    create_task(
+        &mut state,
+        "unthreaded",
+        TaskScope::Global,
+        HumanStatus::Ready,
+    );
+    TaskStore::new(&dir).save(&state).expect("seed store");
+
+    let output = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        "--global".into(),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&output.stdout).expect("JSON rows");
+    assert_eq!(rows[0]["thread"], "release");
+    assert!(rows[1].get("thread").expect("unthreaded field").is_null());
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
+    let _env = env_lock();
+    let repo = project_repo("thread-human");
+    let _context = EnvironmentGuard::context_for(&repo);
+    let dir = temp_state_dir("thread-human");
+    let project = TaskScope::Project {
+        path: repo.to_string_lossy().into_owned(),
+    };
+    let mut state = DomainState::new();
+    create_task_with_thread(
+        &mut state,
+        "scoped threaded",
+        project.clone(),
+        HumanStatus::Ready,
+        Some("alpha"),
+    );
+    create_task(
+        &mut state,
+        "scoped unthreaded",
+        project.clone(),
+        HumanStatus::Ready,
+    );
+    create_task_with_thread(
+        &mut state,
+        "global threaded",
+        TaskScope::Global,
+        HumanStatus::Ready,
+        Some("ops"),
+    );
+    let step = create_task_with_thread(
+        &mut state,
+        "step threaded",
+        TaskScope::Global,
+        HumanStatus::Done,
+        Some("steps"),
+    );
+    state.add_step(step, "Keep this line").expect("add step");
+    let step_short_id = state.get(step).expect("step task").steps[0].id.to_string()[..1].to_owned();
+    TaskStore::new(&dir).save(&state).expect("seed store");
+    let project_name = repo
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("project basename");
+
+    let scoped = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(
+        scoped.stdout,
+        "READY\n - scoped threaded #alpha\n - scoped unthreaded\n"
+    );
+
+    let all = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        "--all".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(
+        all.stdout,
+        format!(
+            "READY\n  {project_name}\n    - scoped threaded #alpha\n    - scoped unthreaded\n  global\n    - global threaded #ops\n"
+        )
+    );
+
+    let single = list(&[
+        "herdr-tasks".into(),
+        "list".into(),
+        step.to_string(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(
+        single.stdout,
+        format!("DONE\n - step threaded #steps\n   [ ] {step_short_id} Keep this line\n")
+    );
+
+    let _ = std::fs::remove_dir_all(repo);
     let _ = std::fs::remove_dir_all(dir);
 }

--- a/tests/edit_target_binding.rs
+++ b/tests/edit_target_binding.rs
@@ -736,6 +736,7 @@ fn a_concurrent_edit_to_the_bound_task_still_reaches_the_save_conflict() {
             "Alpha from the other actor",
             current.notes.clone(),
             current.scope.clone(),
+            current.thread.clone(),
         )
         .expect("second actor edits the same task");
     store
@@ -1013,6 +1014,94 @@ fn a_soft_deleted_bind_opened_through_the_real_key_map_refuses_then_confirms_aft
 /// /: a scope dropdown belongs to the same immutable task form as title and Notes.
 /// A background sync may reorder the queue, but it cannot redirect the pending dropdown choice
 /// or the later atomic form save to the newly selected task.
+#[test]
+fn board_edit_preserves_existing_thread() {
+    let dir = temp_state_dir("thread-preserved");
+    let _guard = TempDirGuard(dir.clone());
+    let store = TaskStore::new(&dir);
+
+    let mut seeded = DomainState::new();
+    let id = seeded
+        .create(
+            "Threaded task",
+            Some("original notes".into()),
+            scope(),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create threaded task");
+    seeded
+        .edit(
+            id,
+            "Threaded task",
+            Some("original notes".into()),
+            scope(),
+            Some("release-2026".into()),
+        )
+        .expect("attach thread");
+    store.save(&seeded).expect("persist threaded task");
+
+    let mut domain = store.load().expect("load threaded task");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    let index = model
+        .visible_ids()
+        .iter()
+        .position(|&visible_id| visible_id == id)
+        .expect("threaded task visible");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectIndex(index),
+        None,
+        None,
+    )
+    .expect("select threaded task");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open board title edit");
+    for _ in 0.."Threaded task".len() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditBackspace,
+            None,
+            None,
+        )
+        .expect("clear title draft");
+    }
+    for character in "Renamed threaded task".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+            None,
+        )
+        .expect("type title draft");
+    }
+
+    assert_eq!(
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::ConfirmEdit,
+            None,
+            None,
+        )
+        .expect("confirm board title edit"),
+        IntentOutcome::Persist
+    );
+    let task = domain.get(id).expect("threaded task after board edit");
+    assert_eq!(task.title, "Renamed threaded task");
+    assert_eq!(task.thread.as_deref(), Some("release-2026"));
+}
+
 #[test]
 fn background_sync_cannot_redirect_a_bound_task_form_while_its_scope_dropdown_is_open() {
     let mut domain = DomainState::new();

--- a/tests/f6_dispatch_recovery.rs
+++ b/tests/f6_dispatch_recovery.rs
@@ -231,6 +231,7 @@ impl ConcurrentBoardMutationStore {
                         "edited by main board while dispatch runs",
                         None,
                         TaskScope::Global,
+                        None,
                     )
                     .map_err(|error| error.to_string())
             })

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -1884,6 +1884,67 @@ fn failed_task_page_view_save_holds_a_dirty_form_for_recovery() {
 }
 
 #[test]
+fn failed_scope_dropdown_save_holds_the_task_form_for_recovery() {
+    let (mut domain, mut model, _) = board_with_two_tasks();
+    let baseline = snapshot_of(&domain);
+    let mut recovery = SaveRecovery::new();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open task form");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsert('!'),
+        None,
+        None,
+    )
+    .expect("dirty title draft");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Scope),
+        None,
+        None,
+    )
+    .expect("focus scope");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenFormScopeDropdown,
+        None,
+        None,
+    )
+    .expect("open scope dropdown");
+    assert_eq!(model.input_mode(), BoardInputMode::FormScopeDropdown);
+
+    apply_board_intent_with_save_recovery(
+        &mut domain,
+        &mut model,
+        &mut recovery,
+        BoardSaveContext {
+            baseline,
+            intent: BoardIntent::ConfirmEdit,
+            snapshot: None,
+            host: None,
+        },
+        |_| Err(INJECTED.into()),
+    )
+    .expect("failed dropdown save stays recoverable");
+
+    assert!(recovery.is_pending());
+    assert!(
+        model.board_form_open(),
+        "a failed scope-dropdown save retains the task form"
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::SaveRecovery);
+}
+
+#[test]
 fn failed_task_thread_edit_cancel_returns_to_task_page_with_a_retained_form() {
     let (mut domain, mut model, id) = board_with_two_tasks();
     let baseline = snapshot_of(&domain);

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -1171,6 +1171,14 @@ fn task_form_save_failure_retries_the_exact_atomic_title_notes_and_scope_mutatio
         None,
         None,
     )
+    .expect("focus Thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FormFocusNext,
+        None,
+        None,
+    )
     .expect("focus Scope");
     apply_intent(
         &mut domain,
@@ -1742,5 +1750,222 @@ fn ctrl_enter_refuses_in_place_when_the_bound_task_was_concurrently_soft_deleted
         texts,
         vec!["alpha step"],
         "a refused chord must not mutate the working state"
+    );
+}
+
+#[test]
+fn successful_title_save_with_boundary_whitespace_releases_the_task_form_once() {
+    let (mut domain, mut model, id) = board_with_two_tasks();
+    let baseline = snapshot_of(&domain);
+    let history_before = domain.get(id).expect("task").history.len();
+    let mut recovery = SaveRecovery::new();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open title");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsert(' '),
+        None,
+        None,
+    )
+    .expect("append boundary whitespace");
+
+    assert_eq!(
+        apply_board_intent_with_save_recovery(
+            &mut domain,
+            &mut model,
+            &mut recovery,
+            BoardSaveContext {
+                baseline,
+                intent: BoardIntent::ConfirmEdit,
+                snapshot: None,
+                host: None,
+            },
+            |_| Ok(()),
+        )
+        .expect("save"),
+        IntentOutcome::Persisted
+    );
+    assert!(
+        !model.board_form_open(),
+        "successful save releases the form"
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::Normal);
+    assert_eq!(domain.get(id).expect("task").title, "Delete me");
+    assert_eq!(
+        domain.get(id).expect("task").history.len(),
+        history_before + 1,
+        "the completed edit records exactly one event"
+    );
+    let saved_baseline = snapshot_of(&domain);
+    assert_eq!(
+        apply_board_intent_with_save_recovery(
+            &mut domain,
+            &mut model,
+            &mut recovery,
+            BoardSaveContext {
+                baseline: saved_baseline,
+                intent: BoardIntent::ConfirmEdit,
+                snapshot: None,
+                host: None,
+            },
+            |_| -> Result<(), String> { panic!("released form cannot save again") },
+        )
+        .expect("released ConfirmEdit is inert"),
+        IntentOutcome::None
+    );
+    assert_eq!(
+        domain.get(id).expect("task").history.len(),
+        history_before + 1,
+        "an inert confirm cannot repeat the edit event"
+    );
+}
+
+#[test]
+fn failed_task_thread_edit_cancel_returns_to_task_page_with_a_retained_form() {
+    let (mut domain, mut model, id) = board_with_two_tasks();
+    let baseline = snapshot_of(&domain);
+    let mut recovery = SaveRecovery::new();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open form");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Thread),
+        None,
+        None,
+    )
+    .expect("focus thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsertText("release-2026".into()),
+        None,
+        None,
+    )
+    .expect("type thread");
+    apply_board_intent_with_save_recovery(
+        &mut domain,
+        &mut model,
+        &mut recovery,
+        BoardSaveContext {
+            baseline,
+            intent: BoardIntent::ConfirmEdit,
+            snapshot: None,
+            host: None,
+        },
+        |_| Err(INJECTED.into()),
+    )
+    .expect("failure stays recoverable");
+
+    assert_eq!(
+        apply_board_intent_with_save_recovery(
+            &mut domain,
+            &mut model,
+            &mut recovery,
+            BoardSaveContext {
+                baseline: DomainState::new(),
+                intent: BoardIntent::CancelSave,
+                snapshot: None,
+                host: None,
+            },
+            |_| -> Result<(), String> { panic!("Cancel does not persist") },
+        )
+        .expect("cancel"),
+        IntentOutcome::None
+    );
+    assert!(model.board_form_open(), "Cancel retains the task page form");
+    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+    assert_eq!(domain.get(id).expect("task").thread, None);
+}
+
+#[test]
+fn failed_save_during_thread_edit_holds_form_until_retry_or_cancel() {
+    let (mut domain, mut model, id) = board_with_two_tasks();
+    let baseline = snapshot_of(&domain);
+    let mut recovery = SaveRecovery::new();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open form");
+    for _ in 0..2 {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::FormFocusNext,
+            None,
+            None,
+        )
+        .expect("focus thread");
+    }
+    for character in "release-2026".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+            None,
+        )
+        .expect("type thread");
+    }
+
+    let failed = apply_board_intent_with_save_recovery(
+        &mut domain,
+        &mut model,
+        &mut recovery,
+        BoardSaveContext {
+            baseline,
+            intent: BoardIntent::ConfirmEdit,
+            snapshot: None,
+            host: None,
+        },
+        |_| Err(INJECTED.into()),
+    )
+    .expect("failure stays recoverable");
+    assert_eq!(failed, IntentOutcome::None);
+    assert!(recovery.is_pending());
+    assert!(model.board_form_open());
+    assert_eq!(model.input_mode(), BoardInputMode::SaveRecovery);
+
+    let retried = apply_board_intent_with_save_recovery(
+        &mut domain,
+        &mut model,
+        &mut recovery,
+        BoardSaveContext {
+            baseline: DomainState::new(),
+            intent: BoardIntent::RetrySave,
+            snapshot: None,
+            host: None,
+        },
+        |working| {
+            assert_eq!(
+                working.get(id).expect("task").thread.as_deref(),
+                Some("release-2026"),
+                "retry receives the held atomic task edit"
+            );
+            Ok(())
+        },
+    )
+    .expect("retry");
+    assert_eq!(retried, IntentOutcome::Persisted);
+    assert_eq!(
+        domain.get(id).expect("task").thread.as_deref(),
+        Some("release-2026")
     );
 }

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -1889,6 +1889,28 @@ fn failed_task_thread_edit_cancel_returns_to_task_page_with_a_retained_form() {
     assert!(model.board_form_open(), "Cancel retains the task page form");
     assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
     assert_eq!(domain.get(id).expect("task").thread, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Title),
+        None,
+        None,
+    )
+    .expect("focus restored title");
+    assert_eq!(model.edit_buffer(), "Delete me");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Thread),
+        None,
+        None,
+    )
+    .expect("focus restored thread");
+    assert_eq!(
+        model.edit_buffer(),
+        "",
+        "Cancel discards staged thread draft"
+    );
 }
 
 #[test]
@@ -1968,4 +1990,9 @@ fn failed_save_during_thread_edit_holds_form_until_retry_or_cancel() {
         domain.get(id).expect("task").thread.as_deref(),
         Some("release-2026")
     );
+    assert!(
+        !model.board_form_open(),
+        "a successful retry releases the held task form"
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::Normal);
 }

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -1912,6 +1912,38 @@ fn failed_task_thread_edit_cancel_returns_to_task_page_with_a_retained_form() {
         None,
     )
     .expect("type thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Notes),
+        None,
+        None,
+    )
+    .expect("focus notes");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsertText("staged notes".into()),
+        None,
+        None,
+    )
+    .expect("type notes");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Scope),
+        None,
+        None,
+    )
+    .expect("focus scope");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FormCycleScope,
+        None,
+        None,
+    )
+    .expect("stage changed scope");
     apply_board_intent_with_save_recovery(
         &mut domain,
         &mut model,
@@ -1957,6 +1989,19 @@ fn failed_task_thread_edit_cancel_returns_to_task_page_with_a_retained_form() {
     apply_intent(
         &mut domain,
         &mut model,
+        BoardIntent::FocusFormField(CaptureField::Notes),
+        None,
+        None,
+    )
+    .expect("focus restored notes");
+    assert_eq!(
+        model.edit_buffer(),
+        "",
+        "Cancel discards staged notes draft"
+    );
+    apply_intent(
+        &mut domain,
+        &mut model,
         BoardIntent::FocusFormField(CaptureField::Thread),
         None,
         None,
@@ -1966,6 +2011,21 @@ fn failed_task_thread_edit_cancel_returns_to_task_page_with_a_retained_form() {
         model.edit_buffer(),
         "",
         "Cancel discards staged thread draft"
+    );
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Scope),
+        None,
+        None,
+    )
+    .expect("focus restored scope");
+    assert_eq!(
+        model.form_scope(),
+        Some(&TaskScope::Project {
+            path: "/repos/app".into(),
+        }),
+        "Cancel restores the durable scope"
     );
 }
 

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -1899,6 +1899,14 @@ fn failed_task_thread_edit_cancel_returns_to_task_page_with_a_retained_form() {
     apply_intent(
         &mut domain,
         &mut model,
+        BoardIntent::EditInsertText(" staged title".into()),
+        None,
+        None,
+    )
+    .expect("stage title");
+    apply_intent(
+        &mut domain,
+        &mut model,
         BoardIntent::FocusFormField(CaptureField::Thread),
         None,
         None,

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -1828,6 +1828,62 @@ fn successful_title_save_with_boundary_whitespace_releases_the_task_form_once() 
 }
 
 #[test]
+fn failed_task_page_view_save_holds_a_dirty_form_for_recovery() {
+    let (mut domain, mut model, _) = board_with_two_tasks();
+    let baseline = snapshot_of(&domain);
+    let mut recovery = SaveRecovery::new();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open task form");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsert('!'),
+        None,
+        None,
+    )
+    .expect("dirty title draft");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Notes),
+        None,
+        None,
+    )
+    .expect("move to notes");
+    apply_intent(&mut domain, &mut model, BoardIntent::CancelEdit, None, None)
+        .expect("return to page while retaining title draft");
+    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+
+    let outcome = apply_board_intent_with_save_recovery(
+        &mut domain,
+        &mut model,
+        &mut recovery,
+        BoardSaveContext {
+            baseline,
+            intent: BoardIntent::ConfirmEdit,
+            snapshot: None,
+            host: None,
+        },
+        |_| Err(INJECTED.into()),
+    )
+    .expect("failed view-mode save stays recoverable");
+
+    assert_eq!(outcome, IntentOutcome::None);
+    assert!(recovery.is_pending());
+    assert!(
+        model.board_form_open(),
+        "a failed view-mode form save retains the page form"
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::SaveRecovery);
+}
+
+#[test]
 fn failed_task_thread_edit_cancel_returns_to_task_page_with_a_retained_form() {
     let (mut domain, mut model, id) = board_with_two_tasks();
     let baseline = snapshot_of(&domain);

--- a/tests/fixtures/pre_thread_tasks.json
+++ b/tests/fixtures/pre_thread_tasks.json
@@ -1,0 +1,20 @@
+{
+  "tasks": [
+    {
+      "id": "88888888-8888-4888-8888-888888888888",
+      "revision": "99999999-9999-4999-8999-999999999999",
+      "title": "Written before threads",
+      "notes": "old store, no thread field",
+      "status": "ready",
+      "scope": "global",
+      "provenance": "manual",
+      "history": [
+        { "kind": "created", "at": [1723852800, 0] }
+      ],
+      "soft_deleted": false,
+      "created_at": [1723852800, 0],
+      "updated_at": [1723852800, 0]
+    }
+  ],
+  "undo_stack": []
+}

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -1029,6 +1029,59 @@ fn canceling_thread_edit_keeps_the_task_page_and_resets_the_thread_draft() {
 }
 
 #[test]
+fn editing_an_unthreaded_task_paints_a_labeled_thread_footer_slot() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open task form");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Thread),
+        None,
+        None,
+    )
+    .expect("focus thread");
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|frame| draw_board(frame, &model))
+        .expect("draw thread field");
+    let painted: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect();
+    assert!(
+        painted.contains("app · thread · created"),
+        "the unthreaded edit footer must label the Thread target: {painted}"
+    );
+    assert!(
+        !painted.contains("app · # · created"),
+        "an empty thread must not render as a dangling hash: {painted}"
+    );
+}
+
+#[test]
 fn thread_field_is_inert_while_step_editor_owns_the_footer() {
     let mut domain = DomainState::new();
     domain

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -968,6 +968,67 @@ fn page_thread_field_refuses_invalid_name_without_persisting() {
 }
 
 #[test]
+fn canceling_thread_edit_keeps_the_task_page_and_resets_the_thread_draft() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open task form");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Thread),
+        None,
+        None,
+    )
+    .expect("focus thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsertText("release".into()),
+        None,
+        None,
+    )
+    .expect("type thread");
+
+    apply_intent(&mut domain, &mut model, BoardIntent::CancelEdit, None, None)
+        .expect("cancel thread field");
+    assert!(
+        model.board_form_open(),
+        "field cancel retains the task page"
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Thread),
+        None,
+        None,
+    )
+    .expect("reopen thread field");
+    assert_eq!(
+        model.edit_buffer(),
+        "",
+        "field cancel restores saved thread"
+    );
+}
+
+#[test]
 fn thread_field_is_inert_while_step_editor_owns_the_footer() {
     let mut domain = DomainState::new();
     domain

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -4,10 +4,14 @@ use std::path::PathBuf;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use herdr_tasks::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
-use herdr_tasks::ui::board::{apply_intent, draw_board, BoardInputMode, BoardModel, IntentOutcome};
+use herdr_tasks::ui::board::{
+    apply_intent, board_hit_map, draw_board, BoardInputMode, BoardModel, IntentOutcome,
+};
 use herdr_tasks::ui::capture::CaptureField;
 use herdr_tasks::ui::input::{map_board_form_key, BoardIntent};
+use herdr_tasks::ui::render::QueueHitTarget;
 use ratatui::backend::TestBackend;
+use ratatui::layout::Rect;
 use ratatui::Terminal;
 
 const THIS_REPO: &str = "/repos/app";
@@ -464,6 +468,14 @@ fn task_form_unifies_palette_field_routes_scope_dropdown_and_atomic_save() {
         false,
         KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
     )
+    .expect("Tab moves to thread");
+    apply_intent(&mut domain, &mut model, tab, None, None).expect("focus thread");
+    assert_eq!(model.form_focus(), Some(CaptureField::Thread));
+    let tab = map_board_form_key(
+        model.form_focus().expect("Thread focus"),
+        false,
+        KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
+    )
     .expect("Tab moves to scope");
     apply_intent(&mut domain, &mut model, tab, None, None).expect("focus scope");
     assert_eq!(model.form_focus(), Some(CaptureField::Scope));
@@ -697,4 +709,554 @@ fn task_page_scope_dropdown_sits_above_the_footer_with_short_names() {
         let first_char = row.chars().next().unwrap_or(' ');
         assert_eq!(first_char, ' ', "options are left-indented: {row:?}");
     }
+}
+
+#[test]
+fn page_view_shows_thread_beside_scope() {
+    let mut domain = DomainState::new();
+    domain
+        .create_with_thread(
+            "Threaded page",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            Some("release-2026".into()),
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|frame| draw_board(frame, &model))
+        .expect("draw");
+    let painted: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect();
+    assert!(
+        painted.contains("#release-2026"),
+        "thread missing: {painted}"
+    );
+}
+
+#[test]
+fn task_page_form_tab_cycle_reaches_thread_and_shift_tab_reverses_it() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Unthreaded task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open form");
+
+    let mut focus = CaptureField::Title;
+    for expected in [
+        CaptureField::Notes,
+        CaptureField::Thread,
+        CaptureField::Scope,
+    ] {
+        let tab = map_board_form_key(
+            focus,
+            false,
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
+        )
+        .expect("Tab maps on every editable form field");
+        assert_eq!(tab, BoardIntent::FormFocusNext);
+        apply_intent(&mut domain, &mut model, tab, None, None).expect("Tab focuses the next field");
+        assert_eq!(model.form_focus(), Some(expected));
+        focus = expected;
+    }
+    for expected in [
+        CaptureField::Thread,
+        CaptureField::Notes,
+        CaptureField::Title,
+    ] {
+        let shift_tab = map_board_form_key(
+            focus,
+            false,
+            KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT),
+        )
+        .expect("Shift+Tab maps on every editable form field");
+        assert_eq!(shift_tab, BoardIntent::FormFocusPrev);
+        apply_intent(&mut domain, &mut model, shift_tab, None, None)
+            .expect("Shift+Tab reverses the prior focus move");
+        assert_eq!(model.form_focus(), Some(expected));
+        focus = expected;
+    }
+}
+
+#[test]
+fn page_edit_sets_thread_and_clearing_unthreads() {
+    let mut domain = DomainState::new();
+    let id = domain
+        .create(
+            "Task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open form");
+    for _ in 0..2 {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::FormFocusNext,
+            None,
+            None,
+        )
+        .expect("focus next");
+    }
+    assert_eq!(model.form_focus(), Some(CaptureField::Thread));
+    for character in "Release-2026".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+            None,
+        )
+        .expect("type thread");
+    }
+    assert_eq!(
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::ConfirmEdit,
+            None,
+            None
+        )
+        .expect("save thread"),
+        IntentOutcome::Persist
+    );
+    assert_eq!(
+        domain.get(id).expect("task").thread.as_deref(),
+        Some("release-2026")
+    );
+
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("reopen form");
+    for _ in 0..2 {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::FormFocusNext,
+            None,
+            None,
+        )
+        .expect("focus thread");
+    }
+    for _ in 0.."release-2026".len() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditBackspace,
+            None,
+            None,
+        )
+        .expect("clear thread");
+    }
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmEdit,
+        None,
+        None,
+    )
+    .expect("unthread");
+    assert_eq!(domain.get(id).expect("task").thread, None);
+}
+
+#[test]
+fn page_thread_field_refuses_invalid_name_without_persisting() {
+    let mut domain = DomainState::new();
+    let id = domain
+        .create(
+            "Task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open");
+    for _ in 0..2 {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::FormFocusNext,
+            None,
+            None,
+        )
+        .expect("focus");
+    }
+    for character in "bad_name".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+            None,
+        )
+        .expect("type");
+    }
+    assert_eq!(
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::ConfirmEdit,
+            None,
+            None
+        )
+        .expect("refusal"),
+        IntentOutcome::None
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::EditThread);
+    assert_eq!(domain.get(id).expect("task").thread, None);
+}
+
+#[test]
+fn thread_field_is_inert_while_step_editor_owns_the_footer() {
+    let mut domain = DomainState::new();
+    domain
+        .create_with_thread(
+            "Task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            Some("release".into()),
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("page");
+    assert!(
+        board_hit_map(Rect::new(0, 0, 80, 24), &model)
+            .regions
+            .iter()
+            .any(|hit| hit.target == QueueHitTarget::FormThread),
+        "the threaded page exposes its footer hit before a step editor opens"
+    );
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginAddStep,
+        None,
+        None,
+    )
+    .expect("item editor");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Thread),
+        None,
+        None,
+    )
+    .expect("inert focus");
+    assert_eq!(model.input_mode(), BoardInputMode::EditStep);
+    let hits = board_hit_map(Rect::new(0, 0, 80, 24), &model);
+    assert!(
+        !hits
+            .regions
+            .iter()
+            .any(|hit| hit.target == QueueHitTarget::FormThread),
+        "a step editor owns the footer, so thread has no hit target: {hits:?}"
+    );
+}
+
+#[test]
+fn thread_refusal_paints_inline_and_clears_without_status_leak() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open");
+    for _ in 0..2 {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::FormFocusNext,
+            None,
+            None,
+        )
+        .expect("focus");
+    }
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsert('_'),
+        None,
+        None,
+    )
+    .expect("type");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmEdit,
+        None,
+        None,
+    )
+    .expect("refuse");
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|frame| draw_board(frame, &model))
+        .expect("draw refusal");
+    let painted: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect();
+    assert!(
+        painted.contains("invalid thread name"),
+        "missing inline refusal: {painted}"
+    );
+    assert_eq!(
+        model.message(),
+        None,
+        "thread refusal must not use status message"
+    );
+    apply_intent(&mut domain, &mut model, BoardIntent::CancelEdit, None, None).expect("close");
+    assert_eq!(model.message(), None);
+}
+
+#[test]
+fn task_page_footer_hits_use_display_columns_and_stay_within_the_painted_row() {
+    let mut domain = DomainState::new();
+    domain
+        .create_with_thread(
+            "Threaded task",
+            None,
+            project("/repos/プロジェクト"),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            Some("a2345678901234567890123456789012".into()),
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+
+    let width = 40;
+    let hits = board_hit_map(Rect::new(0, 0, width, 10), &model);
+    let scope = hits
+        .regions
+        .iter()
+        .find(|hit| hit.target == QueueHitTarget::FormScope)
+        .expect("scope hit");
+    let thread = hits
+        .regions
+        .iter()
+        .find(|hit| hit.target == QueueHitTarget::FormThread)
+        .expect("thread hit");
+    assert_eq!(scope.area.width, 14, "two-space inset plus six wide glyphs");
+    assert_eq!(thread.area.x, 14, "thread starts after the painted scope");
+    assert!(
+        thread.area.right() <= width,
+        "thread hit must not extend beyond the clipped footer: {thread:?}"
+    );
+}
+
+#[test]
+fn long_invalid_thread_refusal_remains_visible_at_40x10() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Thread),
+        None,
+        None,
+    )
+    .expect("focus thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsertText("invalid_thread_name_here".into()),
+        None,
+        None,
+    )
+    .expect("type invalid thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmEdit,
+        None,
+        None,
+    )
+    .expect("refuse");
+
+    let backend = TestBackend::new(40, 10);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|frame| draw_board(frame, &model))
+        .expect("draw compact refusal");
+    let painted: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect();
+    assert!(
+        painted.contains("invalid thread name"),
+        "thread refusal vanished at 40x10: {painted}"
+    );
+}
+
+#[test]
+fn page_footer_thread_edit_operable_at_40x10() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open");
+    for _ in 0..2 {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::FormFocusNext,
+            None,
+            None,
+        )
+        .expect("focus");
+    }
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsertText("tiny".into()),
+        None,
+        None,
+    )
+    .expect("type");
+    let backend = TestBackend::new(40, 10);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|frame| draw_board(frame, &model))
+        .expect("draw compact");
+    let painted: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect();
+    assert!(painted.contains("tiny"), "thread input vanished: {painted}");
 }

--- a/tests/queue_board_model.rs
+++ b/tests/queue_board_model.rs
@@ -51,6 +51,26 @@ fn project(path: &str) -> TaskScope {
     }
 }
 
+fn threaded_task(
+    id: u128,
+    title: &str,
+    status: HumanStatus,
+    scope: TaskScope,
+    updated_secs: u64,
+    thread: &str,
+) -> Task {
+    let mut task = task(id, title, status, scope, updated_secs);
+    task.thread = Some(thread.to_string());
+    task
+}
+
+fn on_deck(view: &herdr_tasks::ui::queue::QueueView) -> &herdr_tasks::ui::queue::QueueSection {
+    view.sections
+        .iter()
+        .find(|section| section.kind == SectionKind::OnDeck)
+        .expect("ON DECK section")
+}
+
 fn temp_dir(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -326,6 +346,357 @@ fn sync_from_domain_reanchors_by_id() {
         "when the pinned id leaves the visible set, reanchor lands on a survivor"
     );
     assert!(!model.visible_ids().contains(&id_todo));
+}
+
+#[test]
+fn deck_group_emits_thread_blocks_with_open_counts_iff_open_tasks() {
+    let tasks = vec![
+        threaded_task(
+            1,
+            "open",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            20,
+            "Release",
+        ),
+        threaded_task(
+            2,
+            "done",
+            HumanStatus::Done,
+            project(THIS_REPO),
+            30,
+            "release",
+        ),
+        threaded_task(
+            3,
+            "doing",
+            HumanStatus::Started,
+            project(THIS_REPO),
+            40,
+            "release",
+        ),
+    ];
+
+    let view = query(
+        &tasks,
+        Some(Path::new(THIS_REPO)),
+        DeckScope::Project(Path::new(THIS_REPO)),
+        true,
+    );
+    let deck = on_deck(&view);
+
+    assert_eq!(deck.thread_blocks.len(), 1);
+    assert_eq!(deck.thread_blocks[0].name, "release");
+    assert_eq!(deck.thread_blocks[0].open_count, 1);
+    assert_eq!(deck.thread_blocks[0].task_ids, vec![Uuid::from_u128(1)]);
+}
+
+#[test]
+fn unthreaded_tasks_list_after_thread_blocks() {
+    let tasks = vec![
+        task(
+            1,
+            "loose newest",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            30,
+        ),
+        threaded_task(
+            2,
+            "threaded",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            20,
+            "release",
+        ),
+        task(
+            3,
+            "loose older",
+            HumanStatus::Blocked,
+            project(THIS_REPO),
+            10,
+        ),
+    ];
+
+    let view = query(
+        &tasks,
+        Some(Path::new(THIS_REPO)),
+        DeckScope::Project(Path::new(THIS_REPO)),
+        false,
+    );
+    let deck = on_deck(&view);
+
+    assert_eq!(deck.thread_blocks[0].task_ids, vec![Uuid::from_u128(2)]);
+    assert_eq!(
+        deck.loose_task_ids,
+        vec![Uuid::from_u128(1), Uuid::from_u128(3)]
+    );
+    assert_eq!(
+        deck.task_ids,
+        vec![Uuid::from_u128(2), Uuid::from_u128(1), Uuid::from_u128(3)]
+    );
+}
+
+#[test]
+fn thread_blocks_order_by_recency_and_tasks_within_by_updated_desc() {
+    let tasks = vec![
+        threaded_task(
+            1,
+            "alpha older",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            20,
+            "alpha",
+        ),
+        threaded_task(
+            2,
+            "alpha newer",
+            HumanStatus::Blocked,
+            project(THIS_REPO),
+            50,
+            "alpha",
+        ),
+        threaded_task(
+            3,
+            "beta",
+            HumanStatus::Review,
+            project(THIS_REPO),
+            40,
+            "beta",
+        ),
+    ];
+
+    let view = query(
+        &tasks,
+        Some(Path::new(THIS_REPO)),
+        DeckScope::Project(Path::new(THIS_REPO)),
+        false,
+    );
+    let deck = on_deck(&view);
+
+    assert_eq!(
+        deck.thread_blocks
+            .iter()
+            .map(|block| block.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha", "beta"]
+    );
+    assert_eq!(
+        deck.thread_blocks[0].task_ids,
+        vec![Uuid::from_u128(2), Uuid::from_u128(1)]
+    );
+}
+
+#[test]
+fn flat_task_ids_equal_block_then_loose_concatenation() {
+    let tasks = vec![
+        threaded_task(
+            1,
+            "alpha",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            10,
+            "alpha",
+        ),
+        threaded_task(
+            2,
+            "beta",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            30,
+            "beta",
+        ),
+        task(3, "loose", HumanStatus::Ready, project(THIS_REPO), 40),
+    ];
+
+    let view = query(
+        &tasks,
+        Some(Path::new(THIS_REPO)),
+        DeckScope::Project(Path::new(THIS_REPO)),
+        false,
+    );
+    let deck = on_deck(&view);
+    let expected: Vec<_> = deck
+        .thread_blocks
+        .iter()
+        .flat_map(|block| block.task_ids.iter().copied())
+        .chain(deck.loose_task_ids.iter().copied())
+        .collect();
+
+    assert_eq!(deck.task_ids, expected);
+}
+
+#[test]
+fn same_thread_name_in_two_scopes_forms_independent_groups() {
+    let tasks = vec![
+        threaded_task(
+            1,
+            "project",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            20,
+            "release",
+        ),
+        threaded_task(
+            2,
+            "global",
+            HumanStatus::Ready,
+            TaskScope::Global,
+            30,
+            "release",
+        ),
+    ];
+
+    let project_view = query(
+        &tasks,
+        Some(Path::new(THIS_REPO)),
+        DeckScope::Project(Path::new(THIS_REPO)),
+        false,
+    );
+    let global_view = query(&tasks, None, DeckScope::Global, false);
+    let project_deck = on_deck(&project_view);
+    let global_deck = on_deck(&global_view);
+
+    assert_eq!(
+        project_deck.thread_blocks[0].task_ids,
+        vec![Uuid::from_u128(1)]
+    );
+    assert_eq!(
+        global_deck.thread_blocks[0].task_ids,
+        vec![Uuid::from_u128(2)]
+    );
+}
+
+#[test]
+fn all_scope_in_motion_and_drawer_emit_no_blocks() {
+    let tasks = vec![
+        threaded_task(
+            1,
+            "deck",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            10,
+            "release",
+        ),
+        threaded_task(
+            2,
+            "motion",
+            HumanStatus::Started,
+            project(THIS_REPO),
+            20,
+            "release",
+        ),
+        threaded_task(
+            3,
+            "done",
+            HumanStatus::Done,
+            project(THIS_REPO),
+            30,
+            "release",
+        ),
+    ];
+
+    let all = query(&tasks, Some(Path::new(THIS_REPO)), DeckScope::All, true);
+    assert!(all
+        .sections
+        .iter()
+        .all(|section| section.thread_blocks.is_empty() && section.loose_task_ids.is_empty()));
+
+    let scoped = query(
+        &tasks,
+        Some(Path::new(THIS_REPO)),
+        DeckScope::Project(Path::new(THIS_REPO)),
+        true,
+    );
+    assert!(scoped
+        .sections
+        .iter()
+        .filter(|section| section.kind != SectionKind::OnDeck)
+        .all(|section| section.thread_blocks.is_empty() && section.loose_task_ids.is_empty()));
+}
+
+#[test]
+fn selection_stays_on_task_id_across_thread_block_reorder() {
+    let mut domain = DomainState::new();
+    let alpha = domain
+        .create_with_thread(
+            "alpha",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            Some("alpha".into()),
+        )
+        .unwrap();
+    let beta = domain
+        .create_with_thread(
+            "beta",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            Some("beta".into()),
+        )
+        .unwrap();
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
+
+    let before = model.queue_view();
+    let before_deck = on_deck(&before);
+    assert_eq!(before_deck.thread_blocks.len(), 2);
+    assert_eq!(
+        before_deck
+            .thread_blocks
+            .iter()
+            .map(|block| block.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["beta", "alpha"]
+    );
+    assert_eq!(before_deck.task_ids, vec![beta, alpha]);
+
+    let beta_index = model
+        .visible_ids()
+        .iter()
+        .position(|id| *id == beta)
+        .expect("beta is visible");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectIndex(beta_index),
+        None,
+        None,
+    )
+    .unwrap();
+
+    domain
+        .edit(
+            alpha,
+            "alpha changed",
+            None,
+            project(THIS_REPO),
+            Some("alpha".into()),
+        )
+        .unwrap();
+    model.sync_from_domain(&domain);
+
+    let after = model.queue_view();
+    let after_deck = on_deck(&after);
+    assert_eq!(after_deck.thread_blocks.len(), 2);
+    assert_eq!(
+        after_deck
+            .thread_blocks
+            .iter()
+            .map(|block| block.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha", "beta"]
+    );
+    assert_eq!(after_deck.task_ids, vec![alpha, beta]);
+    assert_eq!(model.selected_id(), Some(beta));
+    assert_eq!(model.visible_ids(), after_deck.task_ids);
+    assert_eq!(model.selected_index(), Some(1));
+    assert_eq!(after_deck.task_ids[model.selected_index().unwrap()], beta);
 }
 
 /// Two fresh models from the same store share no UI state and write no UI-state files.

--- a/tests/queue_board_model.rs
+++ b/tests/queue_board_model.rs
@@ -27,6 +27,7 @@ fn task(id: u128, title: &str, status: HumanStatus, scope: TaskScope, updated_se
         merge_base_revision: None,
         title: title.into(),
         notes: None,
+        thread: None,
         status,
         scope,
         capsule: None,

--- a/tests/queue_board_model.rs
+++ b/tests/queue_board_model.rs
@@ -8,9 +8,11 @@ use herdr_tasks::domain::{
     DomainState, HumanStatus, ProvenanceOrigin, Task, TaskEvent, TaskEventKind, TaskScope,
 };
 use herdr_tasks::store::TaskStore;
-use herdr_tasks::ui::board::{apply_intent, BoardModel, ProjectScopeOption};
+use herdr_tasks::ui::board::{apply_intent, draw_board, BoardModel, ProjectScopeOption};
 use herdr_tasks::ui::input::BoardIntent;
 use herdr_tasks::ui::queue::{query, DeckScope, SectionKind};
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
 use uuid::Uuid;
 
 const THIS_REPO: &str = "/repos/app";
@@ -700,6 +702,89 @@ fn selection_stays_on_task_id_across_thread_block_reorder() {
 }
 
 /// Two fresh models from the same store share no UI state and write no UI-state files.
+fn board_rows(model: &BoardModel, width: u16, height: u16) -> Vec<String> {
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("test terminal");
+    terminal
+        .draw(|frame| draw_board(frame, model))
+        .expect("draw board");
+    let buffer = terminal.backend().buffer();
+    (0..height)
+        .map(|y| {
+            (0..width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect()
+}
+
+#[test]
+fn arrow_navigation_crosses_painted_header_task_to_task() {
+    let mut domain = DomainState::new();
+    domain
+        .create_with_thread(
+            "alpha task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            Some("alpha".to_string()),
+        )
+        .expect("create alpha");
+    domain
+        .create_with_thread(
+            "beta task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            Some("beta".to_string()),
+        )
+        .expect("create beta");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
+    let ids = model.visible_ids();
+    assert_eq!(ids.len(), 2, "two threaded tasks are visible");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectIndex(0),
+        None,
+        None,
+    )
+    .expect("select first task");
+
+    let rows = board_rows(&model, 80, 24);
+    let first_title = domain.get(ids[0]).expect("first task").title.clone();
+    let second = domain.get(ids[1]).expect("second task");
+    let first_y = rows
+        .iter()
+        .position(|row| row.contains(&first_title))
+        .expect("first task paints");
+    let header_y = rows
+        .iter()
+        .position(|row| row.contains(&format!("#{}", second.thread.as_deref().unwrap())))
+        .expect("second block header paints");
+    let second_y = rows
+        .iter()
+        .position(|row| row.contains(&second.title))
+        .expect("second task paints");
+    assert!(
+        first_y < header_y && header_y < second_y,
+        "a painted header must physically sit between the tasks:\n{}",
+        rows.join("\n")
+    );
+
+    apply_intent(&mut domain, &mut model, BoardIntent::SelectNext, None, None)
+        .expect("arrow navigation moves to next task");
+    assert_eq!(
+        model.selected_id(),
+        Some(ids[1]),
+        "selection must skip decorative headers and land on the next task"
+    );
+}
+
 #[test]
 fn two_fresh_models_from_same_store_share_no_ui_state_and_no_ui_writes_under_state_or_config_dirs()
 {

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -845,6 +845,49 @@ fn click_and_wheel_match_keyboard_effects_for_each_control() {
 /// this rewrite (its `CaptureLayout`/`map_capture_mouse` route is separate from the board's
 /// hit-map, per the task's implementation boundary).
 #[test]
+fn empty_thread_target_follows_a_scope_name_containing_the_thread_label() {
+    let scope_path = "/repos/foo · thread";
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Task",
+            None,
+            project(scope_path),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(scope_path)));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("open task form");
+
+    let hits = board_hit_map(STANDARD, &model);
+    let scope_hit = hits
+        .regions
+        .iter()
+        .find(|hit| hit.target == QueueHitTarget::FormScope)
+        .expect("scope hit");
+    let thread_hit = hits
+        .regions
+        .iter()
+        .find(|hit| hit.target == QueueHitTarget::FormThread)
+        .expect("empty thread target");
+    let expected_scope_width = 2 + "foo · thread".chars().count() as u16;
+    assert_eq!(
+        scope_hit.area.width, expected_scope_width,
+        "the entire project basename remains the scope target"
+    );
+    assert_eq!(thread_hit.area.x, expected_scope_width);
+}
+
+#[test]
 fn capture_popup_mouse_paths_unchanged() {
     let layout = capture_layout(Rect::new(0, 0, 80, 16));
     assert!(

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1300,6 +1300,40 @@ fn non_left_clicks_over_a_live_control_are_ignored() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn header_line_registers_no_hit_target() {
+    let mut domain = DomainState::new();
+    domain
+        .create_with_thread(
+            "threaded row",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+            Some("release".to_string()),
+        )
+        .expect("create threaded task");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
+    let rows = page_rows(&model);
+    let header_y = rows
+        .iter()
+        .position(|row| row.contains("#release"))
+        .expect("thread header paints");
+    let hits = board_hit_map(STANDARD, &model);
+
+    assert!(
+        hits.regions.iter().all(|hit| hit.area.y != header_y as u16),
+        "decorative thread header must register no hit target: {hits:?}"
+    );
+    assert_eq!(
+        map_board_mouse(&model, &hits, left_click(0, header_y as u16)),
+        None,
+        "clicking the decorative header must be inert"
+    );
+}
+
+#[test]
 fn a_row_click_selects_and_peeks_and_a_second_click_opens_the_task_page() {
     let (mut domain, mut model) = deck_of(3);
     let visible = model.visible_ids();

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -19,7 +19,10 @@ use herdr_tasks::ui::board::{
     BoardInputMode, BoardModel,
 };
 use herdr_tasks::ui::capture::CaptureField;
-use herdr_tasks::ui::input::{map_board_form_key, map_key, BoardIntent, PRIMARY_CAPTURE_ACTIONS};
+use herdr_tasks::ui::input::{
+    map_board_form_key, map_capture_key_state, map_capture_paste_state, map_key, BoardIntent,
+    CaptureIntent, PRIMARY_CAPTURE_ACTIONS,
+};
 use herdr_tasks::ui::mouse::{
     capture_layout, capture_mouse_paths_complete, left_click, map_board_mouse, map_capture_mouse,
     primary_capture_action_sample_mouse,
@@ -442,6 +445,7 @@ fn task_form_mouse_fields_dropdown_and_verbs_match_keyboard_while_scrolled() {
         (QueueHitTarget::FormTitle, CaptureField::Title),
         (QueueHitTarget::FormNotes(0), CaptureField::Notes),
         (QueueHitTarget::FormNotes(1), CaptureField::Notes),
+        (QueueHitTarget::FormThread, CaptureField::Thread),
     ] {
         let hit = hits
             .regions
@@ -858,6 +862,34 @@ fn capture_popup_mouse_paths_unchanged() {
     // The narrow capture width still keeps every control clickable.
     let narrow = capture_layout(Rect::new(0, 0, 40, 16));
     assert!(capture_mouse_paths_complete(&narrow));
+}
+
+#[test]
+fn capture_thread_row_click_and_input_paths_focus_and_edit_the_thread_field() {
+    let layout = capture_layout(Rect::new(0, 0, 80, 16));
+    assert_eq!(
+        map_capture_mouse(
+            &layout,
+            left_click(layout.thread_area.x.saturating_add(1), layout.thread_area.y),
+        ),
+        Some(CaptureIntent::FocusField(CaptureField::Thread)),
+        "the visible capture Thread row must take mouse focus"
+    );
+    assert_eq!(
+        map_capture_key_state(
+            CaptureField::Thread,
+            false,
+            false,
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+        ),
+        Some(CaptureIntent::Insert('r')),
+        "a focused Thread field accepts keyboard input"
+    );
+    assert_eq!(
+        map_capture_paste_state(CaptureField::Thread, false, "release"),
+        Some(CaptureIntent::InsertText("release".into())),
+        "a focused Thread field accepts paste"
+    );
 }
 
 /// C1: on a deck long enough for the palette's command panel to actually

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -2260,6 +2260,43 @@ fn threaded_task_rows_indent_under_headers_while_unthreaded_rows_stay_flush() {
 }
 
 #[test]
+fn thread_blocks_leave_a_blank_row_before_loose_tasks() {
+    let mut tasks = fixture_tasks();
+    tasks[2].thread = Some("release".to_string());
+    tasks[3].thread = Some("release".to_string());
+    tasks.push(task(
+        12,
+        "Loose project task",
+        HumanStatus::Ready,
+        project("/repos/herdr-tasks"),
+        30,
+    ));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
+    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+
+    let rows = board_rows(&model, 80, 24);
+    let last_threaded_task = rows
+        .iter()
+        .position(|row| row.contains("Cut rust-toolchain pin into CI docs"))
+        .expect("last threaded task paints");
+    let loose_task = rows
+        .iter()
+        .position(|row| row.contains("Loose project task"))
+        .expect("loose task paints");
+
+    assert!(
+        rows[last_threaded_task + 1].trim().is_empty(),
+        "a thread block leaves a spacer before following content:\n{}",
+        rows.join("\n")
+    );
+    assert!(
+        last_threaded_task + 1 < loose_task,
+        "the loose task follows the thread spacer:\n{}",
+        rows.join("\n")
+    );
+}
+
+#[test]
 fn header_shows_name_and_open_count() {
     let mut tasks = fixture_tasks();
     tasks[2].thread = Some("release".to_string());
@@ -2377,31 +2414,6 @@ fn board_with_headers_paints_within_40x10_and_all_tasks_reachable() {
             rows.iter().all(|row| row_display_width(row) == 40),
             "thread headers and rows must stay within 40 columns"
         );
-
-        if index == 3 {
-            let positions: Vec<usize> = [
-                "#beta 2",
-                "beta second",
-                "beta first",
-                "#alpha 2",
-                "alpha second",
-                "alpha first",
-            ]
-            .into_iter()
-            .map(|line| {
-                rows.iter()
-                    .position(|row| row.contains(line))
-                    .unwrap_or_else(|| {
-                        panic!("{line:?} must occupy the 40x10 frame:\n{}", rows.join("\n"))
-                    })
-            })
-            .collect();
-            assert!(
-                positions.windows(2).all(|pair| pair[0] < pair[1]),
-                "two headers and four tasks must occupy distinct, ordered frame rows:\n{}",
-                rows.join("\n")
-            );
-        }
     }
 }
 

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -880,6 +880,8 @@ fn task_page_renders_header_notes_and_meta_as_a_full_takeover_in_both_tiers() {
         step_marked: None,
         step_editor: None,
         meta: "herdr-tasks \u{b7} created 1h ago \u{b7} updated 1h ago".to_string(),
+        meta_scope_width: 11,
+        thread_slot_width: None,
         focus: None,
         scope_dropdown: None,
     };

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -44,6 +44,7 @@ fn task(id: u128, title: &str, status: HumanStatus, scope: TaskScope, secs_ago: 
         merge_base_revision: None,
         title: title.to_string(),
         notes: None,
+        thread: None,
         status,
         scope,
         capsule: None,

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -2178,6 +2178,224 @@ fn footer_lists_the_step_add_verb() {
     );
 }
 
+/// T-4: scoped ON DECK thread blocks paint one dim decorative header before their task rows.
+#[test]
+fn scoped_board_paints_thread_header_above_its_tasks() {
+    let mut tasks = fixture_tasks();
+    tasks[2].thread = Some("release".to_string());
+    tasks[3].thread = Some("release".to_string());
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
+    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+
+    let rows = board_rows(&model, 80, 24);
+    let header = rows
+        .iter()
+        .position(|row| row.contains("#release"))
+        .expect("scoped thread block must paint its header");
+    let first_task = rows
+        .iter()
+        .position(|row| row.contains("Prototype the queue-style board UI"))
+        .expect("threaded task must paint");
+    assert!(
+        header < first_task,
+        "the thread header must precede its task rows:\n{}",
+        rows.join("\n")
+    );
+}
+
+#[test]
+fn header_shows_name_and_open_count() {
+    let mut tasks = fixture_tasks();
+    tasks[2].thread = Some("release".to_string());
+    tasks[3].thread = Some("release".to_string());
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
+    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+    let deck_index = model
+        .visible_ids()
+        .iter()
+        .position(|id| *id == Uuid::from_u128(10))
+        .expect("threaded task is visible");
+    let mut domain = DomainState::new();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectIndex(deck_index),
+        None,
+        None,
+    )
+    .expect("select threaded task");
+
+    let standard = board_rows(&model, 80, 24).join("\n");
+    assert!(
+        standard.contains("#release") && standard.contains("2 open"),
+        "standard thread header must name its block and its open count:\n{standard}"
+    );
+    let compact = board_rows(&model, 40, 10).join("\n");
+    assert!(
+        compact.contains("#release 2") && !compact.contains("2 open"),
+        "compact thread header must retain name/count in its compressed form:\n{compact}"
+    );
+}
+
+#[test]
+fn board_with_headers_paints_within_40x10_and_all_tasks_reachable() {
+    let mut tasks = vec![
+        task(
+            100,
+            "alpha first",
+            HumanStatus::Ready,
+            project("/repos/herdr-tasks"),
+            40,
+        ),
+        task(
+            101,
+            "alpha second",
+            HumanStatus::Ready,
+            project("/repos/herdr-tasks"),
+            30,
+        ),
+        task(
+            102,
+            "beta first",
+            HumanStatus::Ready,
+            project("/repos/herdr-tasks"),
+            20,
+        ),
+        task(
+            103,
+            "beta second",
+            HumanStatus::Ready,
+            project("/repos/herdr-tasks"),
+            10,
+        ),
+    ];
+    tasks[0].thread = Some("alpha".to_string());
+    tasks[1].thread = Some("alpha".to_string());
+    tasks[2].thread = Some("beta".to_string());
+    tasks[3].thread = Some("beta".to_string());
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
+    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+    let mut domain = DomainState::new();
+    let ids = model.visible_ids();
+    assert_eq!(ids.len(), 4, "fixture must expose every open task");
+    assert_eq!(
+        model.selected_id(),
+        Some(ids[0]),
+        "the first visible task must seed arrow traversal"
+    );
+
+    for (index, id) in ids.into_iter().enumerate() {
+        if index > 0 {
+            apply_intent(&mut domain, &mut model, BoardIntent::SelectNext, None, None)
+                .expect("arrow to next task");
+        }
+        assert_eq!(
+            model.selected_id(),
+            Some(id),
+            "arrow traversal must land on every open task"
+        );
+        let rows = board_rows(&model, 40, 10);
+        let task = model
+            .visible_tasks()
+            .into_iter()
+            .find(|task| task.id == id)
+            .expect("selected task stays visible");
+        let header = format!(
+            "#{} 2",
+            task.thread.as_deref().expect("threaded fixture task")
+        );
+        let header_y = rows
+            .iter()
+            .position(|row| row.contains(&header))
+            .expect("selected task's header must occupy a painted row");
+        let task_y = rows
+            .iter()
+            .position(|row| row.contains(&task.title))
+            .expect("selected task must be reachable at 40x10");
+        assert!(
+            header_y < task_y,
+            "the header must consume its own row before the selected task:\n{}",
+            rows.join("\n")
+        );
+        assert!(
+            rows.iter().all(|row| row_display_width(row) == 40),
+            "thread headers and rows must stay within 40 columns"
+        );
+
+        if index == 3 {
+            let positions: Vec<usize> = [
+                "#beta 2",
+                "beta second",
+                "beta first",
+                "#alpha 2",
+                "alpha second",
+                "alpha first",
+            ]
+            .into_iter()
+            .map(|line| {
+                rows.iter()
+                    .position(|row| row.contains(line))
+                    .unwrap_or_else(|| {
+                        panic!("{line:?} must occupy the 40x10 frame:\n{}", rows.join("\n"))
+                    })
+            })
+            .collect();
+            assert!(
+                positions.windows(2).all(|pair| pair[0] < pair[1]),
+                "two headers and four tasks must occupy distinct, ordered frame rows:\n{}",
+                rows.join("\n")
+            );
+        }
+    }
+}
+
+#[test]
+fn peek_shows_thread_line_only_for_threaded_task() {
+    let mut threaded = task(200, "threaded", HumanStatus::Ready, TaskScope::Global, 1);
+    threaded.thread = Some("release".to_string());
+    let mut threaded_model = BoardModel::from_tasks(vec![threaded], None);
+    let mut domain = DomainState::new();
+    apply_intent(
+        &mut domain,
+        &mut threaded_model,
+        BoardIntent::PeekDetail,
+        None,
+        None,
+    )
+    .expect("open threaded peek");
+    assert!(
+        board_rows(&threaded_model, 80, 24)
+            .join("\n")
+            .contains("thread #release"),
+        "threaded peek must name its thread"
+    );
+
+    let mut unthreaded_model = BoardModel::from_tasks(
+        vec![task(
+            201,
+            "unthreaded",
+            HumanStatus::Ready,
+            TaskScope::Global,
+            1,
+        )],
+        None,
+    );
+    apply_intent(
+        &mut domain,
+        &mut unthreaded_model,
+        BoardIntent::PeekDetail,
+        None,
+        None,
+    )
+    .expect("open unthreaded peek");
+    assert!(
+        !board_rows(&unthreaded_model, 80, 24)
+            .join("\n")
+            .contains("thread #"),
+        "unthreaded peek must not invent a thread line"
+    );
+}
+
 #[test]
 fn all_golden_frames_pass_no_color_sgr_scan() {
     let dir = golden_fixtures_dir();

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -2297,6 +2297,38 @@ fn thread_blocks_leave_a_blank_row_before_loose_tasks() {
 }
 
 #[test]
+fn every_thread_block_leaves_a_spacer_before_following_content() {
+    let mut tasks = fixture_tasks();
+    tasks[2].thread = Some("alpha".to_string());
+    tasks[3].thread = Some("beta".to_string());
+    tasks.push(task(
+        12,
+        "Loose project task",
+        HumanStatus::Ready,
+        project("/repos/herdr-tasks"),
+        30,
+    ));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
+    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+
+    let rows = board_rows(&model, 80, 24);
+    for title in [
+        "Prototype the queue-style board UI",
+        "Cut rust-toolchain pin into CI docs",
+    ] {
+        let task = rows
+            .iter()
+            .position(|row| row.contains(title))
+            .unwrap_or_else(|| panic!("threaded task {title:?} paints"));
+        assert!(
+            rows[task + 1].trim().is_empty(),
+            "each thread block leaves a spacer after {title:?}:\n{}",
+            rows.join("\n")
+        );
+    }
+}
+
+#[test]
 fn header_shows_name_and_open_count() {
     let mut tasks = fixture_tasks();
     tasks[2].thread = Some("release".to_string());

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -2213,6 +2213,53 @@ fn scoped_board_paints_thread_header_above_its_tasks() {
 }
 
 #[test]
+fn threaded_task_rows_indent_under_headers_while_unthreaded_rows_stay_flush() {
+    let mut tasks = fixture_tasks();
+    tasks[2].thread = Some("release".to_string());
+    tasks[3].thread = Some("release".to_string());
+    tasks.push(task(
+        12,
+        "Loose project task",
+        HumanStatus::Ready,
+        project("/repos/herdr-tasks"),
+        30,
+    ));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
+    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+
+    let rows = board_rows(&model, 80, 24);
+    let leading_spaces = |row: &str| {
+        row.chars()
+            .take_while(|character| *character == ' ')
+            .count()
+    };
+    let header = rows
+        .iter()
+        .find(|row| row.contains("#release"))
+        .expect("thread header paints");
+    let threaded = rows
+        .iter()
+        .find(|row| row.contains("Prototype the queue-style board UI"))
+        .expect("threaded task paints");
+    let loose = rows
+        .iter()
+        .find(|row| row.contains("Loose project task"))
+        .expect("unthreaded task paints");
+
+    assert_eq!(
+        leading_spaces(header),
+        leading_spaces(loose),
+        "headers and loose rows keep their existing left edge"
+    );
+    assert_eq!(
+        leading_spaces(threaded),
+        leading_spaces(loose) + 2,
+        "threaded rows indent beneath their header:\n{}",
+        rows.join("\n")
+    );
+}
+
+#[test]
 fn header_shows_name_and_open_count() {
     let mut tasks = fixture_tasks();
     tasks[2].thread = Some("release".to_string());

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -1295,7 +1295,16 @@ fn shift_tab_from_scope_resets_notes_stream_origin_and_aligns_caret() {
     apply_intent(
         &mut domain,
         &mut model,
-        shift_tab.expect("Shift+Tab intent"),
+        shift_tab.clone().expect("Shift+Tab intent"),
+        None,
+        None,
+    )
+    .expect("Shift+Tab into Thread");
+    assert_eq!(model.input_mode(), BoardInputMode::EditThread);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        shift_tab.expect("second Shift+Tab intent"),
         None,
         None,
     )

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -1431,7 +1431,7 @@ fn deleting_from_the_page_closes_it_and_undo_restores() {
 }
 
 #[test]
-fn tab_cycles_view_mode_through_title_notes_and_scope_edits() {
+fn tab_cycles_view_mode_through_title_notes_thread_and_scope_edits() {
     let (mut domain, mut model, _id) = board_with_noted_task();
     apply_intent(
         &mut domain,
@@ -1448,6 +1448,8 @@ fn tab_cycles_view_mode_through_title_notes_and_scope_edits() {
     assert_eq!(model.input_mode(), BoardInputMode::EditTitle);
     apply_intent(&mut domain, &mut model, tab.clone(), None, None).expect("focus notes");
     assert_eq!(model.input_mode(), BoardInputMode::EditNotes);
+    apply_intent(&mut domain, &mut model, tab.clone(), None, None).expect("focus thread");
+    assert_eq!(model.input_mode(), BoardInputMode::EditThread);
     apply_intent(&mut domain, &mut model, tab, None, None).expect("focus scope");
     assert_eq!(model.input_mode(), BoardInputMode::EditScope);
 }
@@ -3133,7 +3135,7 @@ fn t_token_capture_threads_while_item_text_stays_literal() {
     apply_intent(
         &mut domain,
         &mut model,
-        BoardIntent::BeginAddChecklistItem,
+        BoardIntent::BeginAddStep,
         None,
         None,
     )
@@ -3161,7 +3163,7 @@ fn t_token_capture_threads_while_item_text_stays_literal() {
     );
     model.sync_from_domain(&domain);
     assert_eq!(
-        domain.get(task_id).expect("capture").checklist[0].text,
+        domain.get(task_id).expect("capture").steps[0].text,
         "literal !t release-2026 #word"
     );
     assert_eq!(

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use herdr_tasks::context::InvocationSnapshot;
 use herdr_tasks::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskEventKind, TaskScope};
 use herdr_tasks::ui::board::{
     apply_intent, board_intent_may_persist, board_verb_items, draw_board, resolve_board_command,
@@ -3070,4 +3071,101 @@ fn delete_mark_shows_press_again_footer_message() {
         "the hint goes with the mark:\n{removed}"
     );
     assert_eq!(model.message(), None);
+}
+
+#[test]
+fn t_token_capture_threads_while_item_text_stays_literal() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    let snapshot = InvocationSnapshot {
+        default_scope: project(THIS_REPO),
+        this_repo: Some(PathBuf::from(THIS_REPO)),
+        title_prefill: None,
+        provenance: ProvenanceOrigin::Capture,
+        capsule: None,
+        agent_meta: None,
+    };
+
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenCapture,
+        Some(&snapshot),
+        None,
+    )
+    .expect("open quick add");
+    for character in "capture !t Release-2026".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::QuickAddInsert(character),
+            None,
+            None,
+        )
+        .expect("type capture");
+    }
+    assert_eq!(
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::QuickAddSave,
+            None,
+            None,
+        )
+        .expect("save quick add"),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+    let task_id = domain.tasks()[0].id;
+    assert_eq!(
+        domain.get(task_id).expect("capture").thread.as_deref(),
+        Some("release-2026")
+    );
+
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open task page");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginAddChecklistItem,
+        None,
+        None,
+    )
+    .expect("open item editor");
+    for character in "literal !t release-2026 #word".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+            None,
+        )
+        .expect("type item");
+    }
+    assert_eq!(
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::ConfirmEdit,
+            None,
+            None,
+        )
+        .expect("save item"),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+    assert_eq!(
+        domain.get(task_id).expect("capture").checklist[0].text,
+        "literal !t release-2026 #word"
+    );
+    assert_eq!(
+        domain.get(task_id).expect("capture").thread.as_deref(),
+        Some("release-2026")
+    );
 }

--- a/tests/quick_add_capture.rs
+++ b/tests/quick_add_capture.rs
@@ -620,6 +620,12 @@ fn expanded_page_stashes_notes_and_scope_across_esc_and_saves_like_quick_add() {
         "Tab in the page advances the form rather than re-expanding quick add"
     );
     apply(&mut domain, &mut model, BoardIntent::FormFocusNext, None);
+    assert_eq!(model.input_mode(), BoardInputMode::EditThread);
+    assert_eq!(
+        model.form_focus(),
+        Some(herdr_tasks::ui::capture::CaptureField::Thread)
+    );
+    apply(&mut domain, &mut model, BoardIntent::FormFocusNext, None);
     assert_eq!(model.input_mode(), BoardInputMode::EditScope);
     assert_eq!(model.form_scope(), Some(&TaskScope::Global));
 

--- a/tests/quick_add_capture.rs
+++ b/tests/quick_add_capture.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use herdr_tasks::app::{apply_board_intent_with_save_recovery, BoardSaveContext};
 use herdr_tasks::context::InvocationSnapshot;
-use herdr_tasks::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use herdr_tasks::domain::{DomainState, ProvenanceOrigin, TaskEventKind, TaskScope};
 use herdr_tasks::save_recovery::SaveRecovery;
 use herdr_tasks::ui::board::{
     apply_intent, board_hit_map, draw_board, BoardInputMode, BoardModel, IntentOutcome,
@@ -625,7 +625,7 @@ fn expanded_page_stashes_notes_and_scope_across_esc_and_saves_like_quick_add() {
 
     apply(&mut domain, &mut model, BoardIntent::CancelEdit, None);
     assert_eq!(model.input_mode(), BoardInputMode::QuickAdd);
-    assert_eq!(model.quick_add_title_value(), "draft with details");
+    assert_eq!(model.quick_add_title_value(), "draft with details !p");
     apply(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None);
     assert_eq!(model.input_mode(), BoardInputMode::EditNotes);
     assert_eq!(model.edit_buffer(), "preserved note");
@@ -644,6 +644,243 @@ fn expanded_page_stashes_notes_and_scope_across_esc_and_saves_like_quick_add() {
     assert_eq!(task.title, "draft with details");
     assert_eq!(task.notes.as_deref(), Some("preserved note"));
     assert_eq!(task.scope, TaskScope::Global);
+}
+
+#[test]
+fn t_token_threads_while_hash_words_stay_title_text() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let snap = snapshot();
+
+    open(&mut domain, &mut model, &snap);
+    type_title(&mut domain, &mut model, "ship #urgent !t Release-2026");
+    assert_eq!(
+        apply(&mut domain, &mut model, BoardIntent::QuickAddSave, None),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+
+    let task = domain.tasks().last().expect("saved task");
+    assert_eq!(task.title, "ship #urgent");
+    assert_eq!(task.thread.as_deref(), Some("release-2026"));
+}
+
+#[test]
+fn p_token_consumes_one_argument_and_leaves_later_words_in_the_title() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+
+    save_quick_add(&mut domain, &mut model, "ship !p /repos/one now");
+
+    let task = domain.tasks().last().expect("saved task");
+    assert_eq!(task.title, "ship now");
+    assert_eq!(
+        task.scope,
+        TaskScope::Project {
+            path: "/repos/one".into()
+        }
+    );
+}
+
+#[test]
+fn bare_t_token_saves_unthreaded_and_strips() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let snap = snapshot();
+
+    open(&mut domain, &mut model, &snap);
+    type_title(&mut domain, &mut model, "unthread this !t");
+    assert_eq!(
+        apply(&mut domain, &mut model, BoardIntent::QuickAddSave, None),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+
+    let task = domain.tasks().last().expect("saved task");
+    assert_eq!(task.title, "unthread this");
+    assert_eq!(task.thread, None);
+}
+
+#[test]
+fn t_and_p_tokens_combine_in_either_order() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+
+    save_quick_add(
+        &mut domain,
+        &mut model,
+        "first !p /repos/one !t Release-2026",
+    );
+    save_quick_add(&mut domain, &mut model, "second !t Other !p /repos/two");
+
+    for (task, title, path, thread) in [
+        (&domain.tasks()[0], "first", "/repos/one", "release-2026"),
+        (&domain.tasks()[1], "second", "/repos/two", "other"),
+    ] {
+        assert_eq!(task.title, title);
+        assert_eq!(task.scope, TaskScope::Project { path: path.into() });
+        assert_eq!(task.thread.as_deref(), Some(thread));
+    }
+}
+
+#[test]
+fn malformed_t_token_refuses_on_open_line_and_clears_on_close() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let snap = snapshot();
+
+    open(&mut domain, &mut model, &snap);
+    type_title(
+        &mut domain,
+        &mut model,
+        "bad !t release_name !p /repos/other",
+    );
+    assert_eq!(
+        apply(&mut domain, &mut model, BoardIntent::QuickAddSave, None),
+        IntentOutcome::None
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::QuickAdd);
+    assert!(model
+        .message()
+        .is_some_and(|message| message.contains("thread")));
+    assert!(
+        domain.tasks().is_empty(),
+        "a malformed token persists nothing"
+    );
+
+    apply(&mut domain, &mut model, BoardIntent::CancelQuickAdd, None);
+    assert_eq!(model.input_mode(), BoardInputMode::Normal);
+    assert_eq!(model.message(), None);
+}
+
+#[test]
+fn quick_add_without_t_does_not_inherit_a_prior_thread() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+
+    save_quick_add(&mut domain, &mut model, "threaded !t release-2026");
+    save_quick_add(&mut domain, &mut model, "unthreaded follow-up");
+
+    assert_eq!(domain.tasks()[0].thread.as_deref(), Some("release-2026"));
+    assert_eq!(domain.tasks()[1].thread, None);
+}
+
+#[test]
+fn over_length_t_token_refuses_without_applying_scope() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let snap = snapshot();
+    let too_long = "a".repeat(33);
+
+    open(&mut domain, &mut model, &snap);
+    type_title(
+        &mut domain,
+        &mut model,
+        &format!("bad !p /repos/other !t {too_long}"),
+    );
+    assert_eq!(
+        apply(&mut domain, &mut model, BoardIntent::QuickAddSave, None),
+        IntentOutcome::None
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::QuickAdd);
+    assert!(model.message().is_some());
+    assert!(domain.tasks().is_empty());
+}
+
+#[test]
+fn malformed_t_token_keeps_quick_add_open_when_expanding() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let snap = snapshot();
+
+    open(&mut domain, &mut model, &snap);
+    type_title(&mut domain, &mut model, "bad !t release_name");
+    assert_eq!(
+        apply(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None),
+        IntentOutcome::None
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::QuickAdd);
+    assert_eq!(model.quick_add_title_value(), "bad !t release_name");
+    assert!(model.message().is_some());
+    assert!(domain.tasks().is_empty());
+}
+
+#[test]
+fn draft_stash_round_trips_thread_through_tab_and_esc() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let snap = snapshot();
+
+    open(&mut domain, &mut model, &snap);
+    type_title(
+        &mut domain,
+        &mut model,
+        "threaded details !p /repos/draft !t Release-2026",
+    );
+    apply(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None);
+    for character in "preserved note".chars() {
+        apply(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+        );
+    }
+    apply(&mut domain, &mut model, BoardIntent::CancelEdit, None);
+    assert_eq!(model.input_mode(), BoardInputMode::QuickAdd);
+    assert_eq!(
+        model.quick_add_title_value(),
+        "threaded details !p /repos/draft !t Release-2026"
+    );
+
+    apply(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None);
+    assert_eq!(model.edit_buffer(), "preserved note");
+    assert_eq!(
+        apply(&mut domain, &mut model, BoardIntent::ConfirmEdit, None),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+
+    let task = domain.tasks().last().expect("saved task");
+    assert_eq!(task.title, "threaded details");
+    assert_eq!(task.notes.as_deref(), Some("preserved note"));
+    assert_eq!(
+        task.scope,
+        TaskScope::Project {
+            path: "/repos/draft".into()
+        }
+    );
+    assert_eq!(task.thread.as_deref(), Some("release-2026"));
+}
+
+#[test]
+fn threaded_quick_add_produces_only_created_event_and_no_edited_event() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+
+    save_quick_add(&mut domain, &mut model, "ship it !t Release-2026");
+
+    let task = domain.tasks().last().expect("threaded task");
+    assert_eq!(task.thread.as_deref(), Some("release-2026"));
+    assert_eq!(
+        task.history
+            .iter()
+            .map(|event| event.kind)
+            .collect::<Vec<_>>(),
+        vec![TaskEventKind::Created]
+    );
+}
+
+#[test]
+fn bare_t_before_hash_word_unthreads_and_keeps_hash_word_in_title() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+
+    save_quick_add(&mut domain, &mut model, "ship !t #urgent");
+
+    let task = domain.tasks().last().expect("unthreaded task");
+    assert_eq!(task.title, "ship #urgent");
+    assert_eq!(task.thread, None);
 }
 
 #[test]
@@ -783,7 +1020,7 @@ fn capture_bar_renders_spaced_three_row_block_and_stays_bounded_without_color_sg
     let standard = render_text(&model, 80, 24);
     for text in [
         "visible task",
-        "title…   !p global · !p name project · tab details",
+        "title…   !p global · !p name project · !t thread · tab details",
         "enter save · ctrl+enter save+next · tab details · esc close",
     ] {
         assert!(standard.contains(text), "missing {text:?}: {standard}");

--- a/tests/store_persist.rs
+++ b/tests/store_persist.rs
@@ -296,6 +296,157 @@ fn pre_steps_store_decodes_with_empty_steps() {
 }
 
 #[test]
+fn pre_thread_store_decodes_with_no_thread() {
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    fs::copy(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pre_thread_tasks.json"),
+        dir.join("tasks.json"),
+    )
+    .expect("install pre-thread store");
+
+    let state = TaskStore::new(&dir)
+        .load()
+        .expect("pre-thread store loads without migration");
+    let task = state.tasks().first().expect("fixture task");
+    assert_eq!(task.thread, None);
+}
+
+#[test]
+fn thread_round_trips_through_save_and_load() {
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    let store = TaskStore::new(&dir);
+    let mut state = DomainState::new();
+    let id = state
+        .create(
+            "Threaded task",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    state
+        .edit(
+            id,
+            "Threaded task",
+            None,
+            TaskScope::Global,
+            Some("release-2026".into()),
+        )
+        .expect("attach thread");
+
+    store.save(&state).expect("save threaded task");
+    let loaded = store.load().expect("reload threaded task");
+    assert_eq!(
+        loaded.get(id).and_then(|task| task.thread.as_deref()),
+        Some("release-2026")
+    );
+}
+
+#[test]
+fn edit_with_thread_persists_through_one_locked_merge() {
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    let store = TaskStore::new(&dir);
+    let mut seed = DomainState::new();
+    let id = seed
+        .create(
+            "Merge thread",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    store.save(&seed).expect("seed task");
+
+    let mut local = store.load().expect("load local task");
+    local
+        .edit(
+            id,
+            "Merge thread",
+            None,
+            TaskScope::Global,
+            Some("release-2026".into()),
+        )
+        .expect("edit thread");
+    store
+        .reload_merge_save(&mut local)
+        .expect("one locked merge persists thread edit");
+
+    assert_eq!(
+        local.get(id).and_then(|task| task.thread.as_deref()),
+        Some("release-2026")
+    );
+    assert_eq!(
+        store
+            .load()
+            .expect("reload merged state")
+            .get(id)
+            .and_then(|task| task.thread.as_deref()),
+        Some("release-2026")
+    );
+}
+
+#[test]
+fn conflicting_concurrent_thread_edits_reject_via_revision_guard() {
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    let store = TaskStore::new(&dir);
+    let mut seed = DomainState::new();
+    let id = seed
+        .create(
+            "Conflicting threads",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    store.save(&seed).expect("seed task");
+
+    let mut local = store.load().expect("load local writer");
+    let mut concurrent = store.load().expect("load concurrent writer");
+    local
+        .edit(
+            id,
+            "Conflicting threads",
+            None,
+            TaskScope::Global,
+            Some("local".into()),
+        )
+        .expect("stage local thread edit");
+    concurrent
+        .edit(
+            id,
+            "Conflicting threads",
+            None,
+            TaskScope::Global,
+            Some("concurrent".into()),
+        )
+        .expect("stage concurrent thread edit");
+    store.save(&concurrent).expect("save concurrent edit");
+
+    let error = store
+        .reload_merge_save(&mut local)
+        .expect_err("divergent thread edits must conflict");
+    assert!(error.to_string().contains("changed during save"));
+    assert_eq!(
+        store
+            .load()
+            .expect("reload durable concurrent edit")
+            .get(id)
+            .and_then(|task| task.thread.as_deref()),
+        Some("concurrent")
+    );
+}
+
+#[test]
 fn steps_round_trip_preserves_identity_flags_and_order() {
     let dir = temp_state_dir();
     let _guard = TempDirGuard(dir.clone());
@@ -542,6 +693,7 @@ fn stale_undo_refuses_newer_task_revision_without_popping_newer_state() {
             "Changed concurrently",
             Some("newer notes".into()),
             TaskScope::Global,
+            None,
         )
         .expect("newer semantic mutation");
     store.save(&newer_writer).expect("save newer task revision");


### PR DESCRIPTION
## Summary

Adds one optional normalized thread tag to a task. Threads can be captured through quick-add, the task page, Capture, and CLI, and scoped boards render open threaded tasks as decorative blocks.

## Acceptance criteria

- AC-1 to AC-6: compatible persistence, shared normalization, refusal, concurrent edits, and save recovery.
- AC-7 to AC-11: `!t` quick-add grammar, scope composition, inert `#`, and malformed-token refusal.
- AC-12 to AC-21: scoped derived blocks, ordering, chrome-only headers, selection, compact geometry, and peek.
- AC-22 to AC-25: page and Capture fields, draft round-trip, and step-text token isolation.
- AC-26 to AC-33: CLI add/list thread behavior, output shape, and documented contract.

## Coverage

| Task | Criteria |
| --- | --- |
| T-1 | AC-1, AC-2, AC-3, AC-4, AC-5 |
| T-2 | AC-3, AC-4, AC-7, AC-8, AC-9, AC-10, AC-11, AC-24, AC-25 |
| T-3 | AC-12, AC-13, AC-14, AC-15, AC-16, AC-18, AC-19 |
| T-4 | AC-13, AC-17, AC-18, AC-20, AC-21 |
| T-5 | AC-3, AC-4, AC-6, AC-22, AC-23 |
| T-7 | AC-3, AC-4, AC-26, AC-27, AC-28, AC-29, AC-30 |
| T-8 | AC-31, AC-32, AC-33 |

## Verification

Fresh green bar passed:

```text
cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release
exit 0
```

` sdlc-check --require ledger --require verification-report ` passed with 0 findings and 0 notes. The repository intentionally gitignores `docs/specs/`, so the local verification artifact is represented here in full.

| Criterion | Type | Proof |
| --- | --- | --- |
| AC-1 | test-backed | pre_thread_store_decodes_with_no_thread |
| AC-2 | test-backed | thread_round_trips_through_save_and_load |
| AC-3 | test-backed | normalizes_case_and_accepts_valid_shapes, capture::tests::capture_creation_carries_supplied_normalized_thread, add_thread_flag_applies_to_every_item_and_round_trips |
| AC-4 | test-backed | refuses_bad_chars_over_length_and_bad_first_char, page_thread_field_refuses_invalid_name_without_persisting, invalid_thread_flag_is_usage_error_exit_2_nothing_persisted |
| AC-5 | test-backed | conflicting_concurrent_thread_edits_reject_via_revision_guard |
| AC-6 | test-backed | failed_save_during_thread_edit_holds_form_until_retry_or_cancel |
| AC-7 | test-backed | t_token_threads_while_hash_words_stay_title_text |
| AC-8 | test-backed | bare_t_token_saves_unthreaded_and_strips |
| AC-9 | test-backed | t_and_p_tokens_combine_in_either_order |
| AC-10 | test-backed | t_token_threads_while_hash_words_stay_title_text |
| AC-11 | test-backed | malformed_t_token_refuses_on_open_line_and_clears_on_close |
| AC-12 | test-backed | deck_group_emits_thread_blocks_with_open_counts_iff_open_tasks |
| AC-13 | test-backed | header_shows_name_and_open_count |
| AC-14 | test-backed | unthreaded_tasks_list_after_thread_blocks |
| AC-15 | test-backed | thread_blocks_order_by_recency_and_tasks_within_by_updated_desc |
| AC-16 | test-backed | thread_blocks_order_by_recency_and_tasks_within_by_updated_desc |
| AC-17 | test-backed | arrow_navigation_crosses_painted_header_task_to_task |
| AC-18 | test-backed | selection_stays_on_task_id_across_thread_block_reorder |
| AC-19 | test-backed | same_thread_name_in_two_scopes_forms_independent_groups |
| AC-20 | test-backed | board_with_headers_paints_within_40x10_and_all_tasks_reachable |
| AC-21 | test-backed | peek_shows_thread_line_only_for_threaded_task |
| AC-22 | test-backed | page_view_shows_thread_beside_scope |
| AC-23 | test-backed | page_edit_sets_thread_and_clearing_unthreads |
| AC-24 | test-backed | draft_stash_round_trips_thread_through_tab_and_esc |
| AC-25 | test-backed | t_token_capture_threads_while_item_text_stays_literal |
| AC-26 | test-backed | add_thread_flag_applies_to_every_item_and_round_trips |
| AC-27 | test-backed | plan_item_thread_applies_per_item |
| AC-28 | test-backed | invalid_thread_flag_is_usage_error_exit_2_nothing_persisted, thread_flag_ignores_piped_plan_and_creates_only_flag_task, thread_flag_with_file_is_usage_error_exit_2 |
| AC-29 | test-backed | invalid_plan_item_thread_fails_item_exit_1_others_persist |
| AC-30 | test-backed | idempotency_key_includes_thread_both_directions |
| AC-31 | test-backed | list_thread_filters_after_scope_selection |
| AC-32 | test-backed | json_rows_always_carry_thread_field, human_output_appends_thread_marker_iff_row_threaded_snapshots |
| AC-33 | reviewer-checked | Yes. The CLI skill documents add/list flags, plan `thread`, invalid-thread, and exit behavior. |

## Provenance

Threads was built from the owner-authorized `checklists` base, then rebased onto merged `main` at `e334ca4`. Rebase conflicts were resolved against the shipped steps architecture and the complete green bar was rerun. The final two commits are owner-approved presentation refinements: threaded rows indent beneath headers and thread blocks receive a trailing spacer.

## Spec

`docs/specs/threads/threads.md` (local process artifact, intentionally gitignored)
