### PR TITLE
fix: harden the JSON store without changing its shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Store hardening: `tasks.json` carries `format_version` (currently 1) and a
+newer document is refused rather than rewritten; each replace keeps the previous
+file as `tasks.json.1`; leftover `.tasks.json.tmp.*` files are swept under the
+lock; the exclusive lock uses `std::fs::File::lock` instead of `fs2`.
+
 Rebrand to **tsk** ("a task board for your terminal"). The crate is now
 `tsk-tui` building the `tsk` binary. Standalone state and config default to
 `~/.local/share/tsk` and `~/.config/tsk`, with new `TSK_STATE_DIR` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,16 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,7 +1429,6 @@ name = "tsk-tui"
 version = "0.3.0"
 dependencies = [
  "crossterm",
- "fs2",
  "ratatui",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 
 [dependencies]
 crossterm = "0.29.0"
-fs2 = "0.4.3"
 ratatui = "0.30.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.151"

--- a/src/app.rs
+++ b/src/app.rs
@@ -785,7 +785,7 @@ pub fn apply_board_intent_with_save_recovery(
         return Ok(outcome);
     }
     if let Err(error) = persist(domain) {
-        let working = std::mem::replace(domain, DomainState::new());
+        let working = std::mem::take(domain);
         recovery.fail(baseline, working, error);
         model.begin_save_recovery(recovery.error().unwrap_or("save failed"));
         return Ok(IntentOutcome::None);

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -273,12 +273,16 @@ fn record_mutation(task: &mut Task, kind: TaskEventKind) {
     task.history.push(TaskEvent { kind, at: now });
 }
 
-/// Document version written by this binary. Missing on-disk fields load as this value.
+/// Document version written by this binary.
 /// Bump when an older writer cannot round-trip a newly persisted field.
 pub const STORE_FORMAT_VERSION: u32 = 1;
 
+/// Version of documents written before `format_version` existed.
+/// Stay on 1 when [`STORE_FORMAT_VERSION`] is bumped.
+pub const LEGACY_STORE_FORMAT_VERSION: u32 = 1;
+
 fn default_store_format_version() -> u32 {
-    STORE_FORMAT_VERSION
+    LEGACY_STORE_FORMAT_VERSION
 }
 
 /// In-memory task set. Persistence is Task Store.
@@ -286,7 +290,7 @@ fn default_store_format_version() -> u32 {
 /// SHORTCUT: Vec scan by id; fine until store loads many tasks.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DomainState {
-    /// Store document version. Missing on older files loads as [`STORE_FORMAT_VERSION`].
+    /// Store document version. Missing on older files loads as [`LEGACY_STORE_FORMAT_VERSION`].
     #[serde(default = "default_store_format_version")]
     format_version: u32,
     tasks: Vec<Task>,
@@ -897,13 +901,14 @@ mod tests {
     }
 
     #[test]
-    fn missing_format_version_loads_as_current() {
+    fn missing_format_version_loads_as_legacy() {
         let state: DomainState = serde_json::from_value(serde_json::json!({
             "tasks": [],
             "undo_stack": []
         }))
         .expect("legacy document");
-        assert_eq!(state.format_version(), STORE_FORMAT_VERSION);
+        assert_eq!(state.format_version(), LEGACY_STORE_FORMAT_VERSION);
+        assert_eq!(state.format_version(), 1);
     }
 
     #[test]

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -273,11 +273,22 @@ fn record_mutation(task: &mut Task, kind: TaskEventKind) {
     task.history.push(TaskEvent { kind, at: now });
 }
 
+/// Document version written by this binary. Missing on-disk fields load as this value.
+/// Bump when an older writer cannot round-trip a newly persisted field.
+pub const STORE_FORMAT_VERSION: u32 = 1;
+
+fn default_store_format_version() -> u32 {
+    STORE_FORMAT_VERSION
+}
+
 /// In-memory task set. Persistence is Task Store.
 ///
 /// SHORTCUT: Vec scan by id; fine until store loads many tasks.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DomainState {
+    /// Store document version. Missing on older files loads as [`STORE_FORMAT_VERSION`].
+    #[serde(default = "default_store_format_version")]
+    format_version: u32,
     tasks: Vec<Task>,
     /// Active recovery records sharing the task store's lock and atomic replacement boundary.
     #[serde(default)]
@@ -286,13 +297,29 @@ pub struct DomainState {
     undo_stack: Vec<UndoEntry>,
 }
 
+impl Default for DomainState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DomainState {
     pub fn new() -> Self {
         Self {
+            format_version: STORE_FORMAT_VERSION,
             tasks: Vec::new(),
             active_attempts: Vec::new(),
             undo_stack: Vec::new(),
         }
+    }
+
+    pub fn format_version(&self) -> u32 {
+        self.format_version
+    }
+
+    /// Stamp this binary's format version before a durable write.
+    pub(crate) fn stamp_format_version(&mut self) {
+        self.format_version = STORE_FORMAT_VERSION;
     }
 
     /// Inspect the top undo entry without consuming it.
@@ -867,6 +894,16 @@ mod tests {
         local.merge_tasks_from_disk(&disk);
 
         assert_eq!(local.active_attempts(), &[incoming]);
+    }
+
+    #[test]
+    fn missing_format_version_loads_as_current() {
+        let state: DomainState = serde_json::from_value(serde_json::json!({
+            "tasks": [],
+            "undo_stack": []
+        }))
+        .expect("legacy document");
+        assert_eq!(state.format_version(), STORE_FORMAT_VERSION);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -12,7 +12,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::domain::{DomainState, STORE_FORMAT_VERSION};
+use crate::domain::{DomainState, LEGACY_STORE_FORMAT_VERSION, STORE_FORMAT_VERSION};
 
 /// On-disk document name under the state directory.
 const STATE_FILE: &str = "tasks.json";
@@ -214,12 +214,14 @@ impl TaskStore {
         let file = self.state_file();
         if file.exists() {
             match peek_format_version(&fs::read_to_string(&file)?) {
-                Ok(version) => check_format_version(version)?,
-                // A corrupt document is replaced, not treated as a newer format.
+                Ok(version) => {
+                    check_format_version(version)?;
+                    retain_last_good(&file)?;
+                }
+                // A corrupt live document is replaced. Leave any last-good copy alone.
                 Err(StoreError::Json(_)) => {}
                 Err(error) => return Err(error),
             }
-            retain_last_good(&file)?;
         }
         let tmp = self.unique_tmp_path();
         let data = serde_json::to_string_pretty(state)?;
@@ -342,7 +344,7 @@ pub fn default_state_dir() -> PathBuf {
 fn peek_format_version(data: &str) -> Result<u32, StoreError> {
     let value: serde_json::Value = serde_json::from_str(data)?;
     match value.get("format_version") {
-        None => Ok(STORE_FORMAT_VERSION),
+        None => Ok(LEGACY_STORE_FORMAT_VERSION),
         Some(version) => version
             .as_u64()
             .and_then(|n| u32::try_from(n).ok())
@@ -911,7 +913,7 @@ mod tests {
         );
 
         let loaded = TaskStore::new(&dir).load().expect("legacy store must load");
-        assert_eq!(loaded.format_version(), STORE_FORMAT_VERSION);
+        assert_eq!(loaded.format_version(), 1);
         assert!(loaded.tasks().is_empty());
     }
 
@@ -1006,6 +1008,36 @@ mod tests {
         assert_eq!(backup["tasks"][0]["title"], "first");
         let live = store.load().expect("load live");
         assert!(live.tasks().is_empty());
+    }
+
+    #[test]
+    fn corrupt_live_document_does_not_replace_the_last_good_copy() {
+        let dir = temp_dir("corrupt-keeps-backup");
+        let _guard = TempDirGuard(dir.clone());
+        let store = TaskStore::new(&dir);
+        let mut first = DomainState::new();
+        first
+            .create(
+                "keep me",
+                None,
+                TaskScope::Global,
+                None,
+                None,
+                ProvenanceOrigin::Manual,
+            )
+            .expect("create");
+        store.save(&first).expect("first save");
+        store.save(&DomainState::new()).expect("second save");
+
+        fs::write(dir.join(STATE_FILE), b"not valid json").expect("corrupt live");
+        store
+            .save(&DomainState::new())
+            .expect("replace the corrupt live document");
+
+        let backup: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.join(BACKUP_FILE)).expect("read backup"))
+                .expect("backup must stay valid json");
+        assert_eq!(backup["tasks"][0]["title"], "keep me");
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -2,7 +2,9 @@
 //!
 //! Atomic write: unique temp file in the same directory, then rename over the target.
 //! Concurrent writers take an exclusive lock on `tasks.json.lock` and merge by
-//! task/attempt id plus each record's `updated_at`, so writers do not drop sibling records.
+//! task/attempt id plus each record's revision, so writers do not drop sibling records.
+//! A store whose `format_version` is newer than this binary is refused rather than rewritten.
+//! Each successful replace retains the previous document as `tasks.json.1`.
 
 use std::env;
 use std::fs::{self, File, OpenOptions};
@@ -10,12 +12,12 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use fs2::FileExt;
-
-use crate::domain::DomainState;
+use crate::domain::{DomainState, STORE_FORMAT_VERSION};
 
 /// On-disk document name under the state directory.
 const STATE_FILE: &str = "tasks.json";
+/// Previous successful document, retained by hard-link before replace.
+const BACKUP_FILE: &str = "tasks.json.1";
 /// Inter-process exclusive lock file (sibling of the state document).
 const LOCK_FILE: &str = "tasks.json.lock";
 
@@ -117,6 +119,7 @@ impl TaskStore {
         let _guard = self.lock_exclusive()?;
         let mut durable = state.clone();
         durable.clear_merge_bases();
+        durable.stamp_format_version();
         self.save_unlocked(&durable)
     }
 
@@ -129,6 +132,7 @@ impl TaskStore {
         let mut state = self.load_unlocked().map_err(|error| error.to_string())?;
         let result = transition(&mut state)?;
         state.clear_merge_bases();
+        state.stamp_format_version();
         self.save_unlocked(&state)
             .map_err(|error| error.to_string())?;
         Ok(result)
@@ -147,6 +151,7 @@ impl TaskStore {
         let (result, changed) = transition(&mut state)?;
         if changed {
             state.clear_merge_bases();
+            state.stamp_format_version();
             self.save_unlocked(&state)
                 .map_err(|error| error.to_string())?;
         }
@@ -171,22 +176,26 @@ impl TaskStore {
     ) -> Result<(), StoreError> {
         let _guard = self.lock_exclusive()?;
         let disk = self.load_unlocked()?;
+        check_format_version(disk.format_version())?;
         local
             .merge_for_save(&disk)
             .map_err(|message| StoreError::Io(io::Error::other(message)))?;
         let mut durable = local.clone();
         durable.clear_merge_bases();
+        durable.stamp_format_version();
         self.save_unlocked_with(&durable, filesystem)?;
         local.clear_merge_bases();
         Ok(())
     }
 
     fn load_unlocked(&self) -> Result<DomainState, StoreError> {
+        self.sweep_orphan_temps();
         let file = self.state_file();
         if !file.exists() {
             return Ok(DomainState::new());
         }
         let data = fs::read_to_string(&file)?;
+        check_format_version(peek_format_version(&data)?)?;
         let state = serde_json::from_str(&data)?;
         Ok(state)
     }
@@ -201,7 +210,17 @@ impl TaskStore {
         filesystem: &F,
     ) -> Result<(), StoreError> {
         fs::create_dir_all(&self.path)?;
+        self.sweep_orphan_temps();
         let file = self.state_file();
+        if file.exists() {
+            match peek_format_version(&fs::read_to_string(&file)?) {
+                Ok(version) => check_format_version(version)?,
+                // A corrupt document is replaced, not treated as a newer format.
+                Err(StoreError::Json(_)) => {}
+                Err(error) => return Err(error),
+            }
+            retain_last_good(&file)?;
+        }
         let tmp = self.unique_tmp_path();
         let data = serde_json::to_string_pretty(state)?;
         // A save is successful only after the replacement and containing directory are synced.
@@ -230,12 +249,26 @@ impl TaskStore {
             .write(true)
             .truncate(false)
             .open(&lock_path)?;
-        file.lock_exclusive()?;
+        file.lock()?;
         Ok(StoreLockGuard { file })
     }
 
     fn state_file(&self) -> PathBuf {
         self.path.join(STATE_FILE)
+    }
+
+    /// Remove leftover `.tasks.json.tmp.*` files. Safe only under the exclusive lock.
+    fn sweep_orphan_temps(&self) {
+        let Ok(entries) = fs::read_dir(&self.path) else {
+            return;
+        };
+        let prefix = format!(".{STATE_FILE}.tmp.");
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy().starts_with(&prefix) {
+                let _ = fs::remove_file(entry.path());
+            }
+        }
     }
 
     /// Unique temp path so concurrent writers never share `.tasks.json.tmp`.
@@ -266,7 +299,7 @@ impl TaskStateStore for TaskStore {
     }
 }
 
-/// RAII exclusive lock on the store lock file (released on drop via fs2 unlock).
+/// RAII exclusive lock on the store lock file (released on drop via `File::unlock`).
 struct StoreLockGuard {
     file: File,
 }
@@ -306,11 +339,47 @@ pub fn default_state_dir() -> PathBuf {
     PathBuf::from(".tsk-state")
 }
 
+fn peek_format_version(data: &str) -> Result<u32, StoreError> {
+    let value: serde_json::Value = serde_json::from_str(data)?;
+    match value.get("format_version") {
+        None => Ok(STORE_FORMAT_VERSION),
+        Some(version) => version
+            .as_u64()
+            .and_then(|n| u32::try_from(n).ok())
+            .ok_or_else(|| StoreError::Io(io::Error::other("format_version must be a u32"))),
+    }
+}
+
+fn check_format_version(found: u32) -> Result<(), StoreError> {
+    if found > STORE_FORMAT_VERSION {
+        Err(StoreError::UnsupportedFormat {
+            found,
+            supported: STORE_FORMAT_VERSION,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// Keep the previous live document under `tasks.json.1` via hard-link so a crash
+/// between link and rename leaves the backup identical to the still-live file.
+fn retain_last_good(live: &Path) -> Result<(), StoreError> {
+    let backup = live.with_file_name(BACKUP_FILE);
+    match fs::remove_file(&backup) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    fs::hard_link(live, &backup)?;
+    Ok(())
+}
+
 /// Store I/O and JSON failures.
 #[derive(Debug)]
 pub enum StoreError {
     Io(io::Error),
     Json(serde_json::Error),
+    UnsupportedFormat { found: u32, supported: u32 },
 }
 
 impl std::fmt::Display for StoreError {
@@ -318,6 +387,10 @@ impl std::fmt::Display for StoreError {
         match self {
             StoreError::Io(e) => write!(f, "store I/O error: {e}"),
             StoreError::Json(e) => write!(f, "store JSON error: {e}"),
+            StoreError::UnsupportedFormat { found, supported } => write!(
+                f,
+                "store format {found} is newer than this tsk ({supported}); upgrade tsk"
+            ),
         }
     }
 }
@@ -327,6 +400,7 @@ impl std::error::Error for StoreError {
         match self {
             StoreError::Io(e) => Some(e),
             StoreError::Json(e) => Some(e),
+            StoreError::UnsupportedFormat { .. } => None,
         }
     }
 }
@@ -799,6 +873,156 @@ mod tests {
         assert!(
             fallback_s.contains("tsk") || fallback_s == ".tsk-state",
             "unexpected fallback: {fallback_s}"
+        );
+    }
+
+    fn write_state_json(dir: &Path, value: serde_json::Value) {
+        fs::create_dir_all(dir).expect("mkdir");
+        fs::write(
+            dir.join(STATE_FILE),
+            serde_json::to_vec_pretty(&value).expect("json"),
+        )
+        .expect("write store");
+    }
+
+    #[test]
+    fn save_stamps_format_version_one() {
+        let dir = temp_dir("format-stamp");
+        let _guard = TempDirGuard(dir.clone());
+        let store = TaskStore::new(&dir);
+        store.save(&DomainState::new()).expect("save");
+
+        let value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.join(STATE_FILE)).expect("read"))
+                .expect("json");
+        assert_eq!(value["format_version"], 1);
+    }
+
+    #[test]
+    fn load_accepts_legacy_document_without_format_version() {
+        let dir = temp_dir("format-legacy");
+        let _guard = TempDirGuard(dir.clone());
+        write_state_json(
+            &dir,
+            serde_json::json!({
+                "tasks": [],
+                "undo_stack": []
+            }),
+        );
+
+        let loaded = TaskStore::new(&dir).load().expect("legacy store must load");
+        assert_eq!(loaded.format_version(), STORE_FORMAT_VERSION);
+        assert!(loaded.tasks().is_empty());
+    }
+
+    #[test]
+    fn load_refuses_newer_format_without_rewriting() {
+        let dir = temp_dir("format-load-newer");
+        let _guard = TempDirGuard(dir.clone());
+        let newer = serde_json::json!({
+            "format_version": 2,
+            "tasks": [],
+            "undo_stack": []
+        });
+        write_state_json(&dir, newer.clone());
+
+        let error = TaskStore::new(&dir)
+            .load()
+            .expect_err("newer format must refuse");
+        assert!(
+            matches!(
+                error,
+                StoreError::UnsupportedFormat {
+                    found: 2,
+                    supported: 1
+                }
+            ),
+            "{error}"
+        );
+        let on_disk: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.join(STATE_FILE)).expect("read"))
+                .expect("json");
+        assert_eq!(on_disk, newer);
+    }
+
+    #[test]
+    fn save_refuses_newer_format_and_leaves_the_document() {
+        let dir = temp_dir("format-save-newer");
+        let _guard = TempDirGuard(dir.clone());
+        let newer = serde_json::json!({
+            "format_version": 2,
+            "tasks": [],
+            "undo_stack": []
+        });
+        write_state_json(&dir, newer.clone());
+
+        let error = TaskStore::new(&dir)
+            .save(&DomainState::new())
+            .expect_err("must not overwrite a newer store");
+        assert!(
+            matches!(
+                error,
+                StoreError::UnsupportedFormat {
+                    found: 2,
+                    supported: 1
+                }
+            ),
+            "{error}"
+        );
+        let on_disk: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.join(STATE_FILE)).expect("read"))
+                .expect("json");
+        assert_eq!(on_disk, newer);
+    }
+
+    #[test]
+    fn second_save_hard_links_the_previous_document() {
+        let dir = temp_dir("last-good");
+        let _guard = TempDirGuard(dir.clone());
+        let store = TaskStore::new(&dir);
+        let mut first = DomainState::new();
+        first
+            .create(
+                "first",
+                None,
+                TaskScope::Global,
+                None,
+                None,
+                ProvenanceOrigin::Manual,
+            )
+            .expect("create");
+        store.save(&first).expect("first save");
+        assert!(
+            !dir.join(BACKUP_FILE).exists(),
+            "the first save has no previous document to retain"
+        );
+
+        let second = DomainState::new();
+        store.save(&second).expect("second save");
+
+        let backup: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.join(BACKUP_FILE)).expect("read backup"))
+                .expect("json");
+        assert_eq!(backup["tasks"][0]["title"], "first");
+        let live = store.load().expect("load live");
+        assert!(live.tasks().is_empty());
+    }
+
+    #[test]
+    fn save_sweeps_orphan_temp_files_under_the_lock() {
+        let dir = temp_dir("orphan-sweep");
+        let _guard = TempDirGuard(dir.clone());
+        fs::create_dir_all(&dir).expect("mkdir");
+        let orphan = dir.join(".tasks.json.tmp.1.1");
+        fs::write(&orphan, b"stale").expect("seed orphan");
+
+        TaskStore::new(&dir)
+            .save(&DomainState::new())
+            .expect("save");
+
+        assert!(
+            !orphan.exists(),
+            "a locked save must remove leftover temp files"
         );
     }
 }

--- a/src/ui/capture.rs
+++ b/src/ui/capture.rs
@@ -558,7 +558,7 @@ pub fn apply_capture_intent(
             let baseline =
                 serde_json::from_value(serde_json::to_value(&*domain).expect("serialize domain"))
                     .expect("deserialize domain");
-            let mut working = std::mem::replace(domain, DomainState::new());
+            let mut working = std::mem::take(domain);
             let id = match capture_save(
                 &mut working,
                 None,


### PR DESCRIPTION
## Summary

Keeps the single `tasks.json` document. Hardens the four edges the store review named.

- `format_version` (currently 1). A newer document is refused on load and save, so an older binary cannot rewrite it and strip unknown fields. Legacy files without the field still load.
- Each successful replace hard-links the previous file to `tasks.json.1` first. A crash between link and rename leaves the backup identical to the still-live file. Corrupt JSON is still replaced (the backup keeps the junk).
- Leftover `.tasks.json.tmp.*` files are swept under the exclusive lock.
- The lock uses `std::fs::File::lock` (Rust 1.89+, CI is 1.96). `fs2` is gone.

SQLite is not in this PR. Trigger for that conversation is written in the review notes: felt open latency, or the file regularly above ~10 MB.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] format-version tests fail without the guard, then pass with it restored
- [ ] Manual herdr open-board smoke (if host paths changed)

Store-only. Live herdr smoke was not run.