### PR TITLE
chore: rebrand to tsk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,17 @@ The committed `.gitignore` already covers it.
 
 ## Product
 
-**herdr-tasks** is a herdr plugin: a queue board for capture and human-status
-verbs. Park, resume, linking, and dispatch-start are not board or palette
-actions. Dispatch recovery can still open for a persisted attempt. Crate and
-plugin are `0.2.0`.
+**tsk** is a terminal task board ("a task board for your terminal"): a queue
+board for capture and human-status verbs. It ships as the herdr plugin
+`herdr-tasks`, and the built binary (`tsk`) also runs standalone. Park, resume,
+linking, and dispatch-start are not board or palette actions. Dispatch recovery
+can still open for a persisted attempt. Crate (`tsk-tui`) and plugin are
+`0.2.0`.
 
 A gitignored `HANDOFF.md` may hold this clone’s live working state.
 
-For scriptable board work, use `herdr-tasks add` and `herdr-tasks list`; read
-`skills/herdr-tasks-cli/SKILL.md` first for retry and scope-check rules.
+For scriptable board work, use `tsk add` and `tsk list`; read
+`skills/tsk-cli/SKILL.md` first for retry and scope-check rules.
 
 ### Board
 
@@ -66,7 +68,7 @@ For scriptable board work, use `herdr-tasks add` and `herdr-tasks list`; read
 ## Build / test / verify
 
 - Build: `cargo build --release`
-- `herdr-plugin.toml` launches `./target/release/herdr-tasks`. Rebuild in-repo
+- `herdr-plugin.toml` launches `./target/release/tsk`. Rebuild in-repo
   before live smoke. A running board keeps the old binary until you quit it.
 - Test: `cargo test` (plain, parallel)
 - A regression test must fail without its fix. Write it, revert the fix, watch it
@@ -90,6 +92,9 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
 
 - Human status is source of truth. Never auto-complete tasks from agent status.
 - State under `HERDR_PLUGIN_STATE_DIR`. Config under `HERDR_PLUGIN_CONFIG_DIR`.
+  Standalone runs default to `$XDG_DATA_HOME/tsk` / `~/.config/tsk`, overridable
+  with `TSK_STATE_DIR` / `TSK_CONFIG_DIR`; injected host variables keep
+  precedence.
   Verb modifier is `settings.json` in that config dir; the palette flips it.
 - UI chrome lives in `src/ui/` (`board/` model·apply·commands·chrome·draw,
   `capture`, `mouse`, `input`, `render`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+Rebrand to **tsk** ("a task board for your terminal"). The crate is now
+`tsk-tui` building the `tsk` binary. Standalone state and config default to
+`~/.local/share/tsk` and `~/.config/tsk`, with new `TSK_STATE_DIR` /
+`TSK_CONFIG_DIR` overrides beneath the injected herdr variables. The herdr
+plugin id stays `herdr-tasks`, so existing plugin state needs no migration.
+
 ## 0.2.0
 
 Per-task steps: a flat, ordered list on the task page with a shared notes and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,8 +2,8 @@
 
 Canonical terms for this repo. No implementation detail.
 
-- **add command**: headless `herdr-tasks` subcommand that creates tasks without opening a TUI.
-- **list command**: headless `herdr-tasks` subcommand that prints tasks from the board store without changing them.
+- **add command**: headless `tsk add` subcommand that creates tasks without opening a TUI.
+- **list command**: headless `tsk list` subcommand that prints tasks from the board store without changing them.
 - **bulk add**: one `add` invocation that accepts many items, reports each, and makes one durable write of the successes.
 - **invocation default**: capture scope used when the caller omits `project` / `-p`. The cwd repo when known, otherwise global.
 - **tiny result**: JSON report from a plan-shaped `add`. `created` and `existing` rows carry index, id, title. `failed` rows carry index, title (string or null), error code, and human error text. Notes are not echoed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,18 +478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "herdr-tasks"
-version = "0.2.0"
-dependencies = [
- "crossterm",
- "fs2",
- "ratatui",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1433,18 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "tsk-tui"
+version = "0.2.0"
+dependencies = [
+ "crossterm",
+ "fs2",
+ "ratatui",
+ "serde",
+ "serde_json",
+ "uuid",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "herdr-tasks"
+name = "tsk-tui"
 version = "0.2.0"
 edition = "2021"
-description = "herdr plugin: Tasks board and capture"
+description = "tsk: a task board for your terminal"
 license = "MIT"
 publish = false
 
 [[bin]]
-name = "herdr-tasks"
+name = "tsk"
 path = "src/main.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,24 +1,48 @@
-# herdr-tasks
+# tsk
 
-A [herdr](https://herdr.dev) plugin: a queue board for capturing work and moving it
-through human status. Park, resume, attention, linking, and dispatch-start are not
-board actions. Dispatch recovery can still open if a persisted attempt is already
-in the store.
+**A task board for your terminal.**
+
+tsk captures work and moves it through human status: ready, started, blocked,
+review, done. It ships today as a [herdr](https://herdr.dev) plugin, and the
+`tsk` binary also runs standalone against its own state directory.
+
+Park, resume, attention, linking, and dispatch-start are not board actions.
+Dispatch recovery can still open if a persisted attempt is already in the store.
 
 ## Requirements
 
-- herdr 0.7.5 or newer
 - Rust 1.96.0 (pinned in `rust-toolchain.toml`)
 - Linux or macOS
+- herdr 0.7.5 or newer (plugin mode only)
 
 ## Install
 
-The plugin pane runs `./target/release/herdr-tasks`, so build before you link:
+Build from source:
 
 ```bash
-git clone git@github.com:smarzban/herdr-tasks.git
-cd herdr-tasks
+git clone git@github.com:smarzban/tsk.git
+cd tsk
 cargo build --release
+```
+
+The built binary is `target/release/tsk`.
+
+### Standalone
+
+Run `tsk` directly. State lives in `$XDG_DATA_HOME/tsk`
+(`~/.local/share/tsk` by default), config in `~/.config/tsk`. Override either
+with `TSK_STATE_DIR` / `TSK_CONFIG_DIR`.
+
+```bash
+tsk add -t "Draft release notes"
+tsk list
+```
+
+### As a herdr plugin
+
+The plugin pane runs `./target/release/tsk`, so build before you link:
+
+```bash
 herdr plugin link "$PWD"
 ```
 
@@ -27,13 +51,13 @@ after you pull.
 
 ## Open the board
 
-From herdr, pick **Open Tasks board**, or:
+From herdr, pick **Open tsk board**, or:
 
 ```bash
 herdr plugin action invoke open-board --plugin herdr-tasks
 ```
 
-It opens a **Tasks** split beside the current pane. Invoking it again focuses the
+It opens a **tsk** split beside the current pane. Invoking it again focuses the
 board you already have.
 
 **Quick capture** opens the capture form without the board:
@@ -42,8 +66,9 @@ board you already have.
 herdr plugin action invoke quick-capture --plugin herdr-tasks
 ```
 
-State lives under `HERDR_PLUGIN_STATE_DIR`. Config (including the verb modifier)
-lives under `HERDR_PLUGIN_CONFIG_DIR`.
+In plugin mode, state lives under `HERDR_PLUGIN_STATE_DIR` and config under
+`HERDR_PLUGIN_CONFIG_DIR`; the host injects both, so the plugin and a standalone
+CLI can be pointed at the same store deliberately but never collide by accident.
 
 ## Pane size
 
@@ -61,7 +86,8 @@ One urgency-ordered list. Sections are computed, not navigated.
 
 - **IN MOTION**: work you have started
 - When showing all projects: one group per project, global last
-- When scoped to one project: **ON DECK** for that project
+- When scoped to one project: **ON DECK** for that project, with derived thread
+  headers above their open tasks
 - **z** opens the done drawer
 
 ## Keys
@@ -105,7 +131,7 @@ Page `Esc` closes the page.
 
 | Key | Does |
 | --- | --- |
-| `Tab` / `Shift+Tab` | Title, Notes, Scope |
+| `Tab` / `Shift+Tab` | Title, Notes, Thread, Scope |
 | `Enter` in Title | save |
 | `Enter` in Notes | new line |
 | `Ctrl+Enter` or `Alt+Enter` | save from any field |

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Dispatch recovery can still open if a persisted attempt is already in the store.
 Build from source:
 
 ```bash
-git clone git@github.com:smarzban/tsk.git
-cd tsk
+git clone git@github.com:smarzban/herdr-tasks.git
+cd herdr-tasks
 cargo build --release
 ```
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,14 +13,14 @@ command = ["cargo", "build", "--release"]
 
 [[panes]]
 id = "board"
-title = "Tasks"
+title = "tsk"
 placement = "split"
-command = ["./target/release/herdr-tasks"]
+command = ["./target/release/tsk"]
 
 [[actions]]
 id = "open-board"
 platforms = ["linux", "macos"]
-title = "Open Tasks board"
+title = "Open tsk board"
 description = "Open the Tasks board in a split pane beside the current work."
 command = ["bash", "scripts/open-board.sh"]
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -21,7 +21,7 @@ command = ["./target/release/tsk"]
 id = "open-board"
 platforms = ["linux", "macos"]
 title = "Open tsk board"
-description = "Open the Tasks board in a split pane beside the current work."
+description = "Open the tsk board in a split pane beside the current work."
 command = ["bash", "scripts/open-board.sh"]
 
 [[actions]]

--- a/scripts/open-board.sh
+++ b/scripts/open-board.sh
@@ -22,7 +22,7 @@ board_label="Tasks"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Same relative layout as other herdr plugins: scripts/ next to target/release/.
-plugin_bin="${HERDR_TASKS_BIN:-$script_dir/../target/release/herdr-tasks}"
+plugin_bin="${HERDR_TASKS_BIN:-$script_dir/../target/release/tsk}"
 
 open_board() {
   exec "$herdr_bin" plugin pane open \

--- a/scripts/open-board.sh
+++ b/scripts/open-board.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Idempotent open-or-focus for the Tasks board.
 #
-# - No Tasks pane yet  -> plugin pane open --placement split --focus
-# - Tasks pane exists  -> plugin pane focus <pane_id> (no second board)
+# - No tsk board pane yet  -> plugin pane open --placement split --focus
+# - tsk board pane exists  -> plugin pane focus <pane_id> (no second board)
 #
 # herdr actions run a command (no declarative "open this pane" field), so this shells
 # out via $HERDR_BIN_PATH (herdr injects it; fall back to `herdr` on PATH).
-# Existing board is recognized by label/title "Tasks" from `pane list` JSON
+# Existing board is recognized only by its manifest label from `pane list` JSON
 # (matches [[panes]] title in herdr-plugin.toml).
 #
 # Focus selection is done by tsk --find-board-pane (Rust), not python3,
@@ -31,7 +31,7 @@ open_board() {
     --focus
 }
 
-# Extract first flag-safe pane_id whose label or stripped title is Tasks.
+# Extract first flag-safe pane_id whose label is tsk.
 # Uses tsk --find-board-pane (reads pane-list JSON on stdin).
 find_board_pane_id() {
   local panes

--- a/scripts/open-board.sh
+++ b/scripts/open-board.sh
@@ -9,20 +9,19 @@
 # Existing board is recognized by label/title "Tasks" from `pane list` JSON
 # (matches [[panes]] title in herdr-plugin.toml).
 #
-# Focus selection is done by herdr-tasks --find-board-pane (Rust), not python3,
+# Focus selection is done by tsk --find-board-pane (Rust), not python3,
 # so this works on hosts without python3.
 #
-# Manual check: invoke open-board twice; the second focus keeps a single Tasks board.
+# Manual check: invoke open-board twice; the second focus keeps a single tsk board.
 set -uo pipefail
 
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 plugin_id="herdr-tasks"
 entrypoint="board"
-board_label="Tasks"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Same relative layout as other herdr plugins: scripts/ next to target/release/.
-plugin_bin="${HERDR_TASKS_BIN:-$script_dir/../target/release/tsk}"
+plugin_bin="${TSK_BIN:-$script_dir/../target/release/tsk}"
 
 open_board() {
   exec "$herdr_bin" plugin pane open \
@@ -33,7 +32,7 @@ open_board() {
 }
 
 # Extract first flag-safe pane_id whose label or stripped title is Tasks.
-# Uses herdr-tasks --find-board-pane (reads pane-list JSON on stdin).
+# Uses tsk --find-board-pane (reads pane-list JSON on stdin).
 find_board_pane_id() {
   local panes
   panes="$("$herdr_bin" pane list 2>/dev/null || true)"

--- a/scripts/open-capture.sh
+++ b/scripts/open-capture.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Quick-capture launcher: short-lived popup (overlay) in capture mode.
 #
-# Opens the board entrypoint as an overlay and sets HERDR_TASKS_MODE=capture so
+# Opens the board entrypoint as an overlay and sets TSK_MODE=capture so
 # the binary can enter Capture UI without first opening a persistent split board.
 # Capture surfaces are short-lived. Board focus idempotency is in open-board.sh.
 #
@@ -17,4 +17,4 @@ exec "$herdr_bin" plugin pane open \
   --entrypoint "$entrypoint" \
   --placement overlay \
   --focus \
-  --env HERDR_TASKS_MODE=capture
+  --env TSK_MODE=capture

--- a/scripts/tsk-cli.sh
+++ b/scripts/tsk-cli.sh
@@ -24,10 +24,10 @@ else:
     raise SystemExit("herdr-tasks plugin is not enabled")
 '
 )
-binary="$plugin_root/target/release/herdr-tasks"
+binary="$plugin_root/target/release/tsk"
 
 if [[ ! -x "$binary" ]]; then
-  printf 'herdr-tasks binary is missing: %s\nRebuild the enabled plugin, then retry.\n' "$binary" >&2
+  printf 'tsk binary is missing: %s\nRebuild the enabled plugin, then retry.\n' "$binary" >&2
   exit 127
 fi
 

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -1,22 +1,22 @@
 ---
-name: herdr-tasks-cli
-description: Use when asked to add tasks, a task list, or a plan to the Tasks board, or to inspect Tasks board items. Use `herdr-tasks add` and `herdr-tasks list`, never the TUI.
+name: tsk-cli
+description: Use when asked to add tasks, a task list, or a plan to the Tasks board, or to inspect Tasks board items. Use `tsk add` and `tsk list`, never the TUI.
 ---
 
-# herdr-tasks CLI
+# tsk CLI
 
-Use `herdr-tasks add` to create a task or JSON plan, and `herdr-tasks list` to
+Use `tsk add` to create a task or JSON plan, and `tsk list` to
 inspect the shared board store before and after adding work.
 
 ## Adding
 
 ```sh
-herdr-tasks add -t "Draft release notes"
-herdr-tasks add -t "Buy milk" --global
-herdr-tasks add -t "Fix widget" --project widget --thread release-2026
-herdr-tasks add --title="-fix parser" --notes="-5 degrees" --project="-maintenance"
-herdr-tasks add --file plan.json
-cat plan.json | herdr-tasks add
+tsk add -t "Draft release notes"
+tsk add -t "Buy milk" --global
+tsk add -t "Fix widget" --project widget --thread release-2026
+tsk add --title="-fix parser" --notes="-5 degrees" --project="-maintenance"
+tsk add --file plan.json
+cat plan.json | tsk add
 ```
 
 Use `--title=<value>`, `--notes=<value>`, `--project=<value>`,
@@ -39,7 +39,7 @@ persist and the command exits 1.
   Valid siblings still persist. Retry only the `failed` subset. `created` and
   `existing` items both succeeded, so you must never whole-plan-retry an exit 1 run.
 - exit 2: usage or parse error, nothing persisted. Correct the invocation, then run it.
-- exit 3: store I/O, commit indeterminate. Run `herdr-tasks list --all --json` to
+- exit 3: store I/O, commit indeterminate. Run `tsk list --all --json` to
   check every scope, then retry only missing work. You must never whole-plan-retry an exit 3 run.
 
 Add is idempotent by trimmed title and resolved project scope. A non-soft-deleted
@@ -48,7 +48,7 @@ reports it in `existing` with its `i`, `id`, and `title`.
 
 ## Listing scope and filters
 
-`herdr-tasks list` defaults to ready, started, blocked, and review tasks in the
+`tsk list` defaults to ready, started, blocked, and review tasks in the
 invocation project, or global scope outside a repository. Use `-p`/`--project <scope>`
 for the same basename-or-path resolution as add, `--global` for global tasks, or `--all`
 for every scope. `--thread <name>` normalizes then filters tasks after scope
@@ -60,24 +60,24 @@ soft-deleted tasks only, regardless of stored status. Scope selectors are mutual
 exclusive, as are `--done` and `--deleted`.
 
 A typo in a project name silently files the task under a new scope. Use
-`herdr-tasks list --all --json` to recover the resulting scope.
+`tsk list --all --json` to recover the resulting scope.
 
 ## Steps
 
 ```sh
-herdr-tasks steps <task-id> add "Draft outline"
-herdr-tasks steps <task-id> toggle <step-short-id>
-herdr-tasks list <task-id>
+tsk steps <task-id> add "Draft outline"
+tsk steps <task-id> toggle <step-short-id>
+tsk list <task-id>
 ```
 
-`<task-id>` is a task UUID from `herdr-tasks list --json`. A step short id is
-the shortest unambiguous prefix of the step id. `herdr-tasks list <task-id>`
+`<task-id>` is a task UUID from `tsk list --json`. A step short id is
+the shortest unambiguous prefix of the step id. `tsk list <task-id>`
 prints one line per step with its `[x]`/`[ ]` state and short id; with `--json`
 the row's `steps` array carries each step's `id`, `text`, `done`, and
 `short_id`.
 
 `toggle` flips the step state: a retry after an unseen success flips it back.
-Never blind-retry a `steps` invocation — run `herdr-tasks list <task-id>`
+Never blind-retry a `steps` invocation — run `tsk list <task-id>`
 first and retry only a real refusal. `steps` exits 0 when the step was created
 or toggled, 1 for a refusal (stable tokens `empty-step-text`,
 `invalid-step-text`, `unknown-task`, `soft-deleted-task`, `unknown-step`,

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ struct PendingDispatch {
 }
 
 /// Env var set by open-capture launcher for Capture UI mode.
-pub const MODE_ENV: &str = "HERDR_TASKS_MODE";
+pub const MODE_ENV: &str = "TSK_MODE";
 
 /// One binary, two modes (Board default; Capture for quick-capture).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,7 +79,7 @@ pub fn resolve_mode_from<S: AsRef<str>>(
     AppMode::Board
 }
 
-/// Resolve the TUI mode from `HERDR_TASKS_MODE` and remaining argv (after argv0).
+/// Resolve the TUI mode from `TSK_MODE` and remaining argv (after argv0).
 pub fn resolve_mode<S: AsRef<str>>(args: impl IntoIterator<Item = S>) -> AppMode {
     resolve_mode_from(env::var(MODE_ENV).ok().as_deref(), args)
 }
@@ -316,7 +316,7 @@ pub fn load_board_model() -> Result<BoardModel, Box<dyn Error>> {
 
 /// Binary entry used by `main`. Default mode is the Tasks board.
 ///
-/// Pass `capture` argv (or `HERDR_TASKS_MODE=capture`) for popup-style Capture UI.
+/// Pass `capture` argv (or `TSK_MODE=capture`) for popup-style Capture UI.
 pub fn run(args: impl IntoIterator<Item = impl AsRef<str>>) -> Result<(), Box<dyn Error>> {
     match resolve_mode(args) {
         AppMode::Board => run_board(),
@@ -1286,8 +1286,7 @@ mod idle_store_revalidation_tests {
             .unwrap()
             .as_nanos();
         let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let dir =
-            std::env::temp_dir().join(format!("herdr-tasks-idle-revalidate-{label}-{nanos}-{seq}"));
+        let dir = std::env::temp_dir().join(format!("tsk-idle-revalidate-{label}-{nanos}-{seq}"));
         fs::create_dir_all(&dir).unwrap();
         dir
     }
@@ -1765,27 +1764,24 @@ mod tests {
 
     #[test]
     fn default_mode_is_board() {
-        assert_eq!(resolve_mode_from(None, ["herdr-tasks"]), AppMode::Board);
+        assert_eq!(resolve_mode_from(None, ["tsk"]), AppMode::Board);
         assert_eq!(
-            resolve_mode_from(None, ["herdr-tasks", "--something"]),
+            resolve_mode_from(None, ["tsk", "--something"]),
             AppMode::Board
         );
         // Non-capture env values do not select Capture.
-        assert_eq!(
-            resolve_mode_from(Some("board"), ["herdr-tasks"]),
-            AppMode::Board
-        );
+        assert_eq!(resolve_mode_from(Some("board"), ["tsk"]), AppMode::Board);
     }
 
     #[test]
     fn capture_arg_selects_capture_mode() {
         assert_eq!(
-            resolve_mode_from(None, ["herdr-tasks", "capture"]),
+            resolve_mode_from(None, ["tsk", "capture"]),
             AppMode::Capture
         );
         // Arg still wins when env is absent or non-capture.
         assert_eq!(
-            resolve_mode_from(Some("board"), ["herdr-tasks", "capture"]),
+            resolve_mode_from(Some("board"), ["tsk", "capture"]),
             AppMode::Capture
         );
     }
@@ -1793,11 +1789,11 @@ mod tests {
     #[test]
     fn capture_env_selects_capture_mode() {
         assert_eq!(
-            resolve_mode_from(Some("capture"), ["herdr-tasks"]),
+            resolve_mode_from(Some("capture"), ["tsk"]),
             AppMode::Capture
         );
         assert_eq!(
-            resolve_mode_from(Some("CAPTURE"), ["herdr-tasks", "--something"]),
+            resolve_mode_from(Some("CAPTURE"), ["tsk", "--something"]),
             AppMode::Capture
         );
     }
@@ -2247,7 +2243,7 @@ mod tests {
                 .unwrap()
                 .as_nanos();
             let seq = TEMP_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            let dir = env::temp_dir().join(format!("herdr-tasks-{label}-{nanos}-{seq}"));
+            let dir = env::temp_dir().join(format!("tsk-{label}-{nanos}-{seq}"));
             std::fs::create_dir_all(&dir).unwrap();
             let store = TaskStore::new(&dir);
             TempStore { dir, store }
@@ -2415,7 +2411,7 @@ mod tests {
     fn quick_add_project_token_matches_a_project_basename_case_insensitively() {
         let snapshot = InvocationSnapshot {
             default_scope: TaskScope::Global,
-            this_repo: Some(PathBuf::from("/repos/herdr-tasks")),
+            this_repo: Some(PathBuf::from("/repos/tsk-board")),
             title_prefill: None,
             provenance: ProvenanceOrigin::Capture,
             capsule: None,
@@ -2435,7 +2431,7 @@ mod tests {
         apply_intent(
             &mut domain,
             &mut model,
-            BoardIntent::QuickAddInsertText("Case insensitive scope !p HERDR-TASKS".into()),
+            BoardIntent::QuickAddInsertText("Case insensitive scope !p TSK-Board".into()),
             Some(&snapshot),
             None,
         )
@@ -2454,7 +2450,7 @@ mod tests {
         assert_eq!(
             task.scope,
             TaskScope::Project {
-                path: "/repos/herdr-tasks".into()
+                path: "/repos/tsk-board".into()
             }
         );
     }
@@ -3062,7 +3058,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let seq = TEMP_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let dir = env::temp_dir().join(format!("herdr-tasks-attn-cycle-{nanos}-{seq}"));
+        let dir = env::temp_dir().join(format!("tsk-attn-cycle-{nanos}-{seq}"));
         fs::create_dir_all(&dir).unwrap();
 
         let store = TaskStore::new(&dir);
@@ -3131,7 +3127,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let seq = TEMP_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let dir = env::temp_dir().join(format!("herdr-tasks-attn-save-failure-{nanos}-{seq}"));
+        let dir = env::temp_dir().join(format!("tsk-attn-save-failure-{nanos}-{seq}"));
         fs::create_dir_all(&dir).unwrap();
         let store = TaskStore::new(&dir);
         let mut domain = DomainState::new();
@@ -3190,7 +3186,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let seq = TEMP_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let dir = env::temp_dir().join(format!("herdr-tasks-attn-unavailable-{nanos}-{seq}"));
+        let dir = env::temp_dir().join(format!("tsk-attn-unavailable-{nanos}-{seq}"));
         fs::create_dir_all(&dir).unwrap();
         let store = TaskStore::new(&dir);
         let mut domain = DomainState::new();
@@ -3243,7 +3239,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let seq = TEMP_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let dir = env::temp_dir().join(format!("herdr-tasks-attn-merge-{nanos}-{seq}"));
+        let dir = env::temp_dir().join(format!("tsk-attn-merge-{nanos}-{seq}"));
         fs::create_dir_all(&dir).unwrap();
 
         let store = TaskStore::new(&dir);
@@ -3321,7 +3317,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let seq = TEMP_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let dir = env::temp_dir().join(format!("herdr-tasks-attn-noop-{nanos}-{seq}"));
+        let dir = env::temp_dir().join(format!("tsk-attn-noop-{nanos}-{seq}"));
         fs::create_dir_all(&dir).unwrap();
 
         let store = TaskStore::new(&dir);
@@ -3652,7 +3648,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let seq = TEMP_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let dir = env::temp_dir().join(format!("herdr-tasks-{tag}-{nanos}-{seq}"));
+        let dir = env::temp_dir().join(format!("tsk-{tag}-{nanos}-{seq}"));
         fs::create_dir_all(&dir).unwrap();
         dir
     }

--- a/src/board_pane.rs
+++ b/src/board_pane.rs
@@ -7,7 +7,7 @@ use std::io::{self, Read};
 
 use serde_json::Value;
 
-/// Board pane label/title as declared in herdr-plugin.toml `[[panes]]`.
+/// Board pane label as declared in herdr-plugin.toml `[[panes]]`.
 pub const BOARD_PANE_LABEL: &str = "tsk";
 
 /// Read pane-list JSON from `stdin` and print the first flag-safe Tasks pane id.
@@ -22,9 +22,12 @@ pub fn find_board_pane_from_stdin() -> io::Result<Option<String>> {
 
 /// Parse herdr `pane list` JSON and return the first flag-safe Tasks pane_id.
 ///
-/// Matches panes whose `label` or `terminal_title_stripped` equals `"tsk"`.
-/// Pane ids must be non-empty, not start with `-`, and match `[A-Za-z0-9_.:-]+`
-/// so they are safe to pass as a CLI argument to `plugin pane focus`.
+/// Matches panes whose `label` equals `"tsk"`.
+///
+/// A terminal title is not a board identity: it can be the standalone `tsk` binary's
+/// default title in an unrelated pane. Pane ids must be non-empty, not start with `-`,
+/// and match `[A-Za-z0-9_.:-]+` so they are safe to pass as a CLI argument to
+/// `plugin pane focus`.
 pub fn find_board_pane_id(json: &str) -> Option<String> {
     let data: Value = serde_json::from_str(json).ok()?;
     let panes = data
@@ -34,11 +37,7 @@ pub fn find_board_pane_id(json: &str) -> Option<String> {
 
     for pane in panes {
         let label = pane.get("label").and_then(|v| v.as_str()).unwrap_or("");
-        let title = pane
-            .get("terminal_title_stripped")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        if label != BOARD_PANE_LABEL && title != BOARD_PANE_LABEL {
+        if label != BOARD_PANE_LABEL {
             continue;
         }
         let pid = pane.get("pane_id").and_then(|v| v.as_str()).unwrap_or("");
@@ -75,15 +74,15 @@ mod tests {
     }
 
     #[test]
-    fn finds_tasks_pane_by_title() {
+    fn ignores_non_board_pane_with_tsk_terminal_title() {
         let json = r#"{
             "result": {
                 "panes": [
-                    {"pane_id": "w1:p0", "label": "", "terminal_title_stripped": "tsk"}
+                    {"pane_id": "w1:p0", "label": "shell", "terminal_title_stripped": "tsk"}
                 ]
             }
         }"#;
-        assert_eq!(find_board_pane_id(json).as_deref(), Some("w1:p0"));
+        assert_eq!(find_board_pane_id(json), None);
     }
 
     #[test]

--- a/src/board_pane.rs
+++ b/src/board_pane.rs
@@ -1,6 +1,6 @@
 //! Find an existing Tasks board pane from `herdr pane list` JSON.
 //!
-//! Used by `scripts/open-board.sh` via `herdr-tasks --find-board-pane` so the
+//! Used by `scripts/open-board.sh` via `tsk --find-board-pane` so the
 //! launcher does not depend on python3.
 
 use std::io::{self, Read};
@@ -67,7 +67,7 @@ mod tests {
             "result": {
                 "panes": [
                     {"pane_id": "w0:p1", "label": "Editor", "terminal_title_stripped": "nvim"},
-                    {"pane_id": "w0:p2", "label": "Tasks", "terminal_title_stripped": "herdr-tasks"}
+                    {"pane_id": "w0:p2", "label": "Tasks", "terminal_title_stripped": "tsk"}
                 ]
             }
         }"#;

--- a/src/board_pane.rs
+++ b/src/board_pane.rs
@@ -8,7 +8,7 @@ use std::io::{self, Read};
 use serde_json::Value;
 
 /// Board pane label/title as declared in herdr-plugin.toml `[[panes]]`.
-pub const BOARD_PANE_LABEL: &str = "Tasks";
+pub const BOARD_PANE_LABEL: &str = "tsk";
 
 /// Read pane-list JSON from `stdin` and print the first flag-safe Tasks pane id.
 ///
@@ -22,7 +22,7 @@ pub fn find_board_pane_from_stdin() -> io::Result<Option<String>> {
 
 /// Parse herdr `pane list` JSON and return the first flag-safe Tasks pane_id.
 ///
-/// Matches panes whose `label` or `terminal_title_stripped` equals `"Tasks"`.
+/// Matches panes whose `label` or `terminal_title_stripped` equals `"tsk"`.
 /// Pane ids must be non-empty, not start with `-`, and match `[A-Za-z0-9_.:-]+`
 /// so they are safe to pass as a CLI argument to `plugin pane focus`.
 pub fn find_board_pane_id(json: &str) -> Option<String> {
@@ -67,7 +67,7 @@ mod tests {
             "result": {
                 "panes": [
                     {"pane_id": "w0:p1", "label": "Editor", "terminal_title_stripped": "nvim"},
-                    {"pane_id": "w0:p2", "label": "Tasks", "terminal_title_stripped": "tsk"}
+                    {"pane_id": "w0:p2", "label": "tsk", "terminal_title_stripped": "tsk"}
                 ]
             }
         }"#;
@@ -79,7 +79,7 @@ mod tests {
         let json = r#"{
             "result": {
                 "panes": [
-                    {"pane_id": "w1:p0", "label": "", "terminal_title_stripped": "Tasks"}
+                    {"pane_id": "w1:p0", "label": "", "terminal_title_stripped": "tsk"}
                 ]
             }
         }"#;
@@ -91,9 +91,9 @@ mod tests {
         let json = r#"{
             "result": {
                 "panes": [
-                    {"pane_id": "--evil", "label": "Tasks"},
-                    {"pane_id": "bad id", "label": "Tasks"},
-                    {"pane_id": "w0:p9", "label": "Tasks"}
+                    {"pane_id": "--evil", "label": "tsk"},
+                    {"pane_id": "bad id", "label": "tsk"},
+                    {"pane_id": "w0:p9", "label": "tsk"}
                 ]
             }
         }"#;

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -101,7 +101,7 @@ mod tests {
             .expect("clock")
             .as_nanos();
         let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-        env::temp_dir().join(format!("herdr-tasks-t9-{label}-{nanos}-{seq}"))
+        env::temp_dir().join(format!("tsk-t9-{label}-{nanos}-{seq}"))
     }
 
     struct TempDirGuard(PathBuf);

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -63,7 +63,7 @@ pub struct ListResult {
     pub(crate) steps: Vec<crate::cli::steps::StepLine>,
 }
 
-/// Parse `herdr-tasks list` arguments, including argv0 and the `list` subcommand.
+/// Parse `tsk list` arguments, including argv0 and the `list` subcommand.
 pub fn parse(args: &[String]) -> Result<ListInput, String> {
     if args.get(1).map(String::as_str) != Some("list") {
         return Err("expected list command".into());

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -23,7 +23,7 @@ pub struct FlagAdd {
     pub help: bool,
 }
 
-/// Parse `herdr-tasks add` arguments, including argv0 and the `add` subcommand.
+/// Parse `tsk add` arguments, including argv0 and the `add` subcommand.
 pub fn parse_flag_add(args: &[String]) -> Result<FlagAdd, String> {
     if args.get(1).map(String::as_str) != Some("add") {
         return Err("expected add command".into());
@@ -150,7 +150,7 @@ pub struct FlagSteps {
     pub help: bool,
 }
 
-/// Parse `herdr-tasks steps` arguments, including argv0 and the `steps` subcommand.
+/// Parse `tsk steps` arguments, including argv0 and the `steps` subcommand.
 ///
 /// Flags may appear anywhere; the positionals in order are task id, action, and
 /// the action's operand.

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -11,19 +11,19 @@ use crate::ui::terminal_text;
 
 pub fn add_help() -> CliOutput {
     help_output(
-        "usage: herdr-tasks add -t <title> [-n <notes>] [-p <project> | --global] [--thread <name>] [--json] [--state-dir <dir>]\n       herdr-tasks add [--file <path|->] [--state-dir <dir>]",
+        "usage: tsk add -t <title> [-n <notes>] [-p <project> | --global] [--thread <name>] [--json] [--state-dir <dir>]\n       tsk add [--file <path|->] [--state-dir <dir>]",
     )
 }
 
 pub fn list_help() -> CliOutput {
     CliOutput {
         stdout: concat!(
-            "usage: herdr-tasks list [<task-id>] [-p <project> | --global | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n\n",
+            "usage: tsk list [<task-id>] [-p <project> | --global | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n\n",
             "Lists ready, started, blocked, and review tasks in the invocation project by default, or global scope outside a repository.\n",
             "With a task id (a task UUID from add --json or list --json), lists that one task alone and prints its steps: one line per step with its [x]/[ ] state and step short id. A task id cannot be combined with scope, thread, or status filters.\n",
             "--project uses the same basename-or-path scope resolution as add; --global selects global tasks; --all selects every scope. --thread normalizes a thread name and filters within the selected scope; an invalid name is a usage error (exit 2). For dash-leading project and state-directory values, use --project=<scope> and --state-dir=<dir>.\n",
             "--done lists done tasks only. --deleted lists soft-deleted tasks only, regardless of status.\n",
-            "To recover a typo scope, use herdr-tasks list --all --json.\n",
+            "To recover a typo scope, use tsk list --all --json.\n",
             "--json emits a flat array of id, title, status, project, and thread (or null) in displayed group order. Human --all groups rows by status, then project scope, using a unique concise trailing path or global.\n\n",
             "Exit contract:\n",
             "  exit 0: tasks were listed\n",
@@ -39,7 +39,7 @@ pub fn list_help() -> CliOutput {
 fn help_output(usage: &str) -> CliOutput {
     CliOutput {
         stdout: format!(
-            "{usage}\n\nExamples:\n  herdr-tasks add -t \"Draft release notes\"\n  herdr-tasks add -t \"Buy milk\" --global\n  herdr-tasks add -t \"Fix widget\" --project widget --thread release-2026\n  herdr-tasks add --title=\"-fix parser\" --notes=\"-5 degrees\" --project=\"-maintenance\"\n  herdr-tasks add --file plan.json\n  cat plan.json | herdr-tasks add\n\nValues beginning with - must use --title=<value>, --notes=<value>, --project=<value>, --state-dir=<dir>, or --file=<path>.\nItem flags plus --file are usage (exit 2, nothing persists). Piped stdin with item flags is ignored and not read. An add whose trimmed title, resolved project scope, and normalized thread already exist succeeds without changing the task. With --json, flag add emits one object with outcome, id, title, and project (or null).\nPlan JSON: [{{\"title\": \"...\", \"notes\": \"...\", \"project\": \"...\", \"thread\": \"...\"}}] (thread may also be null)\nPlan result: {{\"created\": [...], \"existing\": [...], \"failed\": [...]}}\n\nExit contract:\n  exit 0: every item was created or already existed\n  exit 1: one or more items were refused, retry failed only\n  exit 2: usage or parse error, nothing persisted\n  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
+            "{usage}\n\nExamples:\n  tsk add -t \"Draft release notes\"\n  tsk add -t \"Buy milk\" --global\n  tsk add -t \"Fix widget\" --project widget --thread release-2026\n  tsk add --title=\"-fix parser\" --notes=\"-5 degrees\" --project=\"-maintenance\"\n  tsk add --file plan.json\n  cat plan.json | tsk add\n\nValues beginning with - must use --title=<value>, --notes=<value>, --project=<value>, --state-dir=<dir>, or --file=<path>.\nItem flags plus --file are usage (exit 2, nothing persists). Piped stdin with item flags is ignored and not read. An add whose trimmed title, resolved project scope, and normalized thread already exist succeeds without changing the task. With --json, flag add emits one object with outcome, id, title, and project (or null).\nPlan JSON: [{{\"title\": \"...\", \"notes\": \"...\", \"project\": \"...\", \"thread\": \"...\"}}] (thread may also be null)\nPlan result: {{\"created\": [...], \"existing\": [...], \"failed\": [...]}}\n\nExit contract:\n  exit 0: every item was created or already existed\n  exit 1: one or more items were refused, retry failed only\n  exit 2: usage or parse error, nothing persisted\n  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
         ),
         stderr: String::new(),
         code: 0,
@@ -92,7 +92,7 @@ pub fn usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "herdr-tasks add: {reason}\nusage: herdr-tasks add -t <title> [-n <notes>] [-p <project> | --global] [--thread <name>] [--json] [--state-dir <dir>]\n"
+            "tsk add: {reason}\nusage: tsk add -t <title> [-n <notes>] [-p <project> | --global] [--thread <name>] [--json] [--state-dir <dir>]\n"
         ),
         code: 2,
     }
@@ -369,11 +369,11 @@ fn path_segments(path: &str) -> Vec<String> {
 pub fn steps_help() -> CliOutput {
     CliOutput {
         stdout: concat!(
-            "usage: herdr-tasks steps <task-id> add <text> [--state-dir <dir>]\n",
-            "       herdr-tasks steps <task-id> toggle <step-short-id> [--state-dir <dir>]\n\n",
-            "steps adds one step to a task or toggles one step's done flag. The task id is a task UUID from herdr-tasks list --json.\n",
-            "A step short id is the shortest unambiguous prefix of the step id, as printed by herdr-tasks list <task-id>.\n",
-            "toggle flips the step state: a blind retry after an unseen success flips it back, so verify with herdr-tasks list <task-id> before retrying.\n\n",
+            "usage: tsk steps <task-id> add <text> [--state-dir <dir>]\n",
+            "       tsk steps <task-id> toggle <step-short-id> [--state-dir <dir>]\n\n",
+            "steps adds one step to a task or toggles one step's done flag. The task id is a task UUID from tsk list --json.\n",
+            "A step short id is the shortest unambiguous prefix of the step id, as printed by tsk list <task-id>.\n",
+            "toggle flips the step state: a blind retry after an unseen success flips it back, so verify with tsk list <task-id> before retrying.\n\n",
             "Refusal tokens (exit 1): empty-step-text, invalid-step-text, unknown-task, soft-deleted-task, unknown-step, ambiguous-step.\n\n",
             "Exit contract:\n",
             "  exit 0: step created or toggled\n",
@@ -410,7 +410,7 @@ pub fn steps_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "herdr-tasks steps: {reason}\nusage: herdr-tasks steps <task-id> add <text> | toggle <step-short-id> [--state-dir <dir>]\n"
+            "tsk steps: {reason}\nusage: tsk steps <task-id> add <text> | toggle <step-short-id> [--state-dir <dir>]\n"
         ),
         code: 2,
     }
@@ -423,7 +423,7 @@ pub fn steps_rejected(error: StepsError) -> CliOutput {
     };
     CliOutput {
         stdout: String::new(),
-        stderr: format!("herdr-tasks steps: {detail}\n"),
+        stderr: format!("tsk steps: {detail}\n"),
         code,
     }
 }
@@ -432,7 +432,7 @@ pub fn list_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "herdr-tasks list: {reason}\nusage: herdr-tasks list [<task-id>] [-p <project> | --global | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n"
+            "tsk list: {reason}\nusage: tsk list [<task-id>] [-p <project> | --global | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n"
         ),
         code: 2,
     }
@@ -442,7 +442,7 @@ pub fn list_rejected(error: ListError) -> CliOutput {
     match error {
         ListError::Store(detail) => CliOutput {
             stdout: String::new(),
-            stderr: format!("herdr-tasks list: {detail}\n"),
+            stderr: format!("tsk list: {detail}\n"),
             code: 3,
         },
         // A well-formed id that addresses no task: the invocation is wrong, not the store.
@@ -457,7 +457,7 @@ pub fn rejected(error: AddError) -> CliOutput {
     };
     CliOutput {
         stdout: String::new(),
-        stderr: format!("herdr-tasks add: {detail}\n"),
+        stderr: format!("tsk add: {detail}\n"),
         code,
     }
 }

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -67,29 +67,26 @@ mod tests {
 
     #[test]
     fn add_dash_t_capture_stays_add() {
-        assert_eq!(
-            route(["herdr-tasks", "add", "-t", "capture"], None),
-            Surface::Add
-        );
+        assert_eq!(route(["tsk", "add", "-t", "capture"], None), Surface::Add);
     }
 
     #[test]
     fn tokens_after_add_do_not_select_a_surface() {
         assert_eq!(
-            route(["herdr-tasks", "add", "-t", "--find-board-pane"], None),
+            route(["tsk", "add", "-t", "--find-board-pane"], None),
             Surface::Add
         );
     }
 
     #[test]
     fn unknown_positional_is_usage() {
-        assert_eq!(route(["herdr-tasks", "foo"], None), Surface::Usage);
+        assert_eq!(route(["tsk", "foo"], None), Surface::Usage);
     }
 
     #[test]
     fn unknown_pre_positional_flag_is_usage_even_with_capture_env() {
         assert_eq!(
-            route(["herdr-tasks", "--something"], Some("capture")),
+            route(["tsk", "--something"], Some("capture")),
             Surface::Usage
         );
     }
@@ -97,31 +94,31 @@ mod tests {
     #[test]
     fn find_board_pane_with_extra_argument_is_usage() {
         assert_eq!(
-            route(["herdr-tasks", "--find-board-pane", "extra"], None),
+            route(["tsk", "--find-board-pane", "extra"], None),
             Surface::Usage
         );
     }
 
     #[test]
     fn subcommand_wins_over_capture_env() {
-        assert_eq!(route(["herdr-tasks", "add"], Some("capture")), Surface::Add);
+        assert_eq!(route(["tsk", "add"], Some("capture")), Surface::Add);
     }
 
     #[test]
     fn steps_positional_selects_steps_surface() {
         assert_eq!(
-            route(["herdr-tasks", "steps", "id", "toggle", "abc"], None),
+            route(["tsk", "steps", "id", "toggle", "abc"], None),
             Surface::Steps
         );
     }
 
     #[test]
     fn capture_env_selects_capture_without_subcommand() {
-        assert_eq!(route(["herdr-tasks"], Some("capture")), Surface::Capture);
+        assert_eq!(route(["tsk"], Some("capture")), Surface::Capture);
     }
 
     #[test]
     fn no_args_selects_board() {
-        assert_eq!(route(["herdr-tasks"], None), Surface::Board);
+        assert_eq!(route(["tsk"], None), Surface::Board);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,15 +46,17 @@ struct WalkthroughDocument {
     dismissed: bool,
 }
 
-/// Config dir from `HERDR_PLUGIN_CONFIG_DIR`, else a per-user config directory.
+/// Config dir from `HERDR_PLUGIN_CONFIG_DIR`, else `TSK_CONFIG_DIR`, else per-user config.
 ///
-/// Production herdr injects `HERDR_PLUGIN_CONFIG_DIR`. When unset (manual runs / tests
-/// without the host), use `$XDG_CONFIG_HOME/herdr-tasks` or `$HOME/.config/herdr-tasks`.
+/// Production herdr injects `HERDR_PLUGIN_CONFIG_DIR`. Standalone runs may set
+/// `TSK_CONFIG_DIR`. When neither is set (manual runs / tests without the host), use
+/// `$XDG_CONFIG_HOME/tsk` or `$HOME/.config/tsk`.
 /// Mirrors [`crate::store::default_state_dir`], including its refusal to fall back to a
 /// shared world path under `std::env::temp_dir()`.
 pub fn default_config_dir() -> PathBuf {
     resolve_config_dir(
         env::var_os("HERDR_PLUGIN_CONFIG_DIR").as_deref(),
+        env::var_os("TSK_CONFIG_DIR").as_deref(),
         env::var_os("XDG_CONFIG_HOME").as_deref(),
         env::var_os("HOME").as_deref(),
     )
@@ -72,6 +74,7 @@ pub fn default_config_dir() -> PathBuf {
 /// would write into the current working directory: see the module doc.
 fn resolve_config_dir(
     host: Option<&OsStr>,
+    tsk_env: Option<&OsStr>,
     xdg_config_home: Option<&OsStr>,
     home: Option<&OsStr>,
 ) -> PathBuf {
@@ -80,18 +83,23 @@ fn resolve_config_dir(
             return PathBuf::from(dir);
         }
     }
+    if let Some(dir) = tsk_env {
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
+        }
+    }
     if let Some(xdg) = xdg_config_home {
         if !xdg.is_empty() {
-            return PathBuf::from(xdg).join("herdr-tasks");
+            return PathBuf::from(xdg).join("tsk");
         }
     }
     if let Some(home) = home {
         if !home.is_empty() {
-            return PathBuf::from(home).join(".config/herdr-tasks");
+            return PathBuf::from(home).join(".config/tsk");
         }
     }
-    // Last resort: relative per-process dir (still not shared /tmp/herdr-tasks-config).
-    PathBuf::from(".herdr-tasks-config")
+    // Last resort: relative per-process dir (still not shared /tmp/tsk-config).
+    PathBuf::from(".tsk-config")
 }
 
 /// The single durable fact: the walkthrough was completed or skipped.
@@ -271,7 +279,7 @@ mod tests {
             .expect("clock")
             .as_nanos();
         let seq = TEMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        env::temp_dir().join(format!("herdr-tasks-config-{label}-{nanos}-{seq}"))
+        env::temp_dir().join(format!("tsk-config-{label}-{nanos}-{seq}"))
     }
 
     struct TempDirGuard(PathBuf);
@@ -310,7 +318,12 @@ mod tests {
     #[test]
     fn host_variable_wins_over_every_other_candidate() {
         assert_eq!(
-            resolve_config_dir(Some(os("/host")), Some(os("/xdg")), Some(os("/home/u"))),
+            resolve_config_dir(
+                Some(os("/host")),
+                None,
+                Some(os("/xdg")),
+                Some(os("/home/u"))
+            ),
             PathBuf::from("/host")
         );
     }
@@ -318,33 +331,56 @@ mod tests {
     #[test]
     fn empty_host_variable_falls_through_to_xdg() {
         assert_eq!(
-            resolve_config_dir(Some(os("")), Some(os("/xdg")), Some(os("/home/u"))),
-            PathBuf::from("/xdg/herdr-tasks"),
+            resolve_config_dir(Some(os("")), None, Some(os("/xdg")), Some(os("/home/u"))),
+            PathBuf::from("/xdg/tsk"),
             "an empty host variable must not resolve to the current working directory"
+        );
+    }
+
+    #[test]
+    fn standalone_env_sits_between_host_and_xdg() {
+        assert_eq!(
+            resolve_config_dir(
+                None,
+                Some(os("/tsk-env")),
+                Some(os("/xdg")),
+                Some(os("/home/u"))
+            ),
+            PathBuf::from("/tsk-env")
+        );
+        assert_eq!(
+            resolve_config_dir(
+                Some(os("/host")),
+                Some(os("/tsk-env")),
+                Some(os("/xdg")),
+                Some(os("/home/u"))
+            ),
+            PathBuf::from("/host"),
+            "host injection keeps precedence over the standalone override"
         );
     }
 
     #[test]
     fn xdg_config_home_wins_over_home() {
         assert_eq!(
-            resolve_config_dir(None, Some(os("/xdg")), Some(os("/home/u"))),
-            PathBuf::from("/xdg/herdr-tasks")
+            resolve_config_dir(None, None, Some(os("/xdg")), Some(os("/home/u"))),
+            PathBuf::from("/xdg/tsk")
         );
     }
 
     #[test]
     fn empty_xdg_config_home_falls_through_to_home() {
         assert_eq!(
-            resolve_config_dir(None, Some(os("")), Some(os("/home/u"))),
-            PathBuf::from("/home/u/.config/herdr-tasks")
+            resolve_config_dir(None, None, Some(os("")), Some(os("/home/u"))),
+            PathBuf::from("/home/u/.config/tsk")
         );
     }
 
     #[test]
     fn home_resolves_under_dot_config_not_dot_local_share() {
         assert_eq!(
-            resolve_config_dir(None, None, Some(os("/home/u"))),
-            PathBuf::from("/home/u/.config/herdr-tasks"),
+            resolve_config_dir(None, None, None, Some(os("/home/u"))),
+            PathBuf::from("/home/u/.config/tsk"),
             "this is the config record, not the state store"
         );
     }
@@ -352,16 +388,16 @@ mod tests {
     #[test]
     fn empty_home_falls_through_to_the_relative_fallback() {
         assert_eq!(
-            resolve_config_dir(None, None, Some(os(""))),
-            PathBuf::from(".herdr-tasks-config")
+            resolve_config_dir(None, None, None, Some(os(""))),
+            PathBuf::from(".tsk-config")
         );
     }
 
     #[test]
     fn no_candidate_resolves_to_a_relative_dir_never_a_shared_temp_path() {
-        let fallback = resolve_config_dir(None, None, None);
+        let fallback = resolve_config_dir(None, None, None, None);
 
-        assert_eq!(fallback, PathBuf::from(".herdr-tasks-config"));
+        assert_eq!(fallback, PathBuf::from(".tsk-config"));
         assert!(
             fallback.is_relative(),
             "the last resort must be per-process, not a shared world-writable path"
@@ -376,6 +412,7 @@ mod tests {
             default_config_dir(),
             resolve_config_dir(
                 env::var_os("HERDR_PLUGIN_CONFIG_DIR").as_deref(),
+                env::var_os("TSK_CONFIG_DIR").as_deref(),
                 env::var_os("XDG_CONFIG_HOME").as_deref(),
                 env::var_os("HOME").as_deref(),
             )

--- a/src/context.rs
+++ b/src/context.rs
@@ -367,7 +367,7 @@ mod tests {
             .expect("clock")
             .as_nanos();
         let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-        let dir = env::temp_dir().join(format!("herdr-tasks-t8-{label}-{nanos}-{seq}"));
+        let dir = env::temp_dir().join(format!("tsk-t8-{label}-{nanos}-{seq}"));
         fs::create_dir_all(&dir).expect("create temp dir");
         dir
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -673,8 +673,8 @@ mod tests {
                     },
                     {
                         "pane_id": "w0:p2",
-                        "label": "Tasks",
-                        "terminal_title_stripped": "Tasks",
+                        "label": "tsk",
+                        "terminal_title_stripped": "tsk",
                         "cwd": "/plugin/board-cwd",
                         "foreground_cwd": "/plugin/board-cwd",
                         "focused": true,
@@ -687,7 +687,7 @@ mod tests {
             "result": {
                 "pane": {
                     "pane_id": "w0:p2",
-                    "label": "Tasks",
+                    "label": "tsk",
                     "cwd": "/plugin/board-cwd",
                     "workspace_id": "w0"
                 }
@@ -784,7 +784,7 @@ mod tests {
         PaneInfo {
             pane_id: format!("{workspace}:tasks"),
             workspace_id: Some(workspace.into()),
-            label: Some("Tasks".into()),
+            label: Some("tsk".into()),
             ..PaneInfo::default()
         }
     }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -20,7 +20,7 @@ use crate::store::TaskStateStore;
 use crate::text::non_empty;
 
 /// Env override for dispatch agent kind (default `grok` when unset/empty).
-pub const DISPATCH_AGENT_ENV: &str = "HERDR_TASKS_DISPATCH_AGENT";
+pub const DISPATCH_AGENT_ENV: &str = "TSK_DISPATCH_AGENT";
 
 /// Default agent kind when [`DISPATCH_AGENT_ENV`] is unset or blank.
 pub const DEFAULT_DISPATCH_AGENT: &str = "grok";
@@ -90,7 +90,7 @@ impl DispatchResult {
     }
 }
 
-/// Resolve dispatch agent kind from env. Non-empty `HERDR_TASKS_DISPATCH_AGENT`
+/// Resolve dispatch agent kind from env. Non-empty `TSK_DISPATCH_AGENT`
 /// wins; otherwise [`DEFAULT_DISPATCH_AGENT`].
 pub fn dispatch_agent_kind_from_env() -> String {
     dispatch_agent_kind(env::var(DISPATCH_AGENT_ENV).ok())
@@ -1578,7 +1578,7 @@ mod tests {
             .expect("clock")
             .as_nanos();
         let sequence = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!("herdr-tasks-dispatch-{nanos}-{sequence}"));
+        let dir = std::env::temp_dir().join(format!("tsk-dispatch-{nanos}-{sequence}"));
         std::fs::create_dir_all(&dir).expect("mkdir");
         dir
     }

--- a/src/host.rs
+++ b/src/host.rs
@@ -1261,7 +1261,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("clock")
             .as_nanos();
-        let dir = env::temp_dir().join(format!("herdr-tasks-host-{nanos}"));
+        let dir = env::temp_dir().join(format!("tsk-host-{nanos}"));
         fs::create_dir_all(&dir).expect("mkdir");
         dir
     }

--- a/src/host.rs
+++ b/src/host.rs
@@ -751,10 +751,12 @@ fn validate_host_id(value: &str, kind: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// True when the pane is the Tasks board (label or stripped title).
+/// True when the pane carries the board label from the plugin manifest.
+///
+/// The stripped terminal title is not an identity: a standalone `tsk` process can use it
+/// in an unrelated pane.
 pub fn is_tasks_pane(pane: &PaneInfo) -> bool {
     pane.label.as_deref() == Some(BOARD_PANE_LABEL)
-        || pane.terminal_title_stripped.as_deref() == Some(BOARD_PANE_LABEL)
 }
 
 /// Pick one work pane in the board workspace (not the Tasks board).
@@ -981,6 +983,18 @@ mod tests {
         let cur = parse_pane_current(current_json).expect("current");
         assert_eq!(cur.pane_id, "w0:p2");
         assert!(is_tasks_pane(&cur));
+    }
+
+    #[test]
+    fn terminal_title_alone_does_not_identify_a_board_pane() {
+        let pane = PaneInfo {
+            pane_id: "w0:p1".into(),
+            label: Some("shell".into()),
+            terminal_title_stripped: Some("tsk".into()),
+            ..PaneInfo::default()
+        };
+
+        assert!(!is_tasks_pane(&pane));
     }
 
     #[test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -865,7 +865,7 @@ mod tests {
             "result": {
                 "panes": [
                     {"pane_id": "w0:p1", "label": "Editor"},
-                    {"pane_id": "w0:p2", "label": "Tasks"}
+                    {"pane_id": "w0:p2", "label": "tsk"}
                 ]
             }
         }"#;
@@ -950,7 +950,7 @@ mod tests {
                     },
                     {
                         "pane_id": "w0:p2",
-                        "label": "Tasks",
+                        "label": "tsk",
                         "cwd": "/plugin",
                         "focused": false,
                         "workspace_id": "w0"
@@ -972,7 +972,7 @@ mod tests {
             "result": {
                 "pane": {
                     "pane_id": "w0:p2",
-                    "label": "Tasks",
+                    "label": "tsk",
                     "cwd": "/plugin",
                     "workspace_id": "w0"
                 }
@@ -995,7 +995,7 @@ mod tests {
             },
             PaneInfo {
                 pane_id: "w0:p2".into(),
-                label: Some("Tasks".into()),
+                label: Some("tsk".into()),
                 cwd: Some("/plugin".into()),
                 focused: false,
                 workspace_id: Some("w0".into()),
@@ -1018,7 +1018,7 @@ mod tests {
             },
             PaneInfo {
                 pane_id: "w0:p2".into(),
-                label: Some("Tasks".into()),
+                label: Some("tsk".into()),
                 focused: false,
                 workspace_id: Some("w0".into()),
                 ..PaneInfo::default()
@@ -1043,7 +1043,7 @@ mod tests {
             },
             PaneInfo {
                 pane_id: "w0:p2".into(),
-                label: Some("Tasks".into()),
+                label: Some("tsk".into()),
                 focused: false,
                 workspace_id: Some("w0".into()),
                 ..PaneInfo::default()
@@ -1068,8 +1068,8 @@ mod tests {
             },
             PaneInfo {
                 pane_id: "w0:p2".into(),
-                label: Some("Tasks".into()),
-                terminal_title_stripped: Some("Tasks".into()),
+                label: Some("tsk".into()),
+                terminal_title_stripped: Some("tsk".into()),
                 cwd: Some("/plugin-state".into()),
                 focused: true,
                 workspace_id: Some("w0".into()),
@@ -1085,7 +1085,7 @@ mod tests {
     fn select_work_pane_none_when_only_tasks() {
         let panes = vec![PaneInfo {
             pane_id: "w0:p2".into(),
-            label: Some("Tasks".into()),
+            label: Some("tsk".into()),
             focused: true,
             workspace_id: Some("w0".into()),
             ..PaneInfo::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! herdr-tasks library root.
+//! tsk library root.
 
 pub mod app;
 pub mod attention;
@@ -20,9 +20,9 @@ pub mod views;
 
 pub use board_pane::{find_board_pane_from_stdin, find_board_pane_id};
 
-/// Run the herdr-tasks binary entrypoint with argv-style arguments.
+/// Run the tsk binary entrypoint with argv-style arguments.
 ///
-/// Default mode is the Tasks board. Pass `capture` (or set `HERDR_TASKS_MODE=capture`)
+/// Default mode is the Tasks board. Pass `capture` (or set `TSK_MODE=capture`)
 /// for Capture UI mode (form; exits after save/cancel).
 ///
 /// `--find-board-pane` is handled by the binary (`main`) before this entry.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,26 @@
-//! herdr-tasks binary entry.
+//! tsk binary entry.
 
 use std::io::{self, IsTerminal, Write};
 use std::process::ExitCode;
 
-use herdr_tasks::cli::router::{route, Surface};
+use tsk_tui::cli::router::{route, Surface};
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
-    match route(
-        &args,
-        std::env::var(herdr_tasks::app::MODE_ENV).ok().as_deref(),
-    ) {
+    match route(&args, std::env::var(tsk_tui::app::MODE_ENV).ok().as_deref()) {
         Surface::FindBoardPane => find_board_pane_main(),
         Surface::GlobalHelp => {
             println!(
-                "usage: herdr-tasks [capture] | add | steps | list | --find-board-pane | --help\n\nCommands:\n  add    create one task or apply a JSON plan\n  steps  add or toggle one step on a task\n  list   inspect tasks\n\nRun `herdr-tasks add --help`, `herdr-tasks steps --help`, or `herdr-tasks list --help` for command details."
+                "usage: tsk [capture] | add | steps | list | --find-board-pane | --help\n\nCommands:\n  add    create one task or apply a JSON plan\n  steps  add or toggle one step on a task\n  list   inspect tasks\n\nRun `tsk add --help`, `tsk steps --help`, or `tsk list --help` for command details."
             );
             ExitCode::SUCCESS
         }
         Surface::Usage => usage_exit(),
         Surface::Add | Surface::Steps | Surface::List => headless_main(args),
-        Surface::Board | Surface::Capture => match herdr_tasks::run(args) {
+        Surface::Board | Surface::Capture => match tsk_tui::run(args) {
             Ok(()) => ExitCode::SUCCESS,
             Err(err) => {
-                eprintln!("herdr-tasks: {err}");
+                eprintln!("tsk: {err}");
                 ExitCode::from(1)
             }
         },
@@ -31,14 +28,14 @@ fn main() -> ExitCode {
 }
 
 fn usage_exit() -> ExitCode {
-    eprintln!("usage: herdr-tasks [capture] | add | steps | list | --find-board-pane | --help");
+    eprintln!("usage: tsk [capture] | add | steps | list | --find-board-pane | --help");
     ExitCode::from(2)
 }
 
 fn headless_main(args: Vec<String>) -> ExitCode {
     let stdin = io::stdin();
     let stdin_is_tty = stdin.is_terminal();
-    let output = herdr_tasks::cli::run_with(args, stdin, stdin_is_tty);
+    let output = tsk_tui::cli::run_with(args, stdin, stdin_is_tty);
     if io::stdout().write_all(output.stdout.as_bytes()).is_err() {
         return ExitCode::from(1);
     }
@@ -50,7 +47,7 @@ fn headless_main(args: Vec<String>) -> ExitCode {
 
 /// Read herdr `pane list` JSON from stdin; print first Tasks pane_id or exit 1.
 fn find_board_pane_main() -> ExitCode {
-    match herdr_tasks::find_board_pane_from_stdin() {
+    match tsk_tui::find_board_pane_from_stdin() {
         Ok(Some(id)) => {
             if writeln!(io::stdout(), "{id}").is_err() {
                 return ExitCode::from(1);
@@ -59,7 +56,7 @@ fn find_board_pane_main() -> ExitCode {
         }
         Ok(None) => ExitCode::from(1),
         Err(err) => {
-            eprintln!("herdr-tasks --find-board-pane: {err}");
+            eprintln!("tsk --find-board-pane: {err}");
             ExitCode::from(1)
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -277,27 +277,33 @@ impl Drop for StoreLockGuard {
     }
 }
 
-/// State dir from `HERDR_PLUGIN_STATE_DIR`, else a per-user data directory.
+/// State dir from `HERDR_PLUGIN_STATE_DIR`, else `TSK_STATE_DIR`, else per-user data.
 ///
-/// Production herdr injects `HERDR_PLUGIN_STATE_DIR`. When unset (manual runs / tests
-/// without the host), use `$XDG_DATA_HOME/herdr-tasks` or `$HOME/.local/share/herdr-tasks`.
+/// Production herdr injects `HERDR_PLUGIN_STATE_DIR`. Standalone runs may set
+/// `TSK_STATE_DIR`. When neither is set (manual runs / tests without the host), use
+/// `$XDG_DATA_HOME/tsk` or `$HOME/.local/share/tsk`.
 /// Never falls back to a shared world path under `std::env::temp_dir()`.
 pub fn default_state_dir() -> PathBuf {
     if let Some(dir) = env::var_os("HERDR_PLUGIN_STATE_DIR") {
         return PathBuf::from(dir);
     }
+    if let Some(dir) = env::var_os("TSK_STATE_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
+        }
+    }
     if let Some(xdg) = env::var_os("XDG_DATA_HOME") {
         if !xdg.is_empty() {
-            return PathBuf::from(xdg).join("herdr-tasks");
+            return PathBuf::from(xdg).join("tsk");
         }
     }
     if let Some(home) = env::var_os("HOME") {
         if !home.is_empty() {
-            return PathBuf::from(home).join(".local/share/herdr-tasks");
+            return PathBuf::from(home).join(".local/share/tsk");
         }
     }
-    // Last resort: relative per-process dir (still not shared /tmp/herdr-tasks-state).
-    PathBuf::from(".herdr-tasks-state")
+    // Last resort: relative per-process dir (still not shared /tmp/tsk-state).
+    PathBuf::from(".tsk-state")
 }
 
 /// Store I/O and JSON failures.
@@ -360,7 +366,7 @@ mod tests {
             .expect("clock")
             .as_nanos();
         let seq = TEMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        env::temp_dir().join(format!("herdr-tasks-store-{label}-{nanos}-{seq}"))
+        env::temp_dir().join(format!("tsk-store-{label}-{nanos}-{seq}"))
     }
 
     struct TempDirGuard(PathBuf);
@@ -763,16 +769,35 @@ mod tests {
         assert_eq!(default_state_dir(), marker);
         env::remove_var("HERDR_PLUGIN_STATE_DIR");
 
+        // The standalone override sits between the host variable and XDG.
+        let standalone = marker.join("standalone");
+        env::set_var("TSK_STATE_DIR", &standalone);
+        assert_eq!(default_state_dir(), standalone);
+        env::set_var("HERDR_PLUGIN_STATE_DIR", &marker);
+        assert_eq!(
+            default_state_dir(),
+            marker,
+            "host injection beats TSK_STATE_DIR"
+        );
+        env::remove_var("HERDR_PLUGIN_STATE_DIR");
+        env::set_var("TSK_STATE_DIR", "");
+        assert_ne!(
+            default_state_dir(),
+            PathBuf::from(""),
+            "empty falls through"
+        );
+        env::remove_var("TSK_STATE_DIR");
+
         let fallback = default_state_dir();
-        let shared_tmp = env::temp_dir().join("herdr-tasks-state");
+        let shared_tmp = env::temp_dir().join("tsk-state");
         assert_ne!(
             fallback, shared_tmp,
-            "fallback must not be shared /tmp/herdr-tasks-state"
+            "fallback must not be shared /tmp/tsk-state"
         );
         // Prefer XDG/HOME style paths when available.
         let fallback_s = fallback.to_string_lossy();
         assert!(
-            fallback_s.contains("herdr-tasks") || fallback_s == ".herdr-tasks-state",
+            fallback_s.contains("tsk") || fallback_s == ".tsk-state",
             "unexpected fallback: {fallback_s}"
         );
     }

--- a/src/ui/capture.rs
+++ b/src/ui/capture.rs
@@ -938,7 +938,7 @@ mod tests {
             .expect("clock")
             .as_nanos();
         let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-        env::temp_dir().join(format!("herdr-tasks-t13-{label}-{nanos}-{seq}"))
+        env::temp_dir().join(format!("tsk-t13-{label}-{nanos}-{seq}"))
     }
 
     struct TempDirGuard(PathBuf);

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -2551,7 +2551,7 @@ mod tests {
             &"x".repeat(200),
             "safe\u{1b}]52;clipboard\u{7}payload",
         ];
-        let metas = ["", "1h", "herdr-tasks · 2d", &"m".repeat(80)];
+        let metas = ["", "1h", "tsk · 2d", &"m".repeat(80)];
 
         for geo in cases {
             for title in titles {
@@ -2640,7 +2640,7 @@ mod tests {
             TaskRowPaint {
                 glyph: "▲",
                 title: "bold title",
-                meta: "herdr-tasks · 2m",
+                meta: "tsk · 2m",
                 selected: false,
                 title_bold: true,
             },

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -7,9 +7,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::cli::{parser, run_with};
-use herdr_tasks::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
-use herdr_tasks::store::TaskStore;
+use tsk_tui::cli::{parser, run_with};
+use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
+use tsk_tui::store::TaskStore;
 
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -27,12 +27,12 @@ fn temp_state_dir(label: &str) -> PathBuf {
         .expect("clock after epoch")
         .as_nanos();
     let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("herdr-tasks-cli-add-{label}-{nanos}-{seq}"));
+    let dir = std::env::temp_dir().join(format!("tsk-cli-add-{label}-{nanos}-{seq}"));
     std::fs::create_dir_all(&dir).expect("create state directory");
     dir
 }
 
-fn add(args: &[String], stdin_is_tty: bool) -> herdr_tasks::cli::CliOutput {
+fn add(args: &[String], stdin_is_tty: bool) -> tsk_tui::cli::CliOutput {
     run_with(args, Cursor::new(Vec::<u8>::new()), stdin_is_tty)
 }
 
@@ -58,7 +58,7 @@ fn add_thread_flag_applies_to_every_item_and_round_trips() {
     let dir = temp_state_dir("thread-flag");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -87,7 +87,7 @@ fn thread_flag_with_file_is_usage_error_exit_2() {
     std::fs::write(&plan, r#"[{"title":"from file"}]"#).expect("write plan");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -118,7 +118,7 @@ fn thread_flag_ignores_piped_plan_and_creates_only_flag_task() {
     let dir = temp_state_dir("thread-stdin-plan");
     let output = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dir),
@@ -154,7 +154,7 @@ fn plan_item_thread_applies_per_item() {
     .expect("write plan");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -172,12 +172,7 @@ fn plan_item_thread_applies_per_item() {
 
     let stdin_dir = temp_state_dir("plan-item-thread-stdin");
     let stdin = run_with(
-        [
-            "herdr-tasks",
-            "add",
-            "--state-dir",
-            &state_dir_arg(&stdin_dir),
-        ],
+        ["tsk", "add", "--state-dir", &state_dir_arg(&stdin_dir)],
         Cursor::new(r#"[{"title":"threaded from stdin","thread":"ops"}]"#),
         false,
     );
@@ -202,7 +197,7 @@ fn invalid_thread_flag_is_usage_error_exit_2_nothing_persisted() {
     let dir = temp_state_dir("invalid-thread-flag");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -232,7 +227,7 @@ fn invalid_plan_item_thread_fails_item_exit_1_others_persist() {
     let dir = temp_state_dir("invalid-plan-thread");
     let output = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dir),
@@ -265,7 +260,7 @@ fn idempotency_key_includes_thread_both_directions() {
     let threaded_first_dir = temp_state_dir("thread-idempotency-threaded-first");
     let threaded_first = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&threaded_first_dir),
@@ -280,7 +275,7 @@ fn idempotency_key_includes_thread_both_directions() {
     assert_eq!(threaded_first.code, 0);
     let unthreaded_second = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&threaded_first_dir),
@@ -303,7 +298,7 @@ fn idempotency_key_includes_thread_both_directions() {
     let unthreaded_first_dir = temp_state_dir("thread-idempotency-unthreaded-first");
     let unthreaded_first = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&unthreaded_first_dir),
@@ -316,7 +311,7 @@ fn idempotency_key_includes_thread_both_directions() {
     assert_eq!(unthreaded_first.code, 0);
     let threaded_second = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&unthreaded_first_dir),
@@ -331,7 +326,7 @@ fn idempotency_key_includes_thread_both_directions() {
     assert_eq!(threaded_second.code, 0);
     let normalized_duplicate = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&unthreaded_first_dir),
@@ -357,7 +352,7 @@ fn idempotency_key_includes_thread_both_directions() {
     let plan_dir = temp_state_dir("thread-plan-idempotency");
     let plan = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&plan_dir),
@@ -421,7 +416,7 @@ fn flag_add_creates_ready_task_and_prints_added_title() {
     let dir = temp_state_dir("flag");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -453,7 +448,7 @@ fn flag_add_existing_trimmed_title_and_scope_is_a_successful_noop() {
     let dir = temp_state_dir("flag-existing");
     let first = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -484,7 +479,7 @@ fn flag_add_existing_trimmed_title_and_scope_is_a_successful_noop() {
 
     let duplicate = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -544,7 +539,7 @@ fn flag_add_ignores_soft_deleted_title_and_scope_matches() {
 
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -568,7 +563,7 @@ fn flag_add_does_not_read_piped_stdin() {
     let dir = temp_state_dir("piped-stdin");
     let output = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dir),
@@ -590,7 +585,7 @@ fn flag_add_keeps_non_whitespace_notes_and_drops_whitespace_notes() {
     let notes_dir = temp_state_dir("notes");
     let notes_output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&notes_dir),
@@ -612,7 +607,7 @@ fn flag_add_keeps_non_whitespace_notes_and_drops_whitespace_notes() {
     let blank_dir = temp_state_dir("blank-notes");
     let blank_output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&blank_dir),
@@ -641,7 +636,7 @@ fn flag_add_resolves_global_and_project_basename_scopes() {
     let global_dir = temp_state_dir("global");
     let global_output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&global_dir),
@@ -675,7 +670,7 @@ fn flag_add_resolves_global_and_project_basename_scopes() {
     store.save(&seeded).expect("save seed");
     let project_output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&project_dir),
@@ -718,7 +713,7 @@ fn flag_add_uses_the_invocation_default_scope() {
 
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -761,7 +756,7 @@ fn flag_add_requires_a_title() {
     let dir = temp_state_dir("missing-title");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -786,7 +781,7 @@ fn flag_add_refuses_empty_and_control_character_titles() {
     let empty_dir = temp_state_dir("empty-title");
     let empty = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&empty_dir),
@@ -806,7 +801,7 @@ fn flag_add_refuses_empty_and_control_character_titles() {
     let invalid_dir = temp_state_dir("invalid-title");
     let invalid = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&invalid_dir),
@@ -827,7 +822,7 @@ fn flag_add_refuses_empty_and_control_character_titles() {
     let end_control_dir = temp_state_dir("end-control-title");
     let end_control = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&end_control_dir),
@@ -848,7 +843,7 @@ fn flag_add_refuses_empty_and_control_character_titles() {
     let whitespace_dir = temp_state_dir("whitespace-title");
     let whitespace = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&whitespace_dir),
@@ -877,7 +872,7 @@ fn flag_add_rejects_global_with_project() {
     let dir = temp_state_dir("global-project");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -907,7 +902,7 @@ fn add_without_item_flags_on_a_tty_is_usage() {
     let dir = temp_state_dir("tty");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -936,7 +931,7 @@ fn mixed_plan_persists_only_valid_items_exits_1() {
     );
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -1003,7 +998,7 @@ fn plan_with_only_existing_tasks_is_a_successful_read_only_noop() {
         let _read_only = ReadOnlyDir::new(&dir);
         run_with(
             [
-                "herdr-tasks",
+                "tsk",
                 "add",
                 "--state-dir",
                 &state_dir_arg(&dir),
@@ -1059,7 +1054,7 @@ fn mixed_plan_exit_1_preserves_created_and_existing_rows_for_failed_only_retry()
 
     let initial = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dir),
@@ -1086,7 +1081,7 @@ fn mixed_plan_exit_1_preserves_created_and_existing_rows_for_failed_only_retry()
 
     let retry = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dir),
@@ -1148,7 +1143,7 @@ fn plan_marks_earlier_accepted_duplicate_as_existing_and_keeps_scopes_distinct()
     let dir = temp_state_dir("plan-duplicate");
     let output = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dir),
@@ -1189,7 +1184,7 @@ fn plan_reads_dash_file_and_piped_stdin_and_allows_empty_array() {
     let dash_dir = temp_state_dir("dash-plan");
     let dash = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dash_dir),
@@ -1211,12 +1206,7 @@ fn plan_reads_dash_file_and_piped_stdin_and_allows_empty_array() {
 
     let piped_dir = temp_state_dir("piped-plan");
     let piped = run_with(
-        [
-            "herdr-tasks",
-            "add",
-            "--state-dir",
-            &state_dir_arg(&piped_dir),
-        ],
+        ["tsk", "add", "--state-dir", &state_dir_arg(&piped_dir)],
         Cursor::new(r#"[{"title":"from pipe"}]"#),
         false,
     );
@@ -1233,7 +1223,7 @@ fn plan_reads_dash_file_and_piped_stdin_and_allows_empty_array() {
     let empty_dir = temp_state_dir("empty-plan");
     let empty = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&empty_dir),
@@ -1265,7 +1255,7 @@ fn plan_usage_errors_persist_nothing_and_do_not_read_mixed_stdin() {
     let object_dir = temp_state_dir("object-plan");
     let object = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&object_dir),
@@ -1279,7 +1269,7 @@ fn plan_usage_errors_persist_nothing_and_do_not_read_mixed_stdin() {
     assert!(object.stdout.is_empty());
     let malformed = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&object_dir),
@@ -1300,7 +1290,7 @@ fn plan_usage_errors_persist_nothing_and_do_not_read_mixed_stdin() {
     let mixed_dir = temp_state_dir("mixed-plan-flags");
     let mixed = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&mixed_dir),
@@ -1340,7 +1330,7 @@ fn plan_projects_and_item_validation_follow_the_contract() {
 
     let output = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dir),
@@ -1409,7 +1399,7 @@ fn plan_project_string_uses_the_shared_basename_resolver() {
 
     let output = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&dir),
@@ -1437,7 +1427,7 @@ fn plan_project_resolution_is_independent_of_item_order() {
     let forward_dir = temp_state_dir("plan-project-order-forward");
     let forward = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&forward_dir),
@@ -1467,7 +1457,7 @@ fn plan_project_resolution_is_independent_of_item_order() {
     let reverse_dir = temp_state_dir("plan-project-order-reverse");
     let reverse = run_with(
         [
-            "herdr-tasks",
+            "tsk",
             "add",
             "--state-dir",
             &state_dir_arg(&reverse_dir),
@@ -1515,7 +1505,7 @@ fn flag_add_rejects_flag_like_item_values_without_persisting() {
     ] {
         let dir = temp_state_dir(label);
         let mut args = vec![
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -1542,7 +1532,7 @@ fn flag_add_equals_forms_allow_dash_leading_values() {
     let dir = temp_state_dir("dash-leading-values");
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&dir),
@@ -1577,8 +1567,8 @@ fn flag_add_equals_state_dir_and_file_forms_accept_dash_leading_values() {
         r#"[{"title":"equals file task","project":null}]"#,
     )
     .expect("write dash-leading plan");
-    let binary = std::env::var("CARGO_BIN_EXE_herdr-tasks")
-        .expect("Cargo must provide the herdr-tasks binary path");
+    let binary =
+        std::env::var("CARGO_BIN_EXE_tsk").expect("Cargo must provide the tsk binary path");
 
     let output = Command::new(binary)
         .current_dir(&cwd)
@@ -1597,7 +1587,7 @@ fn flag_add_equals_state_dir_and_file_forms_accept_dash_leading_values() {
         "equals file task"
     );
 
-    let stdin = parser::parse_flag_add(&["herdr-tasks".into(), "add".into(), "--file=-".into()])
+    let stdin = parser::parse_flag_add(&["tsk".into(), "add".into(), "--file=-".into()])
         .expect("parse stdin file marker");
     assert_eq!(stdin.file, Some(PathBuf::from("-")));
 
@@ -1609,8 +1599,8 @@ fn flag_add_rejects_flag_like_state_dir_and_file_values_without_mutating() {
     let _env = env_lock();
     let cwd = temp_state_dir("flag-like-global-value");
     let state_dir = temp_state_dir("flag-like-global-state");
-    let binary = std::env::var("CARGO_BIN_EXE_herdr-tasks")
-        .expect("Cargo must provide the herdr-tasks binary path");
+    let binary =
+        std::env::var("CARGO_BIN_EXE_tsk").expect("Cargo must provide the tsk binary path");
 
     let state_dir_output = Command::new(&binary)
         .current_dir(&cwd)
@@ -1643,7 +1633,7 @@ fn flag_add_json_reports_created_and_existing_resolved_tasks() {
     let _env = env_lock();
     let dir = temp_state_dir("json");
     let args = [
-        "herdr-tasks".into(),
+        "tsk".into(),
         "add".into(),
         "--json".into(),
         "--state-dir".into(),
@@ -1677,7 +1667,7 @@ fn flag_add_json_reports_created_and_existing_resolved_tasks() {
 
     let global = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--json".into(),
             "--state-dir".into(),
@@ -1705,7 +1695,7 @@ fn add_when_state_dir_is_a_file_exits_3() {
 
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&state_file),
@@ -1733,7 +1723,7 @@ fn state_dir_flag_wins_over_environment() {
 
     let output = add(
         &[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "add".into(),
             "--state-dir".into(),
             state_dir_arg(&argument_dir),

--- a/tests/cli_discovery.rs
+++ b/tests/cli_discovery.rs
@@ -1,18 +1,18 @@
 #[test]
 fn skill_documents_retry_and_misfiling() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let skill = std::fs::read_to_string(root.join("skills/herdr-tasks-cli/SKILL.md"))
+    let skill = std::fs::read_to_string(root.join("skills/tsk-cli/SKILL.md"))
         .expect("CLI skill should exist");
     let agents = std::fs::read_to_string(root.join("AGENTS.md")).expect("AGENTS.md should exist");
 
     for term in [
-        "herdr-tasks add -t",
+        "tsk add -t",
         "--global",
         "--project",
         "--file plan.json",
         "--file=<path>",
         "--state-dir=<dir>",
-        "cat plan.json | herdr-tasks add",
+        "cat plan.json | tsk add",
         "exit 0",
         "exit 1",
         "exit 2",
@@ -30,6 +30,6 @@ fn skill_documents_retry_and_misfiling() {
         skill.contains("typo") && skill.contains("scope"),
         "skill should warn that a typo can create a new scope"
     );
-    assert!(agents.contains("herdr-tasks add"));
-    assert!(agents.contains("herdr-tasks list"));
+    assert!(agents.contains("tsk add"));
+    assert!(agents.contains("tsk list"));
 }

--- a/tests/cli_help.rs
+++ b/tests/cli_help.rs
@@ -1,11 +1,11 @@
 use std::io::Cursor;
 
-use herdr_tasks::cli::run_with;
+use tsk_tui::cli::run_with;
 
 #[test]
 fn add_help_documents_plan_shape_and_exit_contract() {
     let add = run_with(
-        ["herdr-tasks", "add", "--help"],
+        ["tsk", "add", "--help"],
         Cursor::new(Vec::<u8>::new()),
         true,
     );
@@ -28,7 +28,7 @@ fn add_help_documents_plan_shape_and_exit_contract() {
         "indeterminate",
         "list",
         "--json",
-        "herdr-tasks add -t",
+        "tsk add -t",
         "--global",
         "--project",
         "--title=<value>",
@@ -37,7 +37,7 @@ fn add_help_documents_plan_shape_and_exit_contract() {
         "--state-dir=<dir>",
         "--file=<path>",
         "--file plan.json",
-        "cat plan.json | herdr-tasks add",
+        "cat plan.json | tsk add",
     ] {
         assert!(
             add.stdout.contains(term),
@@ -46,7 +46,7 @@ fn add_help_documents_plan_shape_and_exit_contract() {
     }
 
     let list = run_with(
-        ["herdr-tasks", "list", "--help"],
+        ["tsk", "list", "--help"],
         Cursor::new(Vec::<u8>::new()),
         true,
     );

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -5,9 +5,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::cli::run_with;
-use herdr_tasks::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
-use herdr_tasks::store::TaskStore;
+use tsk_tui::cli::run_with;
+use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
+use tsk_tui::store::TaskStore;
 
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -62,7 +62,7 @@ fn temp_state_dir(label: &str) -> PathBuf {
         .expect("clock after epoch")
         .as_nanos();
     let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("herdr-tasks-cli-list-{label}-{nanos}-{seq}"));
+    let dir = std::env::temp_dir().join(format!("tsk-cli-list-{label}-{nanos}-{seq}"));
     std::fs::create_dir_all(&dir).expect("create state directory");
     dir
 }
@@ -77,7 +77,7 @@ fn state_dir_arg(dir: &Path) -> String {
     dir.to_string_lossy().into_owned()
 }
 
-fn list(args: &[String]) -> herdr_tasks::cli::CliOutput {
+fn list(args: &[String]) -> tsk_tui::cli::CliOutput {
     run_with(args, Cursor::new(Vec::<u8>::new()), true)
 }
 
@@ -178,7 +178,7 @@ fn list_defaults_to_invocation_project_open_tasks_in_human_and_json_group_order(
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let human = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--state-dir".into(),
         state_dir_arg(&dir),
@@ -191,7 +191,7 @@ fn list_defaults_to_invocation_project_open_tasks_in_human_and_json_group_order(
     );
 
     let json = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--json".into(),
         "--state-dir".into(),
@@ -244,7 +244,7 @@ fn list_resolves_named_and_global_scopes() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let named = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "-p".into(),
         "widget".into(),
@@ -260,7 +260,7 @@ fn list_resolves_named_and_global_scopes() {
     assert_eq!(named_rows[0]["project"], "/projects/Widget");
 
     let global = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--global".into(),
         "--json".into(),
@@ -326,7 +326,7 @@ fn list_done_and_deleted_filters_are_status_and_soft_delete_specific() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let done = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--done".into(),
         "--state-dir".into(),
@@ -336,7 +336,7 @@ fn list_done_and_deleted_filters_are_status_and_soft_delete_specific() {
     assert_eq!(done.stdout, "DONE\n - done visible\n");
 
     let deleted = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--deleted".into(),
         "--json".into(),
@@ -357,7 +357,7 @@ fn list_done_and_deleted_filters_are_status_and_soft_delete_specific() {
     assert_eq!(deleted_rows[1]["status"], "done");
 
     let deleted_human = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--deleted".into(),
         "--state-dir".into(),
@@ -465,7 +465,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
         .expect("project basename");
 
     let open = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--state-dir".into(),
@@ -480,7 +480,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
     );
 
     let open_json = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--json".into(),
@@ -505,7 +505,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
     );
 
     let done = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--done".into(),
@@ -533,7 +533,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
         );
     }
     let done_human = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--done".into(),
@@ -546,7 +546,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
     );
 
     let deleted = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--deleted".into(),
@@ -565,7 +565,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
         vec!["global deleted", "other deleted"]
     );
     let deleted_human = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--deleted".into(),
@@ -635,7 +635,7 @@ fn list_all_distinguishes_global_from_project_global_and_uses_visible_scope_labe
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--state-dir".into(),
@@ -696,7 +696,7 @@ fn list_all_uses_shortest_unique_trailing_scope_labels_across_statuses() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--state-dir".into(),
@@ -733,7 +733,7 @@ fn list_all_preserves_raw_scope_syntax_after_trailing_segments_are_exhausted() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--state-dir".into(),
@@ -772,7 +772,7 @@ fn list_all_visibly_escapes_and_disambiguates_control_scope_labels() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--state-dir".into(),
@@ -816,7 +816,7 @@ fn human_list_escapes_terminal_control_titles_without_changing_json() {
 
     for view in [vec![], vec!["--done"], vec!["--deleted"]] {
         let mut args = vec![
-            "herdr-tasks".into(),
+            "tsk".into(),
             "list".into(),
             "--global".into(),
             "--state-dir".into(),
@@ -832,7 +832,7 @@ fn human_list_escapes_terminal_control_titles_without_changing_json() {
     }
 
     let json = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--global".into(),
         "--json".into(),
@@ -863,7 +863,7 @@ fn human_list_escapes_terminal_control_thread_markers_without_changing_json() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let human = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--global".into(),
         "--state-dir".into(),
@@ -875,7 +875,7 @@ fn human_list_escapes_terminal_control_thread_markers_without_changing_json() {
     assert!(!human.stdout.contains('\u{0007}'));
 
     let json = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--global".into(),
         "--json".into(),
@@ -901,8 +901,8 @@ fn list_equals_state_dir_form_accepts_dash_leading_value() {
         HumanStatus::Ready,
     );
     TaskStore::new(&state_dir).save(&state).expect("seed state");
-    let binary = std::env::var("CARGO_BIN_EXE_herdr-tasks")
-        .expect("Cargo must provide the herdr-tasks binary path");
+    let binary =
+        std::env::var("CARGO_BIN_EXE_tsk").expect("Cargo must provide the tsk binary path");
 
     let output = std::process::Command::new(binary)
         .current_dir(&cwd)
@@ -942,7 +942,7 @@ fn bare_list_outside_a_repo_falls_back_to_global_scope() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--json".into(),
         "--state-dir".into(),
@@ -966,7 +966,7 @@ fn list_rejects_conflicting_scope_and_filter_flags_and_missing_project_values() 
 
     for args in [
         vec![
-            "herdr-tasks".into(),
+            "tsk".into(),
             "list".into(),
             "--all".into(),
             "--project".into(),
@@ -975,7 +975,7 @@ fn list_rejects_conflicting_scope_and_filter_flags_and_missing_project_values() 
             state_dir_arg(&dir),
         ],
         vec![
-            "herdr-tasks".into(),
+            "tsk".into(),
             "list".into(),
             "--all".into(),
             "--global".into(),
@@ -983,7 +983,7 @@ fn list_rejects_conflicting_scope_and_filter_flags_and_missing_project_values() 
             state_dir_arg(&dir),
         ],
         vec![
-            "herdr-tasks".into(),
+            "tsk".into(),
             "list".into(),
             "--global".into(),
             "--project".into(),
@@ -992,7 +992,7 @@ fn list_rejects_conflicting_scope_and_filter_flags_and_missing_project_values() 
             state_dir_arg(&dir),
         ],
         vec![
-            "herdr-tasks".into(),
+            "tsk".into(),
             "list".into(),
             "--done".into(),
             "--deleted".into(),
@@ -1000,7 +1000,7 @@ fn list_rejects_conflicting_scope_and_filter_flags_and_missing_project_values() 
             state_dir_arg(&dir),
         ],
         vec![
-            "herdr-tasks".into(),
+            "tsk".into(),
             "list".into(),
             "-p".into(),
             "--json".into(),
@@ -1008,7 +1008,7 @@ fn list_rejects_conflicting_scope_and_filter_flags_and_missing_project_values() 
             state_dir_arg(&dir),
         ],
         vec![
-            "herdr-tasks".into(),
+            "tsk".into(),
             "list".into(),
             "-p".into(),
             "-maintenance".into(),
@@ -1019,7 +1019,7 @@ fn list_rejects_conflicting_scope_and_filter_flags_and_missing_project_values() 
         let output = list(&args);
         assert_eq!(output.code, 2);
         assert!(output.stdout.is_empty());
-        assert!(output.stderr.contains("usage: herdr-tasks list"));
+        assert!(output.stderr.contains("usage: tsk list"));
     }
 
     let _ = std::fs::remove_dir_all(dir);
@@ -1031,7 +1031,7 @@ fn list_thread_parse_rejects_invalid_space_and_equals_forms() {
     let dir = temp_state_dir("invalid-thread");
 
     for thread in ["--thread", "--thread=bad_name"] {
-        let mut args = vec!["herdr-tasks".into(), "list".into(), thread.into()];
+        let mut args = vec!["tsk".into(), "list".into(), thread.into()];
         if thread == "--thread" {
             args.push("bad_name".into());
         }
@@ -1061,7 +1061,7 @@ fn list_equals_project_form_accepts_dash_leading_scope() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--project=-maintenance".into(),
         "--json".into(),
@@ -1092,7 +1092,7 @@ fn list_when_state_dir_is_a_file_exits_3() {
     std::fs::write(&state_file, "not a directory").expect("create state-dir file");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--json".into(),
         "--state-dir".into(),
@@ -1134,7 +1134,7 @@ fn list_state_dir_flag_wins_over_environment() {
     let _state_dir = EnvironmentGuard::set("HERDR_PLUGIN_STATE_DIR", &environment_dir);
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--global".into(),
         "--json".into(),
@@ -1168,7 +1168,7 @@ fn list_uses_environment_state_dir_by_default() {
     let _state_dir = EnvironmentGuard::set("HERDR_PLUGIN_STATE_DIR", &dir);
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--global".into(),
         "--json".into(),
@@ -1184,7 +1184,7 @@ fn list_uses_environment_state_dir_by_default() {
 
 /// One task whose steps carry chosen ids `aaa1…`/`aaa2…`, shaped through
 /// the store document because step ids are otherwise minted by the domain.
-fn state_with_steps(done_first: bool) -> (DomainState, herdr_tasks::domain::Step) {
+fn state_with_steps(done_first: bool) -> (DomainState, tsk_tui::domain::Step) {
     let mut state = DomainState::new();
     let id = state
         .create(
@@ -1226,7 +1226,7 @@ fn list_task_prints_step_lines_with_state_and_short_id() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         task.to_string(),
         "--state-dir".into(),
@@ -1246,7 +1246,7 @@ fn list_task_prints_step_lines_with_state_and_short_id() {
     );
 
     let json = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         task.to_string(),
         "--json".into(),
@@ -1295,7 +1295,7 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
     let task = state.tasks()[0].id;
 
     let plain = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         task.to_string(),
         "--state-dir".into(),
@@ -1305,7 +1305,7 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
     assert_eq!(plain.stdout, "READY\n - plain target\n");
 
     let plain_json = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         task.to_string(),
         "--json".into(),
@@ -1328,7 +1328,7 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
 
     for extra in ["--global", "--all", "--done", "--deleted"] {
         let output = list(&[
-            "herdr-tasks".into(),
+            "tsk".into(),
             "list".into(),
             task.to_string(),
             extra.into(),
@@ -1337,10 +1337,10 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
         ]);
         assert_eq!(output.code, 2, "task id with {extra} is usage");
         assert!(output.stdout.is_empty());
-        assert!(output.stderr.contains("usage: herdr-tasks list"));
+        assert!(output.stderr.contains("usage: tsk list"));
     }
     let threaded = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         task.to_string(),
         "--thread".into(),
@@ -1350,10 +1350,10 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
     ]);
     assert_eq!(threaded.code, 2, "task id with --thread is usage");
     assert!(threaded.stdout.is_empty());
-    assert!(threaded.stderr.contains("usage: herdr-tasks list"));
+    assert!(threaded.stderr.contains("usage: tsk list"));
 
     let invalid = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "not-a-uuid".into(),
         "--state-dir".into(),
@@ -1401,7 +1401,7 @@ fn list_thread_filters_after_scope_selection() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let scoped = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--project".into(),
         "selected".into(),
@@ -1423,7 +1423,7 @@ fn list_thread_filters_after_scope_selection() {
     );
 
     let all = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--thread=RELEASE".into(),
@@ -1465,7 +1465,7 @@ fn json_rows_always_carry_thread_field() {
     TaskStore::new(&dir).save(&state).expect("seed store");
 
     let output = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--global".into(),
         "--json".into(),
@@ -1527,7 +1527,7 @@ fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
         .expect("project basename");
 
     let scoped = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--state-dir".into(),
         state_dir_arg(&dir),
@@ -1538,7 +1538,7 @@ fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
     );
 
     let all = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         "--all".into(),
         "--state-dir".into(),
@@ -1552,7 +1552,7 @@ fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
     );
 
     let single = list(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         step.to_string(),
         "--state-dir".into(),

--- a/tests/cli_router_process.rs
+++ b/tests/cli_router_process.rs
@@ -5,14 +5,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::domain::{DomainState, ProvenanceOrigin, TaskScope};
-use herdr_tasks::store::TaskStore;
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::store::TaskStore;
 
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
 fn binary() -> String {
-    std::env::var("CARGO_BIN_EXE_herdr-tasks")
-        .expect("Cargo must provide the herdr-tasks binary path")
+    std::env::var("CARGO_BIN_EXE_tsk").expect("Cargo must provide the tsk binary path")
 }
 
 fn temp_state_dir(label: &str) -> PathBuf {
@@ -21,7 +20,7 @@ fn temp_state_dir(label: &str) -> PathBuf {
         .expect("clock after epoch")
         .as_nanos();
     let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("herdr-tasks-process-{label}-{nanos}-{seq}"));
+    let dir = std::env::temp_dir().join(format!("tsk-process-{label}-{nanos}-{seq}"));
     std::fs::create_dir_all(&dir).expect("create state directory");
     dir
 }
@@ -61,8 +60,8 @@ fn top_level_help_names_subcommands_and_their_help() {
     let stdout = String::from_utf8(output.stdout).expect("UTF-8 help");
     assert!(stdout.contains("add"));
     assert!(stdout.contains("list"));
-    assert!(stdout.contains("herdr-tasks add --help"));
-    assert!(stdout.contains("herdr-tasks list --help"));
+    assert!(stdout.contains("tsk add --help"));
+    assert!(stdout.contains("tsk list --help"));
 }
 
 #[test]
@@ -150,7 +149,7 @@ fn unknown_positional_exits_2_without_opening_the_board() {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn herdr-tasks foo");
+        .expect("spawn tsk foo");
     let deadline = Instant::now() + Duration::from_secs(2);
     let status = loop {
         if let Some(status) = child.try_wait().expect("poll child process") {

--- a/tests/cli_steps.rs
+++ b/tests/cli_steps.rs
@@ -3,9 +3,9 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::cli::run_with;
-use herdr_tasks::domain::{DomainState, ProvenanceOrigin, TaskScope};
-use herdr_tasks::store::TaskStore;
+use tsk_tui::cli::run_with;
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::store::TaskStore;
 use uuid::Uuid;
 
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -16,7 +16,7 @@ fn temp_state_dir(label: &str) -> PathBuf {
         .expect("clock after epoch")
         .as_nanos();
     let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("herdr-tasks-cli-steps-{label}-{nanos}-{seq}"));
+    let dir = std::env::temp_dir().join(format!("tsk-cli-steps-{label}-{nanos}-{seq}"));
     std::fs::create_dir_all(&dir).expect("create state directory");
     dir
 }
@@ -25,7 +25,7 @@ fn state_dir_arg(dir: &std::path::Path) -> String {
     dir.to_string_lossy().into_owned()
 }
 
-fn steps(args: &[String]) -> herdr_tasks::cli::CliOutput {
+fn steps(args: &[String]) -> tsk_tui::cli::CliOutput {
     run_with(args, Cursor::new(Vec::<u8>::new()), true)
 }
 
@@ -47,7 +47,7 @@ fn seed_task(dir: &std::path::Path, title: &str) -> Uuid {
 
 fn steps_args(dir: &std::path::Path, task: Uuid) -> Vec<String> {
     vec![
-        "herdr-tasks".into(),
+        "tsk".into(),
         "steps".into(),
         task.to_string(),
         "--state-dir".into(),
@@ -97,7 +97,7 @@ fn steps_add_then_toggle_round_trips_step_state() {
     assert_eq!(add_second.code, 0, "add second step: {}", add_second.stderr);
 
     let listed = steps(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         task.to_string(),
         "--state-dir".into(),
@@ -121,7 +121,7 @@ fn steps_add_then_toggle_round_trips_step_state() {
     assert_eq!(toggle.code, 0, "toggle by short id: {}", toggle.stderr);
 
     let after_toggle = steps(&[
-        "herdr-tasks".into(),
+        "tsk".into(),
         "list".into(),
         task.to_string(),
         "--state-dir".into(),
@@ -346,11 +346,11 @@ fn steps_on_soft_deleted_task_refuses_without_mutation() {
 
 #[test]
 fn steps_help_documents_toggle_flip_and_verify_guidance() {
-    let output = steps(&["herdr-tasks".into(), "steps".into(), "--help".into()]);
+    let output = steps(&["tsk".into(), "steps".into(), "--help".into()]);
     assert_eq!(output.code, 0, "{}", output.stderr);
     assert!(output.stderr.is_empty());
     for term in [
-        "usage: herdr-tasks steps",
+        "usage: tsk steps",
         "toggle",
         "flips",
         "verify",

--- a/tests/domain_agent_meta.rs
+++ b/tests/domain_agent_meta.rs
@@ -7,8 +7,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use herdr_tasks::attention::ObservationMap;
-use herdr_tasks::domain::{
+use tsk_tui::attention::ObservationMap;
+use tsk_tui::domain::{
     AgentMeta, AgentSessionIdentity, ContextCapsule, DomainState, HumanStatus, ObservedStatus,
     ProvenanceOrigin, TaskEventKind, TaskScope,
 };

--- a/tests/e2e_persist.rs
+++ b/tests/e2e_persist.rs
@@ -2,8 +2,8 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use herdr_tasks::domain::{DomainState, ProvenanceOrigin, TaskScope};
-use herdr_tasks::store::TaskStore;
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::store::TaskStore;
 
 fn temp_state_dir() -> std::path::PathBuf {
     static SEQ: AtomicUsize = AtomicUsize::new(0);
@@ -12,7 +12,7 @@ fn temp_state_dir() -> std::path::PathBuf {
         .duration_since(std::time::UNIX_EPOCH)
         .expect("clock after epoch")
         .as_nanos();
-    let dir = std::env::temp_dir().join(format!("herdr-tasks-e2e-persist-{nanos}-{seq}"));
+    let dir = std::env::temp_dir().join(format!("tsk-e2e-persist-{nanos}-{seq}"));
     std::fs::create_dir_all(&dir).expect("create state directory");
     dir
 }

--- a/tests/edit_target_binding.rs
+++ b/tests/edit_target_binding.rs
@@ -24,16 +24,16 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::app::{
+use tsk_tui::app::{
     apply_board_intent_with_save_recovery, confirm_edit_refusal_against_the_record,
     refresh_before_mutation, run_attention_cycle, BoardSaveContext,
 };
-use herdr_tasks::domain::{DomainError, DomainState, ProvenanceOrigin, TaskScope};
-use herdr_tasks::host::HostPorts;
-use herdr_tasks::save_recovery::SaveRecovery;
-use herdr_tasks::store::TaskStore;
-use herdr_tasks::ui::board::{apply_intent, BoardInputMode, BoardModel, IntentOutcome};
-use herdr_tasks::ui::input::{map_key, BoardIntent};
+use tsk_tui::domain::{DomainError, DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::host::HostPorts;
+use tsk_tui::save_recovery::SaveRecovery;
+use tsk_tui::store::TaskStore;
+use tsk_tui::ui::board::{apply_intent, BoardInputMode, BoardModel, IntentOutcome};
+use tsk_tui::ui::input::{map_key, BoardIntent};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -52,9 +52,7 @@ fn temp_state_dir(tag: &str) -> PathBuf {
         .as_nanos();
     static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!(
-        "herdr-tasks-edit-target-binding-{tag}-{nanos}-{seq}"
-    ));
+    let dir = std::env::temp_dir().join(format!("tsk-edit-target-binding-{tag}-{nanos}-{seq}"));
     fs::create_dir_all(&dir).expect("create temp state dir");
     dir
 }
@@ -1160,7 +1158,7 @@ fn background_sync_cannot_redirect_a_bound_task_form_while_its_scope_dropdown_is
 
     // The same refresh shape the idle loop uses: Bravo moves ahead in queue order.
     domain
-        .set_status(bravo, herdr_tasks::domain::HumanStatus::Started)
+        .set_status(bravo, tsk_tui::domain::HumanStatus::Started)
         .expect("move Bravo");
     model.sync_from_domain(&domain);
     assert_eq!(model.edit_target(), Some(alpha));

--- a/tests/f6_dispatch_recovery.rs
+++ b/tests/f6_dispatch_recovery.rs
@@ -5,17 +5,17 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::dispatch::{
+use tsk_tui::dispatch::{
     cleanup_dispatch_attempt, resume_dispatch_attempt, start_dispatch_attempt, DispatchMode,
     DispatchRecoveryAction, DispatchRecoveryResult,
 };
-use herdr_tasks::domain::{
+use tsk_tui::domain::{
     AgentReceipt, AgentSessionIdentity, DispatchAttemptPhase, DomainState, PaneReceipt,
     ProvenanceOrigin, TaskEventKind, TaskScope, WorktreeReceipt,
 };
-use herdr_tasks::host::HostPorts;
-use herdr_tasks::store::{StoreError, TaskStateStore, TaskStore};
-use herdr_tasks::ui::board::{apply_dispatch_recovery_result, BoardInputMode, BoardModel};
+use tsk_tui::host::HostPorts;
+use tsk_tui::store::{StoreError, TaskStateStore, TaskStore};
+use tsk_tui::ui::board::{apply_dispatch_recovery_result, BoardInputMode, BoardModel};
 
 fn temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -24,7 +24,7 @@ fn temp_dir(label: &str) -> PathBuf {
         .as_nanos();
     static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("herdr-tasks-f6-{label}-{nanos}-{seq}"));
+    let dir = std::env::temp_dir().join(format!("tsk-f6-{label}-{nanos}-{seq}"));
     fs::create_dir_all(&dir).unwrap();
     dir
 }
@@ -272,19 +272,15 @@ impl TaskStateStore for ConcurrentBoardMutationStore {
 fn durable_dispatching_attempt(store: &TaskStore, task_id: uuid::Uuid) -> uuid::Uuid {
     let mut state = store.load().unwrap();
     let attempt_id = state
-        .start_dispatch_attempt(
-            task_id,
-            herdr_tasks::domain::DispatchAttemptMode::Here,
-            "grok",
-        )
+        .start_dispatch_attempt(task_id, tsk_tui::domain::DispatchAttemptMode::Here, "grok")
         .unwrap();
     let revision = state.active_attempt(attempt_id).unwrap().revision();
     state
         .transition_dispatch_attempt(
             attempt_id,
             revision,
-            herdr_tasks::domain::DispatchAttemptTransition::RecordReceipt(
-                herdr_tasks::domain::OwnedResourceReceipt::Pane(PaneReceipt {
+            tsk_tui::domain::DispatchAttemptTransition::RecordReceipt(
+                tsk_tui::domain::OwnedResourceReceipt::Pane(PaneReceipt {
                     pane_id: "pane-owned".into(),
                 }),
             ),
@@ -758,11 +754,11 @@ fn cleanup_persistence_failure_after_pane_removal_stops_before_later_resources()
     assert!(attempt
         .owned_resources()
         .iter()
-        .any(|receipt| matches!(receipt, herdr_tasks::domain::OwnedResourceReceipt::Pane(_))));
-    assert!(attempt.owned_resources().iter().any(|receipt| matches!(
-        receipt,
-        herdr_tasks::domain::OwnedResourceReceipt::Worktree(_)
-    )));
+        .any(|receipt| matches!(receipt, tsk_tui::domain::OwnedResourceReceipt::Pane(_))));
+    assert!(attempt
+        .owned_resources()
+        .iter()
+        .any(|receipt| matches!(receipt, tsk_tui::domain::OwnedResourceReceipt::Worktree(_))));
 }
 
 #[test]
@@ -963,11 +959,7 @@ fn persisted_dispatch_attempt_resurfaces_recovery_after_worker_error() {
         )
         .expect("create task");
     let attempt_id = domain
-        .start_dispatch_attempt(
-            task_id,
-            herdr_tasks::domain::DispatchAttemptMode::Here,
-            "grok",
-        )
+        .start_dispatch_attempt(task_id, tsk_tui::domain::DispatchAttemptMode::Here, "grok")
         .expect("start durable attempt");
     let mut model = BoardModel::from_domain(&domain, None);
     assert_eq!(model.input_mode(), BoardInputMode::Recovery);

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -3,31 +3,29 @@
 use std::fs;
 use std::path::PathBuf;
 
-use herdr_tasks::context::InvocationSnapshot;
-use herdr_tasks::store::TaskStore;
-use herdr_tasks::ui::capture::{
+use tsk_tui::context::InvocationSnapshot;
+use tsk_tui::store::TaskStore;
+use tsk_tui::ui::capture::{
     apply_capture_intent, CaptureField, CaptureModel, CaptureOutcome, CaptureScopeChoice,
 };
-use herdr_tasks::ui::input::{map_capture_key_state, CaptureIntent};
-use herdr_tasks::ui::mouse::{
-    capture_layout_for_model, capture_recovery_layout, map_capture_mouse,
-};
+use tsk_tui::ui::input::{map_capture_key_state, CaptureIntent};
+use tsk_tui::ui::mouse::{capture_layout_for_model, capture_recovery_layout, map_capture_mouse};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use herdr_tasks::app::{apply_board_intent_with_save_recovery, BoardSaveContext};
-use herdr_tasks::domain::{DomainError, DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
-use herdr_tasks::save_recovery::SaveRecovery;
-use herdr_tasks::ui::board::{
-    apply_intent, board_hit_map, draw_board, resolve_board_command, BoardInputMode, BoardModel,
-    CommandSurface, IntentOutcome,
-};
-use herdr_tasks::ui::capture::draw_capture;
-use herdr_tasks::ui::input::{map_key, BoardIntent};
-use herdr_tasks::ui::mouse::{left_click, map_board_mouse, BoardPopup};
-use herdr_tasks::ui::render::QueueHitTarget;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 use ratatui::Terminal;
+use tsk_tui::app::{apply_board_intent_with_save_recovery, BoardSaveContext};
+use tsk_tui::domain::{DomainError, DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
+use tsk_tui::save_recovery::SaveRecovery;
+use tsk_tui::ui::board::{
+    apply_intent, board_hit_map, draw_board, resolve_board_command, BoardInputMode, BoardModel,
+    CommandSurface, IntentOutcome,
+};
+use tsk_tui::ui::capture::draw_capture;
+use tsk_tui::ui::input::{map_key, BoardIntent};
+use tsk_tui::ui::mouse::{left_click, map_board_mouse, BoardPopup};
+use tsk_tui::ui::render::QueueHitTarget;
 
 /// Capture areas: roomy, and narrow enough for the compact scope controls.
 const WIDE_CAPTURE: (u16, u16) = (80, 16);
@@ -68,10 +66,7 @@ fn capture_snapshot() -> InvocationSnapshot {
 }
 
 fn bad_store_path() -> (PathBuf, PathBuf) {
-    let root = std::env::temp_dir().join(format!(
-        "herdr-tasks-capture-recovery-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let root = std::env::temp_dir().join(format!("tsk-capture-recovery-{}", uuid::Uuid::new_v4()));
     fs::create_dir_all(&root).expect("create temp root");
     let file = root.join("not-a-directory");
     fs::write(&file, "not a state directory").expect("create blocking file");

--- a/tests/fixtures/queue_board/accordion.txt
+++ b/tests/fixtures/queue_board/accordion.txt
@@ -3,13 +3,13 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                               herdr-tasks · 3m │
+│  ▸ Smoke-test worktree dispatch                                       tsk · 3m │
 │    │ no notes yet                                                              │
-│    │ scope herdr-tasks                                                         │
+│    │ scope tsk                                                                 │
 │    │ created 3m ago · updated 3m ago                                           │
 │  ▸ Edit target binding pin                                         herdr · 12m │
 │                                                                                │
-│ herdr-tasks ─────────────────────────────────────────────────────────────────2 │
+│ tsk ─────────────────────────────────────────────────────────────────────────2 │
 │                                                                                │
 │  ○ Prototype the queue-style board UI                                       1h │
 │  ○ Cut rust-toolchain pin into CI docs                                      1d │

--- a/tests/fixtures/queue_board/board.txt
+++ b/tests/fixtures/queue_board/board.txt
@@ -3,10 +3,10 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                               herdr-tasks · 3m │
+│  ▸ Smoke-test worktree dispatch                                       tsk · 3m │
 │  ▸ Edit target binding pin                                         herdr · 12m │
 │                                                                                │
-│ herdr-tasks ─────────────────────────────────────────────────────────────────2 │
+│ tsk ─────────────────────────────────────────────────────────────────────────2 │
 │                                                                                │
 │  ○ Prototype the queue-style board UI                                       1h │
 │  ○ Cut rust-toolchain pin into CI docs                                      1d │

--- a/tests/fixtures/queue_board/board_default_split_78.txt
+++ b/tests/fixtures/queue_board/board_default_split_78.txt
@@ -3,10 +3,10 @@
 │                                                                              │
 │ IN MOTION ─────────────────────────────────────────────────────────────────2 │
 │                                                                              │
-│  ▸ Smoke-test worktree dispatch                             herdr-tasks · 3m │
+│  ▸ Smoke-test worktree dispatch                                     tsk · 3m │
 │  ▸ Edit target binding pin                                       herdr · 12m │
 │                                                                              │
-│ herdr-tasks ───────────────────────────────────────────────────────────────2 │
+│ tsk ───────────────────────────────────────────────────────────────────────2 │
 │                                                                              │
 │  ○ Prototype the queue-style board UI                                     1h │
 │  ○ Cut rust-toolchain pin into CI docs                                    1d │

--- a/tests/fixtures/queue_board/done_drawer.txt
+++ b/tests/fixtures/queue_board/done_drawer.txt
@@ -3,10 +3,10 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                               herdr-tasks · 3m │
+│  ▸ Smoke-test worktree dispatch                                       tsk · 3m │
 │  ▸ Edit target binding pin                                         herdr · 12m │
 │                                                                                │
-│ herdr-tasks ─────────────────────────────────────────────────────────────────2 │
+│ tsk ─────────────────────────────────────────────────────────────────────────2 │
 │                                                                                │
 │  ○ Prototype the queue-style board UI                                       1h │
 │  ○ Cut rust-toolchain pin into CI docs                                      1d │

--- a/tests/fixtures/queue_board/palette.txt
+++ b/tests/fixtures/queue_board/palette.txt
@@ -3,10 +3,10 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                               herdr-tasks · 3m │
+│  ▸ Smoke-test worktree dispatch                                       tsk · 3m │
 │  ▸ Edit target binding pin                                         herdr · 12m │
 │                                                                                │
-│ herdr-tasks ─────────────────────────────────────────────────────────────────2 │
+│ tsk ─────────────────────────────────────────────────────────────────────────2 │
 │                                                                                │
 │  ○ Prototype the queue-style board UI                                       1h │
 │  ○ Cut rust-toolchain pin into CI docs                                      1d │

--- a/tests/host_scripts.rs
+++ b/tests/host_scripts.rs
@@ -138,11 +138,11 @@ fn open_board_has_idempotent_focus_list_logic() {
     );
     assert!(
         active.contains("--find-board-pane"),
-        "open-board must pipe pane list through herdr-tasks --find-board-pane (no python3)"
+        "open-board must pipe pane list through tsk --find-board-pane (no python3)"
     );
     assert!(
-        active.contains("target/release/herdr-tasks") || active.contains("HERDR_TASKS_BIN"),
-        "open-board must locate plugin binary relative to script (or HERDR_TASKS_BIN)"
+        active.contains("target/release/tsk") || active.contains("TSK_BIN"),
+        "open-board must locate plugin binary relative to script (or TSK_BIN)"
     );
 
     // No bare python3 dependency for focus logic.
@@ -170,7 +170,7 @@ fn open_capture_uses_herdr_cli_and_capture_path() {
         "open-capture must open capture mode or a popup/overlay surface"
     );
     assert!(
-        text.contains("herdr-tasks") || text.contains("board"),
+        text.contains("tsk") || text.contains("board"),
         "open-capture must target this plugin / board entrypoint"
     );
 }

--- a/tests/host_scripts.rs
+++ b/tests/host_scripts.rs
@@ -3,9 +3,11 @@
 //! (no live herdr). Manual: second open-board focuses the same Tasks board.
 
 use std::fs;
+
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tsk_tui::app::MODE_ENV;
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -112,8 +114,8 @@ fn open_board_uses_herdr_cli_and_board_entrypoint() {
         "open-board must reference the board entrypoint id"
     );
     assert!(
-        text.contains("Tasks"),
-        "open-board must reference the Tasks board title/label"
+        text.contains("tsk"),
+        "open-board must reference the tsk board title/label"
     );
     assert!(
         text.contains("split"),
@@ -172,6 +174,20 @@ fn open_capture_uses_herdr_cli_and_capture_path() {
     assert!(
         text.contains("tsk") || text.contains("board"),
         "open-capture must target this plugin / board entrypoint"
+    );
+}
+
+#[test]
+fn quick_capture_injects_the_mode_env_var_the_binary_reads() {
+    let text = read(&open_capture_path());
+    assert!(
+        text.contains(&format!("--env {}=capture", MODE_ENV)),
+        "open-capture must inject --env {MODE_ENV}=capture: the binary reads \
+         app::MODE_ENV, and any other variable name silently opens the full board instead"
+    );
+    assert!(
+        !text.contains("HERDR_TASKS_"),
+        "open-capture must not carry legacy HERDR_TASKS_* variable names"
     );
 }
 

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -3,6 +3,8 @@
 use std::fs;
 use std::path::PathBuf;
 
+use tsk_tui::board_pane::BOARD_PANE_LABEL;
+
 fn manifest_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("herdr-plugin.toml")
 }
@@ -49,10 +51,15 @@ fn platforms_include_linux_and_macos() {
 }
 
 #[test]
-fn panes_entry_has_tasks_title_and_split_placement() {
+fn panes_entry_has_board_pane_label_title_and_split_placement() {
     let text = read_manifest();
     assert!(text.contains("[[panes]]"), "must declare a [[panes]] entry");
-    assert!(text.contains("Tasks"), "pane title must contain Tasks");
+    assert!(
+        text.contains(&format!(r#"title = "{BOARD_PANE_LABEL}""#)),
+        "pane title must equal board_pane::BOARD_PANE_LABEL ({BOARD_PANE_LABEL:?}): the host \
+         labels the pane from this manifest title, and open-board focus plus host pane \
+         classification match on that label"
+    );
     assert!(
         text.contains(r#"placement = "split""#),
         "pane placement must be split"

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -22,11 +22,11 @@ fn table_section<'a>(text: &'a str, header: &str) -> &'a str {
 }
 
 #[test]
-fn id_contains_tasks_product_id() {
+fn id_keeps_the_herdr_tasks_plugin_id() {
     let text = read_manifest();
     assert!(
         text.contains(r#"id = "herdr-tasks""#),
-        "manifest id must be the tasks product id herdr-tasks"
+        "manifest id must stay herdr-tasks: the host keys injected state dirs and links by it"
     );
 }
 
@@ -80,12 +80,12 @@ fn actions_include_quick_capture() {
 }
 
 #[test]
-fn pane_command_references_herdr_tasks_binary() {
+fn pane_command_references_tsk_tui_binary() {
     let text = read_manifest();
     let panes = table_section(&text, "[[panes]]");
     assert!(
-        panes.contains(r#"command = ["./target/release/herdr-tasks"]"#),
-        "pane command must reference the release binary ./target/release/herdr-tasks \
+        panes.contains(r#"command = ["./target/release/tsk"]"#),
+        "pane command must reference the release binary ./target/release/tsk \
          (not merely the product id elsewhere in the file)"
     );
 }

--- a/tests/queue_board_bench.rs
+++ b/tests/queue_board_bench.rs
@@ -42,12 +42,12 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use herdr_tasks::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
-use herdr_tasks::ui::{apply_intent, draw_board, BoardIntent, BoardModel};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
+use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
+use tsk_tui::ui::{apply_intent, draw_board, BoardIntent, BoardModel};
 
-const THIS_REPO: &str = "/repos/herdr-tasks";
+const THIS_REPO: &str = "/repos/tsk";
 const TASK_COUNT: usize = 100;
 const WIDTH: u16 = 80;
 const HEIGHT: u16 = 24;
@@ -240,7 +240,7 @@ fn keypress_to_repaint_p99_under_16ms_during_navigation_at_80x24_with_100_tasks(
     let has_section = ["IN MOTION", "ON DECK", "DONE"]
         .iter()
         .any(|header| plain.contains(header))
-        || ["herdr-tasks", "herdr", "alpha", "beta", "global"]
+        || ["tsk", "herdr", "alpha", "beta", "global"]
             .iter()
             .any(|name| plain.contains(&format!("{name} ─")));
     assert!(

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -3,16 +3,16 @@
 use std::path::PathBuf;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use herdr_tasks::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
-use herdr_tasks::ui::board::{
-    apply_intent, board_hit_map, draw_board, BoardInputMode, BoardModel, IntentOutcome,
-};
-use herdr_tasks::ui::capture::CaptureField;
-use herdr_tasks::ui::input::{map_board_form_key, BoardIntent};
-use herdr_tasks::ui::render::QueueHitTarget;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 use ratatui::Terminal;
+use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
+use tsk_tui::ui::board::{
+    apply_intent, board_hit_map, draw_board, BoardInputMode, BoardModel, IntentOutcome,
+};
+use tsk_tui::ui::capture::CaptureField;
+use tsk_tui::ui::input::{map_board_form_key, BoardIntent};
+use tsk_tui::ui::render::QueueHitTarget;
 
 const THIS_REPO: &str = "/repos/app";
 
@@ -631,7 +631,7 @@ fn task_page_scope_dropdown_sits_above_the_footer_with_short_names() {
             "scoped task",
             None,
             TaskScope::Project {
-                path: "/repos/herdr-tasks".into(),
+                path: "/repos/tsk".into(),
             },
             None,
             None,
@@ -650,10 +650,7 @@ fn task_page_scope_dropdown_sits_above_the_footer_with_short_names() {
             ProvenanceOrigin::Manual,
         )
         .expect("create second project");
-    let mut model = BoardModel::from_domain(
-        &domain,
-        Some(std::path::PathBuf::from("/repos/herdr-tasks")),
-    );
+    let mut model = BoardModel::from_domain(&domain, Some(std::path::PathBuf::from("/repos/tsk")));
     apply_intent(
         &mut domain,
         &mut model,
@@ -688,7 +685,7 @@ fn task_page_scope_dropdown_sits_above_the_footer_with_short_names() {
     let option_rows: Vec<(usize, &String)> = rows[..footer_y]
         .iter()
         .enumerate()
-        .filter(|(_, row)| row.contains("herdr-tasks") || row.contains("other-project"))
+        .filter(|(_, row)| row.contains("tsk") || row.contains("other-project"))
         .collect();
     assert!(
         !option_rows.is_empty(),

--- a/tests/queue_board_loop.rs
+++ b/tests/queue_board_loop.rs
@@ -8,12 +8,12 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::app::{board_frame, board_poll_duration, load_board_model, FramePoll};
-use herdr_tasks::domain::DomainState;
-use herdr_tasks::ui::scheduler::{next_wait, DEFAULT_BASE_TICK};
-use herdr_tasks::ui::{draw_board, BoardModel};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
+use tsk_tui::app::{board_frame, board_poll_duration, load_board_model, FramePoll};
+use tsk_tui::domain::DomainState;
+use tsk_tui::ui::scheduler::{next_wait, DEFAULT_BASE_TICK};
+use tsk_tui::ui::{draw_board, BoardModel};
 
 /// A directory this test owns alone, removed on drop even if the test panics.
 struct TempDirGuard(PathBuf);
@@ -55,9 +55,7 @@ fn temp_state_dir(label: &str) -> PathBuf {
         .expect("clock after epoch")
         .as_nanos();
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-    let dir = env::temp_dir().join(format!(
-        "herdr-tasks-queue-board-loop-{label}-{nanos}-{seq}"
-    ));
+    let dir = env::temp_dir().join(format!("tsk-queue-board-loop-{label}-{nanos}-{seq}"));
     fs::create_dir_all(&dir).expect("create temp state dir");
     dir
 }

--- a/tests/queue_board_model.rs
+++ b/tests/queue_board_model.rs
@@ -4,15 +4,15 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::domain::{
-    DomainState, HumanStatus, ProvenanceOrigin, Task, TaskEvent, TaskEventKind, TaskScope,
-};
-use herdr_tasks::store::TaskStore;
-use herdr_tasks::ui::board::{apply_intent, draw_board, BoardModel, ProjectScopeOption};
-use herdr_tasks::ui::input::BoardIntent;
-use herdr_tasks::ui::queue::{query, DeckScope, SectionKind};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
+use tsk_tui::domain::{
+    DomainState, HumanStatus, ProvenanceOrigin, Task, TaskEvent, TaskEventKind, TaskScope,
+};
+use tsk_tui::store::TaskStore;
+use tsk_tui::ui::board::{apply_intent, draw_board, BoardModel, ProjectScopeOption};
+use tsk_tui::ui::input::BoardIntent;
+use tsk_tui::ui::queue::{query, DeckScope, SectionKind};
 use uuid::Uuid;
 
 const THIS_REPO: &str = "/repos/app";
@@ -66,7 +66,7 @@ fn threaded_task(
     task
 }
 
-fn on_deck(view: &herdr_tasks::ui::queue::QueueView) -> &herdr_tasks::ui::queue::QueueSection {
+fn on_deck(view: &tsk_tui::ui::queue::QueueView) -> &tsk_tui::ui::queue::QueueSection {
     view.sections
         .iter()
         .find(|section| section.kind == SectionKind::OnDeck)
@@ -80,8 +80,7 @@ fn temp_dir(tag: &str) -> PathBuf {
         .as_nanos();
     static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let dir =
-        std::env::temp_dir().join(format!("herdr-tasks-queue-board-model-{tag}-{nanos}-{seq}"));
+    let dir = std::env::temp_dir().join(format!("tsk-queue-board-model-{tag}-{nanos}-{seq}"));
     fs::create_dir_all(&dir).expect("temp dir");
     dir
 }

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -13,21 +13,21 @@ use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 use ratatui::Terminal;
 
-use herdr_tasks::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
-use herdr_tasks::ui::board::{
+use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
+use tsk_tui::ui::board::{
     apply_intent, board_hit_map, board_verb_items, draw_board, resolve_board_command,
     BoardInputMode, BoardModel,
 };
-use herdr_tasks::ui::capture::CaptureField;
-use herdr_tasks::ui::input::{
+use tsk_tui::ui::capture::CaptureField;
+use tsk_tui::ui::input::{
     map_board_form_key, map_capture_key_state, map_capture_paste_state, map_key, BoardIntent,
     CaptureIntent, PRIMARY_CAPTURE_ACTIONS,
 };
-use herdr_tasks::ui::mouse::{
+use tsk_tui::ui::mouse::{
     capture_layout, capture_mouse_paths_complete, left_click, map_board_mouse, map_capture_mouse,
     primary_capture_action_sample_mouse,
 };
-use herdr_tasks::ui::render::{QueueHit, QueueHitMap, QueueHitTarget};
+use tsk_tui::ui::render::{QueueHit, QueueHitMap, QueueHitTarget};
 
 const THIS_REPO: &str = "/repos/app";
 const OTHER_REPO: &str = "/repos/other";
@@ -780,8 +780,7 @@ fn click_and_wheel_match_keyboard_effects_for_each_control() {
         .project_options()
         .iter()
         .position(|option| {
-            *option
-                == herdr_tasks::ui::board::ProjectScopeOption::Project(PathBuf::from(OTHER_REPO))
+            *option == tsk_tui::ui::board::ProjectScopeOption::Project(PathBuf::from(OTHER_REPO))
         })
         .expect("the other repo is an offered option");
     assert!(
@@ -1043,7 +1042,7 @@ fn click_a_task_row_selects_its_index_on_a_scrolled_list() {
     assert_eq!(model.detail_open(), Some(visible[last]));
 
     let hits = board_hit_map(STANDARD, &model);
-    let geo = herdr_tasks::ui::tier::resolve(STANDARD.width, STANDARD.height);
+    let geo = tsk_tui::ui::tier::resolve(STANDARD.width, STANDARD.height);
     assert!(
         hits.regions
             .iter()

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -5,22 +5,22 @@ use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use herdr_tasks::config::VerbModifier;
-use herdr_tasks::domain::{
+use ratatui::backend::TestBackend;
+use ratatui::{Frame, Terminal};
+use tsk_tui::config::VerbModifier;
+use tsk_tui::domain::{
     DomainState, HumanStatus, ProvenanceOrigin, Task, TaskEvent, TaskEventKind, TaskScope,
 };
-use herdr_tasks::ui::input::map_key;
-use herdr_tasks::ui::queue::{self, DeckScope, QueueView};
-use herdr_tasks::ui::render::{
+use tsk_tui::ui::input::map_key;
+use tsk_tui::ui::queue::{self, DeckScope, QueueView};
+use tsk_tui::ui::render::{
     assert_buffer_mono, assert_no_color_sgr, draw_queue_frame, BottomInputSlot, PaletteCommandRow,
     QueueFrameModel, QueueOverlay, VerbEntry,
 };
-use herdr_tasks::ui::tier::{self, Tier, TierGeometry};
-use herdr_tasks::ui::{
+use tsk_tui::ui::tier::{self, Tier, TierGeometry};
+use tsk_tui::ui::{
     apply_intent, board_verb_items, draw_board, BoardInputMode, BoardIntent, BoardModel,
 };
-use ratatui::backend::TestBackend;
-use ratatui::{Frame, Terminal};
 use uuid::Uuid;
 
 /// Fixed "now" for deterministic age labels in the fixture.
@@ -75,7 +75,7 @@ fn fixture_tasks() -> Vec<Task> {
             1,
             "Smoke-test worktree dispatch",
             HumanStatus::Started,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             3 * 60,
         ),
         task(
@@ -89,14 +89,14 @@ fn fixture_tasks() -> Vec<Task> {
             10,
             "Prototype the queue-style board UI",
             HumanStatus::Ready,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             3600,
         ),
         task(
             11,
             "Cut rust-toolchain pin into CI docs",
             HumanStatus::Ready,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             86400,
         ),
         task(
@@ -124,7 +124,7 @@ fn fixture_tasks() -> Vec<Task> {
             40,
             "Ship the queue board milestone",
             HumanStatus::Done,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             5 * 3600,
         ),
         task(
@@ -141,7 +141,7 @@ fn fixture_tasks() -> Vec<Task> {
 /// task 1 ("Smoke-test worktree dispatch", Doing) [`fixture_model`] hardcodes as its
 /// selection.
 fn base_board_model() -> BoardModel {
-    let model = BoardModel::from_tasks(fixture_tasks(), Some(PathBuf::from("/repos/herdr-tasks")));
+    let model = BoardModel::from_tasks(fixture_tasks(), Some(PathBuf::from("/repos/tsk")));
     assert_eq!(
         model.selected_id(),
         Some(Uuid::from_u128(1)),
@@ -290,7 +290,7 @@ fn palette_commands() -> Vec<PaletteCommandRow<'static>> {
 fn fixture_view(tasks: &[Task], drawer_open: bool) -> QueueView {
     queue::query(
         tasks,
-        Some(Path::new("/repos/herdr-tasks")),
+        Some(Path::new("/repos/tsk")),
         DeckScope::All,
         drawer_open,
     )
@@ -404,7 +404,7 @@ fn standard_78x24_fixture_has_selector_list_rule_status_verb_and_no_other_chrome
         "list must include IN MOTION header:\n{list}"
     );
     assert!(
-        list.contains("herdr-tasks") && list.contains("global"),
+        list.contains("tsk") && list.contains("global"),
         "list must include project group headers:\n{list}"
     );
     assert!(
@@ -548,7 +548,7 @@ fn every_section_header_has_symmetric_spacing_and_scrolls_with_its_selected_task
             "Smoke-test worktree dispatch",
         ),
         (
-            "herdr-tasks",
+            "tsk",
             Uuid::from_u128(10),
             "Prototype the queue-style board UI",
         ),
@@ -879,7 +879,7 @@ fn task_page_renders_header_notes_and_meta_as_a_full_takeover_in_both_tiers() {
         step_scroll: 0,
         step_marked: None,
         step_editor: None,
-        meta: "herdr-tasks \u{b7} created 1h ago \u{b7} updated 1h ago".to_string(),
+        meta: "tsk \u{b7} created 1h ago \u{b7} updated 1h ago".to_string(),
         meta_scope_width: 11,
         thread_slot_width: None,
         focus: None,
@@ -1593,7 +1593,7 @@ fn standard_accordion_expands_full_width_under_selection_without_mutating_domain
         .map(|r| trimmed(r))
         .collect::<Vec<_>>()
         .join("\n");
-    for expected in ["no notes yet", "scope herdr-tasks", "created", "updated"] {
+    for expected in ["no notes yet", "scope tsk", "created", "updated"] {
         assert!(
             body_joined.contains(expected),
             "accordion body missing {expected:?}:\n{body_joined}"
@@ -1608,7 +1608,7 @@ fn standard_accordion_expands_full_width_under_selection_without_mutating_domain
         .join("\n");
     for still_present in [
         "IN MOTION",
-        "herdr-tasks",
+        "tsk",
         "DONE",
         "Edit target binding pin",
         "Prototype the queue-style board UI",
@@ -1669,7 +1669,7 @@ fn standard_peek_body_caps_notes_at_five_lines_with_a_more_lines_tail() {
         "peek must name the three hidden lines:\n{joined}"
     );
     assert!(
-        joined.contains("scope herdr-tasks") && joined.contains("created"),
+        joined.contains("scope tsk") && joined.contains("created"),
         "peek keeps the scope and age lines:\n{joined}"
     );
 }
@@ -1719,7 +1719,7 @@ fn standard_accordion_on_a_task_below_the_fold_scrolls_the_whole_block_into_view
             2000 + i,
             &format!("Padding task {i}"),
             HumanStatus::Ready,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             3600,
         ));
     }
@@ -1741,7 +1741,7 @@ fn standard_accordion_on_a_task_below_the_fold_scrolls_the_whole_block_into_view
         viewport.contains("Padding task 29"),
         "the expanded task's own row must be scrolled into view:\n{viewport}"
     );
-    for expected in ["no notes yet", "scope herdr-tasks", "created", "updated"] {
+    for expected in ["no notes yet", "scope tsk", "created", "updated"] {
         assert!(
             viewport.contains(expected),
             "accordion body missing {expected:?} once scrolled into view:\n{viewport}"
@@ -1763,7 +1763,7 @@ fn plain_selection_on_a_task_below_the_fold_scrolls_it_into_view_in_both_tiers()
                 5000 + i,
                 &format!("Selection padding task {i}"),
                 HumanStatus::Ready,
-                project("/repos/herdr-tasks"),
+                project("/repos/tsk"),
                 3600,
             )
         })
@@ -1825,7 +1825,7 @@ fn compact_peek_is_inline_and_editors_stay_full_screen_takeovers() {
             "{w}x{h}: the peeked task's row must stay visible:\n{viewport}"
         );
         assert!(
-            viewport.contains("scope herdr-tasks"),
+            viewport.contains("scope tsk"),
             "{w}x{h}: the peek body must weave inline under the row:\n{viewport}"
         );
 
@@ -1878,7 +1878,7 @@ fn compact_paints_no_takeover_for_a_detail_open_task_excluded_by_the_current_sco
     let tasks = fixture_tasks();
     // Task 20 ("Wire dispatch cleanup receipts", Blocked, `/repos/herdr`) stays in
     // `tasks` -- the slice `QueueFrameModel::tasks` always carries -- but a view scoped to
-    // just `/repos/herdr-tasks` excludes it from `view.sections` entirely (unlike a Doing
+    // just `/repos/tsk` excludes it from `view.sections` entirely (unlike a Doing
     // task, an ON DECK task is genuinely scope-filtered; `IN MOTION` is not).
     let excluded_id = Uuid::from_u128(20);
     assert!(
@@ -1887,8 +1887,8 @@ fn compact_paints_no_takeover_for_a_detail_open_task_excluded_by_the_current_sco
     );
     let scoped_view = queue::query(
         &tasks,
-        Some(Path::new("/repos/herdr-tasks")),
-        DeckScope::Project(Path::new("/repos/herdr-tasks")),
+        Some(Path::new("/repos/tsk")),
+        DeckScope::Project(Path::new("/repos/tsk")),
         false,
     );
     assert!(
@@ -1901,7 +1901,7 @@ fn compact_paints_no_takeover_for_a_detail_open_task_excluded_by_the_current_sco
     );
     let model = QueueFrameModel {
         detail_open: Some(excluded_id),
-        scope_label: "herdr-tasks",
+        scope_label: "tsk",
         all_projects_scope: false,
         ..fixture_model(&tasks, &scoped_view)
     };
@@ -1973,7 +1973,7 @@ fn golden_scenes() -> Vec<GoldenScene> {
     // recorded here so a reviewer does not re-litigate the divergence as a bug.
     let mut help_model = fixture_model(&tasks, &board_view);
     let help_lines: Vec<String> =
-        herdr_tasks::ui::input::help_card_lines(herdr_tasks::config::VerbModifier::Alt);
+        tsk_tui::ui::input::help_card_lines(tsk_tui::config::VerbModifier::Alt);
     help_model.overlay = QueueOverlay::Help { lines: &help_lines };
     let (help_rows, _) = paint(80, 24, &help_model);
 
@@ -2195,8 +2195,8 @@ fn scoped_board_paints_thread_header_above_its_tasks() {
     let mut tasks = fixture_tasks();
     tasks[2].thread = Some("release".to_string());
     tasks[3].thread = Some("release".to_string());
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
-    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
+    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
 
     let rows = board_rows(&model, 80, 24);
     let header = rows
@@ -2223,11 +2223,11 @@ fn threaded_task_rows_indent_under_headers_while_unthreaded_rows_stay_flush() {
         12,
         "Loose project task",
         HumanStatus::Ready,
-        project("/repos/herdr-tasks"),
+        project("/repos/tsk"),
         30,
     ));
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
-    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
+    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
 
     let rows = board_rows(&model, 80, 24);
     let leading_spaces = |row: &str| {
@@ -2270,11 +2270,11 @@ fn thread_blocks_leave_a_blank_row_before_loose_tasks() {
         12,
         "Loose project task",
         HumanStatus::Ready,
-        project("/repos/herdr-tasks"),
+        project("/repos/tsk"),
         30,
     ));
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
-    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
+    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
 
     let rows = board_rows(&model, 80, 24);
     let last_threaded_task = rows
@@ -2307,11 +2307,11 @@ fn every_thread_block_leaves_a_spacer_before_following_content() {
         12,
         "Loose project task",
         HumanStatus::Ready,
-        project("/repos/herdr-tasks"),
+        project("/repos/tsk"),
         30,
     ));
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
-    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
+    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
 
     let rows = board_rows(&model, 80, 24);
     for title in [
@@ -2335,8 +2335,8 @@ fn header_shows_name_and_open_count() {
     let mut tasks = fixture_tasks();
     tasks[2].thread = Some("release".to_string());
     tasks[3].thread = Some("release".to_string());
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
-    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
+    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
     let deck_index = model
         .visible_ids()
         .iter()
@@ -2371,28 +2371,28 @@ fn board_with_headers_paints_within_40x10_and_all_tasks_reachable() {
             100,
             "alpha first",
             HumanStatus::Ready,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             40,
         ),
         task(
             101,
             "alpha second",
             HumanStatus::Ready,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             30,
         ),
         task(
             102,
             "beta first",
             HumanStatus::Ready,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             20,
         ),
         task(
             103,
             "beta second",
             HumanStatus::Ready,
-            project("/repos/herdr-tasks"),
+            project("/repos/tsk"),
             10,
         ),
     ];
@@ -2400,8 +2400,8 @@ fn board_with_headers_paints_within_40x10_and_all_tasks_reachable() {
     tasks[1].thread = Some("alpha".to_string());
     tasks[2].thread = Some("beta".to_string());
     tasks[3].thread = Some("beta".to_string());
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/herdr-tasks")));
-    model.set_selected_project(Some(PathBuf::from("/repos/herdr-tasks")));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
+    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
     let mut domain = DomainState::new();
     let ids = model.visible_ids();
     assert_eq!(ids.len(), 4, "fixture must expose every open task");

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -3,18 +3,18 @@
 use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use herdr_tasks::context::InvocationSnapshot;
-use herdr_tasks::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskEventKind, TaskScope};
-use herdr_tasks::ui::board::{
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+use tsk_tui::context::InvocationSnapshot;
+use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskEventKind, TaskScope};
+use tsk_tui::ui::board::{
     apply_intent, board_intent_may_persist, board_verb_items, draw_board, resolve_board_command,
     BoardInputMode, BoardModel, CommandSurface, IntentOutcome, ProjectScopeOption,
 };
-use herdr_tasks::ui::input::{map_key, normal_help_bindings, BoardIntent};
-use herdr_tasks::ui::mouse::BoardPopup;
-use herdr_tasks::ui::queue::SectionKind;
-use herdr_tasks::ui::tier;
-use ratatui::backend::TestBackend;
-use ratatui::Terminal;
+use tsk_tui::ui::input::{map_key, normal_help_bindings, BoardIntent};
+use tsk_tui::ui::mouse::BoardPopup;
+use tsk_tui::ui::queue::SectionKind;
+use tsk_tui::ui::tier;
 
 const THIS_REPO: &str = "/repos/app";
 
@@ -743,7 +743,7 @@ fn palette_excludes_park_resume_link_dispatch() {
         )
         .expect("create");
     domain
-        .start_dispatch_attempt(id, herdr_tasks::domain::DispatchAttemptMode::Here, "grok")
+        .start_dispatch_attempt(id, tsk_tui::domain::DispatchAttemptMode::Here, "grok")
         .expect("start attempt");
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
     assert!(

--- a/tests/quick_add_capture.rs
+++ b/tests/quick_add_capture.rs
@@ -6,17 +6,17 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use herdr_tasks::app::{apply_board_intent_with_save_recovery, BoardSaveContext};
-use herdr_tasks::context::InvocationSnapshot;
-use herdr_tasks::domain::{DomainState, ProvenanceOrigin, TaskEventKind, TaskScope};
-use herdr_tasks::save_recovery::SaveRecovery;
-use herdr_tasks::ui::board::{
-    apply_intent, board_hit_map, draw_board, BoardInputMode, BoardModel, IntentOutcome,
-};
-use herdr_tasks::ui::input::{map_key, BoardIntent};
 use ratatui::backend::{CrosstermBackend, TestBackend};
 use ratatui::layout::Rect;
 use ratatui::{Terminal, TerminalOptions, Viewport};
+use tsk_tui::app::{apply_board_intent_with_save_recovery, BoardSaveContext};
+use tsk_tui::context::InvocationSnapshot;
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskEventKind, TaskScope};
+use tsk_tui::save_recovery::SaveRecovery;
+use tsk_tui::ui::board::{
+    apply_intent, board_hit_map, draw_board, BoardInputMode, BoardModel, IntentOutcome,
+};
+use tsk_tui::ui::input::{map_key, BoardIntent};
 
 fn snapshot() -> InvocationSnapshot {
     InvocationSnapshot {
@@ -323,16 +323,16 @@ fn save_quick_add(domain: &mut DomainState, model: &mut BoardModel, title: &str)
 #[test]
 fn unique_project_basename_resolves_for_expansion_without_a_saved_status_message() {
     let mut domain = DomainState::new();
-    create_project_fixture(&mut domain, "/work/herdr-tasks");
+    create_project_fixture(&mut domain, "/work/tsk");
     let mut model = BoardModel::from_domain(&domain, None);
 
     open(&mut domain, &mut model, &snapshot());
-    type_title(&mut domain, &mut model, "expanded task !p herdr-tasks");
+    type_title(&mut domain, &mut model, "expanded task !p tsk");
     apply(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None);
     assert_eq!(
         model.form_scope(),
         Some(&TaskScope::Project {
-            path: "/work/herdr-tasks".into()
+            path: "/work/tsk".into()
         })
     );
     assert_eq!(
@@ -343,7 +343,7 @@ fn unique_project_basename_resolves_for_expansion_without_a_saved_status_message
     assert_eq!(
         domain.tasks().last().expect("saved task").scope,
         TaskScope::Project {
-            path: "/work/herdr-tasks".into()
+            path: "/work/tsk".into()
         }
     );
     assert_eq!(model.message(), None);
@@ -415,18 +415,14 @@ fn ambiguous_project_basename_stays_verbatim() {
 #[test]
 fn project_token_with_a_slash_stays_verbatim() {
     let mut domain = DomainState::new();
-    create_project_fixture(&mut domain, "/work/herdr-tasks");
+    create_project_fixture(&mut domain, "/work/tsk");
     let mut model = BoardModel::from_domain(&domain, None);
 
-    save_quick_add(
-        &mut domain,
-        &mut model,
-        "explicit task !p elsewhere/herdr-tasks",
-    );
+    save_quick_add(&mut domain, &mut model, "explicit task !p elsewhere/tsk");
     assert_eq!(
         domain.tasks().last().expect("saved task").scope,
         TaskScope::Project {
-            path: "elsewhere/herdr-tasks".into()
+            path: "elsewhere/tsk".into()
         }
     );
 }
@@ -565,7 +561,7 @@ fn empty_enter_stays_open_esc_discards_and_tab_expands_the_seeded_task_page() {
     assert_eq!(model.edit_buffer(), "");
     assert_eq!(
         model.form_focus(),
-        Some(herdr_tasks::ui::capture::CaptureField::Notes)
+        Some(tsk_tui::ui::capture::CaptureField::Notes)
     );
     assert_eq!(
         model.form_scope(),
@@ -590,7 +586,7 @@ fn expanded_page_stashes_notes_and_scope_across_esc_and_saves_like_quick_add() {
     assert_eq!(model.input_mode(), BoardInputMode::EditNotes);
     assert_eq!(
         model.form_focus(),
-        Some(herdr_tasks::ui::capture::CaptureField::Notes)
+        Some(tsk_tui::ui::capture::CaptureField::Notes)
     );
     let page = render_text(&model, 80, 24);
     assert!(page.contains("draft with details"));
@@ -611,8 +607,8 @@ fn expanded_page_stashes_notes_and_scope_across_esc_and_saves_like_quick_add() {
         );
     }
     assert_eq!(
-        herdr_tasks::ui::input::map_board_form_key(
-            herdr_tasks::ui::capture::CaptureField::Notes,
+        tsk_tui::ui::input::map_board_form_key(
+            tsk_tui::ui::capture::CaptureField::Notes,
             false,
             KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
         ),
@@ -623,7 +619,7 @@ fn expanded_page_stashes_notes_and_scope_across_esc_and_saves_like_quick_add() {
     assert_eq!(model.input_mode(), BoardInputMode::EditThread);
     assert_eq!(
         model.form_focus(),
-        Some(herdr_tasks::ui::capture::CaptureField::Thread)
+        Some(tsk_tui::ui::capture::CaptureField::Thread)
     );
     apply(&mut domain, &mut model, BoardIntent::FormFocusNext, None);
     assert_eq!(model.input_mode(), BoardInputMode::EditScope);
@@ -979,7 +975,7 @@ fn render_rows(model: &BoardModel, width: u16, height: u16) -> Vec<String> {
         .draw(|frame| draw_board(frame, model))
         .expect("draw board");
     let buffer = terminal.backend().buffer();
-    herdr_tasks::ui::render::assert_buffer_mono(buffer);
+    tsk_tui::ui::render::assert_buffer_mono(buffer);
     (0..height)
         .map(|y| {
             (0..width)
@@ -1065,5 +1061,5 @@ fn capture_bar_renders_spaced_three_row_block_and_stays_bounded_without_color_sg
         .expect("ANSI draw");
     drop(terminal);
     let output = String::from_utf8(bytes.borrow().clone()).expect("ANSI output");
-    herdr_tasks::ui::render::assert_no_color_sgr(&output);
+    tsk_tui::ui::render::assert_no_color_sgr(&output);
 }

--- a/tests/scope_resolver.rs
+++ b/tests/scope_resolver.rs
@@ -1,17 +1,17 @@
 use std::path::PathBuf;
 
-use herdr_tasks::context::InvocationSnapshot;
-use herdr_tasks::domain::{DomainState, ProvenanceOrigin, TaskScope};
-use herdr_tasks::scope::resolve_project_path;
-use herdr_tasks::ui::board::{apply_intent, BoardModel, IntentOutcome};
-use herdr_tasks::ui::input::BoardIntent;
+use tsk_tui::context::InvocationSnapshot;
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::scope::resolve_project_path;
+use tsk_tui::ui::board::{apply_intent, BoardModel, IntentOutcome};
+use tsk_tui::ui::input::BoardIntent;
 
 fn snapshot() -> InvocationSnapshot {
     InvocationSnapshot {
         default_scope: TaskScope::Project {
             path: "/repos/default".into(),
         },
-        this_repo: Some(PathBuf::from("/repos/herdr-tasks")),
+        this_repo: Some(PathBuf::from("/repos/tsk-board")),
         title_prefill: None,
         provenance: ProvenanceOrigin::Capture,
         capsule: None,
@@ -82,9 +82,9 @@ fn shared_resolver_and_board_quick_add_agree_on_fixtures() {
         ("normal", "normal path !p normal", "/repos/normal"),
         ("ghost", "soft deleted path !p ghost", "/repos/ghost"),
         (
-            "HERDR-TASKS",
-            "snapshot repo !p HERDR-TASKS",
-            "/repos/herdr-tasks",
+            "TSK-Board",
+            "snapshot repo !p TSK-Board",
+            "/repos/tsk-board",
         ),
         ("missing", "missing !p missing", "missing"),
         ("/abs/x", "verbatim !p /abs/x", "/abs/x"),

--- a/tests/store_persist.rs
+++ b/tests/store_persist.rs
@@ -5,16 +5,16 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use herdr_tasks::dispatch::DispatchRecoveryResult;
-use herdr_tasks::domain::{
+use tsk_tui::dispatch::DispatchRecoveryResult;
+use tsk_tui::domain::{
     AgentMeta, AgentReceipt, AgentSessionIdentity, ContextCapsule, DispatchAttemptError,
     DispatchAttemptMode, DispatchAttemptPhase, DispatchAttemptStep, DispatchAttemptStepState,
     DispatchAttemptTransition, DomainError, DomainState, HumanStatus, ObservedStatus,
     OwnedResourceReceipt, PaneReceipt, ProvenanceOrigin, Step, TaskEvent, TaskEventKind, TaskScope,
     WorktreeReceipt,
 };
-use herdr_tasks::store::TaskStore;
-use herdr_tasks::ui::board::{apply_dispatch_recovery_result, BoardInputMode, BoardModel};
+use tsk_tui::store::TaskStore;
+use tsk_tui::ui::board::{apply_dispatch_recovery_result, BoardInputMode, BoardModel};
 use uuid::Uuid;
 
 fn temp_state_dir() -> PathBuf {
@@ -24,7 +24,7 @@ fn temp_state_dir() -> PathBuf {
         .as_nanos();
     static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("herdr-tasks-store-persist-{nanos}-{seq}"));
+    let dir = std::env::temp_dir().join(format!("tsk-store-persist-{nanos}-{seq}"));
     fs::create_dir_all(&dir).expect("create temp state dir");
     dir
 }

--- a/tests/v1_keymap_guard.rs
+++ b/tests/v1_keymap_guard.rs
@@ -1,9 +1,9 @@
 //! Guard the documented V1 queue keymap against retired UI returning.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use herdr_tasks::domain::{DomainState, ProvenanceOrigin, TaskScope};
-use herdr_tasks::ui::board::{apply_intent, BoardInputMode, BoardModel};
-use herdr_tasks::ui::input::{map_key, normal_mode_keymap, BoardIntent};
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::ui::board::{apply_intent, BoardInputMode, BoardModel};
+use tsk_tui::ui::input::{map_key, normal_mode_keymap, BoardIntent};
 
 fn normal(code: KeyCode) -> Option<BoardIntent> {
     map_key(


### PR DESCRIPTION
## Summary

Rebrands the project to **tsk** ("a task board for your terminal"). The crate is now `tsk-tui` building the `tsk` binary, standalone state paths exist, and docs, scripts, and skills carry the new name. No behavior changes beyond the path/env seam below.

The GitHub repo keeps the name `herdr-tasks` for now; only in-repo identity changes here.

## Changes

- Crate/package `tsk-tui`, bin name `tsk`; release builds to `target/release/tsk`
- Standalone defaults: state `$XDG_DATA_HOME/tsk` (else `~/.local/share/tsk`), config `~/.config/tsk`; new `TSK_STATE_DIR` / `TSK_CONFIG_DIR` overrides with injected `HERDR_PLUGIN_*` variables keeping precedence; both resolvers covered by precedence tests
- Plugin id stays `herdr-tasks` so existing plugin state needs no migration; a manifest test pins this against future sweeps
- `scripts/tsk-cli.sh` and `skills/tsk-cli/SKILL.md` renamed; README rewritten around the tsk-first identity; AGENTS.md, CONTEXT.md, CHANGELOG updated
- Golden frames regenerated via `regenerate_golden_fixtures` (never hand-edited)

## Deliberate keeps

- Repo name `herdr-tasks`, plugin id `herdr-tasks`, fixture payload paths like `/work/herdr-tasks`
- `publish = false` until the crates.io decision
- Two case-insensitivity tests rebuilt as `/repos/tsk-board` vs `TSK-Board` (same coverage, old token was the dead brand name)

## Verification

Fresh green bar:

```text
cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release
```

All 27 test binaries pass. Live smoke: `tsk add` / `tsk list` round-trip in a temp `TSK_STATE_DIR`; `scripts/tsk-cli.sh list --all` reads the real plugin store through the renamed binary.

After pulling, relaunch any running board pane once so it picks up the renamed binary.
