### PR TITLE
feat: one store at ~/.tsk for every host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,11 +91,10 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
 ## Conventions
 
 - Human status is source of truth. Never auto-complete tasks from agent status.
-- State under `HERDR_PLUGIN_STATE_DIR`. Config under `HERDR_PLUGIN_CONFIG_DIR`.
-  Standalone runs default to `$XDG_DATA_HOME/tsk` / `~/.config/tsk`, overridable
-  with `TSK_STATE_DIR` / `TSK_CONFIG_DIR`; injected host variables keep
-  precedence.
-  Verb modifier is `settings.json` in that config dir; the palette flips it.
+- One store: state is `$HOME/.tsk/tasks.json`, config `$HOME/.tsk/settings.json`,
+  overridable with `TSK_STATE_DIR` / `TSK_CONFIG_DIR`. Injected host variables such as
+  `HERDR_PLUGIN_STATE_DIR` are deliberately ignored so every host edits the same board.
+  Verb modifier is `settings.json`; the palette flips it.
 - UI chrome lives in `src/ui/` (`board/` model·apply·commands·chrome·draw,
   `capture`, `mouse`, `input`, `render`).
 - `map_edit` and `map_board_form_key` share `map_form_edit_key`. Save-recovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ Rebrand to **tsk** ("a task board for your terminal"). The crate is now
 `tsk-tui` building the `tsk` binary. The store unifies at `~/.tsk` (`tasks.json`
 and `settings.json` side by side), overridable with `TSK_STATE_DIR` /
 `TSK_CONFIG_DIR`; injected host variables like `HERDR_PLUGIN_STATE_DIR` are
-ignored so the herdr pane and a bare terminal edit one board. Existing data
-migrates by moving the old store directory's files into `~/.tsk`. The herdr
-plugin id stays `herdr-tasks`, so existing plugin state needs no migration.
+ignored so the herdr pane and a bare terminal edit one board. There is no
+automatic move from the old locations; a first run creates an empty `~/.tsk`.
+The herdr plugin id stays `herdr-tasks`.
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ file as `tasks.json.1`; leftover `.tasks.json.tmp.*` files are swept under the
 lock; the exclusive lock uses `std::fs::File::lock` instead of `fs2`.
 
 Rebrand to **tsk** ("a task board for your terminal"). The crate is now
-`tsk-tui` building the `tsk` binary. Standalone state and config default to
-`~/.local/share/tsk` and `~/.config/tsk`, with new `TSK_STATE_DIR` /
-`TSK_CONFIG_DIR` overrides beneath the injected herdr variables. The herdr
+`tsk-tui` building the `tsk` binary. The store unifies at `~/.tsk` (`tasks.json`
+and `settings.json` side by side), overridable with `TSK_STATE_DIR` /
+`TSK_CONFIG_DIR`; injected host variables like `HERDR_PLUGIN_STATE_DIR` are
+ignored so the herdr pane and a bare terminal edit one board. Existing data
+migrates by moving the old store directory's files into `~/.tsk`. The herdr
 plugin id stays `herdr-tasks`, so existing plugin state needs no migration.
 
 ## 0.3.0

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The built binary is `target/release/tsk`.
 
 ### Standalone
 
-Run `tsk` directly. State lives in `$XDG_DATA_HOME/tsk`
-(`~/.local/share/tsk` by default), config in `~/.config/tsk`. Override either
-with `TSK_STATE_DIR` / `TSK_CONFIG_DIR`.
+Run `tsk` directly. The store is `~/.tsk`: `tasks.json` and `settings.json`
+live side by side. Override the locations with `TSK_STATE_DIR` /
+`TSK_CONFIG_DIR`.
 
 ```bash
 tsk add -t "Draft release notes"
@@ -66,9 +66,11 @@ board you already have.
 herdr plugin action invoke quick-capture --plugin herdr-tasks
 ```
 
-In plugin mode, state lives under `HERDR_PLUGIN_STATE_DIR` and config under
-`HERDR_PLUGIN_CONFIG_DIR`; the host injects both, so the plugin and a standalone
-CLI can be pointed at the same store deliberately but never collide by accident.
+In plugin mode herdr injects `HERDR_PLUGIN_STATE_DIR` / `HERDR_PLUGIN_CONFIG_DIR`, but
+tsk deliberately ignores them: there is one store (`~/.tsk`) whether the board runs in
+herdr, another multiplexer, or a bare terminal. Herdr documents plugin state as
+plugin-owned and never touches its contents, so the pane and the CLI edit the same
+board safely.
 
 ## Pane size
 

--- a/scripts/tsk-cli.sh
+++ b/scripts/tsk-cli.sh
@@ -3,13 +3,8 @@ set -euo pipefail
 
 herdr_bin=${HERDR_BIN_PATH:-herdr}
 
-# A plugin pane receives this from Herdr. Agents run outside that pane, so use
-# Herdr's default plugin-state location rather than the binary's standalone
-# XDG-data fallback. An explicit caller override still wins.
-if [[ -z ${HERDR_PLUGIN_STATE_DIR:-} ]]; then
-  xdg_state_home=${XDG_STATE_HOME:-"$HOME/.local/state"}
-  export HERDR_PLUGIN_STATE_DIR="$xdg_state_home/herdr/plugins/herdr-tasks"
-fi
+# tsk owns one store (~/.tsk by default), so agents need no state plumbing: the same
+# files back the herdr pane and a bare terminal run.
 
 plugin_root=$(
   "$herdr_bin" plugin list --json | python3 -c '

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,9 +17,8 @@
 //!
 //! # Empty environment values
 //!
-//! Unlike [`crate::store::default_state_dir`], an empty `HERDR_PLUGIN_CONFIG_DIR` falls
-//! through rather than resolving to `""`, which would put `walkthrough.json` in whatever
-//! directory the board was launched from. Durable state stays in the plugin directories.
+//! An empty `TSK_CONFIG_DIR` falls through to `$HOME/.tsk` rather than resolving to `""`,
+//! which would put `walkthrough.json` in whatever directory the board was launched from.
 
 use std::env;
 use std::ffi::OsStr;
@@ -46,56 +45,34 @@ struct WalkthroughDocument {
     dismissed: bool,
 }
 
-/// Config dir from `HERDR_PLUGIN_CONFIG_DIR`, else `TSK_CONFIG_DIR`, else per-user config.
+/// Config dir from `TSK_CONFIG_DIR`, else `~/.tsk`.
 ///
-/// Production herdr injects `HERDR_PLUGIN_CONFIG_DIR`. Standalone runs may set
-/// `TSK_CONFIG_DIR`. When neither is set (manual runs / tests without the host), use
-/// `$XDG_CONFIG_HOME/tsk` or `$HOME/.config/tsk`.
-/// Mirrors [`crate::store::default_state_dir`], including its refusal to fall back to a
-/// shared world path under `std::env::temp_dir()`.
+/// One store everywhere: the herdr plugin pane and a bare terminal run resolve to the same
+/// files, so settings live beside the board's data. Herdr's injected
+/// `HERDR_PLUGIN_CONFIG_DIR` is deliberately ignored — see [`crate::store::default_state_dir`].
+/// Mirrors its refusal to fall back to a shared world path under `std::env::temp_dir()`.
 pub fn default_config_dir() -> PathBuf {
     resolve_config_dir(
-        env::var_os("HERDR_PLUGIN_CONFIG_DIR").as_deref(),
         env::var_os("TSK_CONFIG_DIR").as_deref(),
-        env::var_os("XDG_CONFIG_HOME").as_deref(),
         env::var_os("HOME").as_deref(),
     )
 }
 
-/// Pure resolution over the three candidate values, in precedence order.
+/// Pure resolution over the candidate values, in precedence order.
 ///
 /// Split out from [`default_config_dir`] so every branch is testable without mutating the
 /// process environment: `setenv` racing another thread's `getenv` is a data race, and this
-/// crate's tests run in threads inside one process. The fourth candidate (the relative
-/// last resort) is a constant and needs no input.
-///
-/// Empty values fall through, including an empty host variable. That last part is a
-/// deliberate divergence from [`crate::store::default_state_dir`], which returns `""` and
-/// would write into the current working directory: see the module doc.
-fn resolve_config_dir(
-    host: Option<&OsStr>,
-    tsk_env: Option<&OsStr>,
-    xdg_config_home: Option<&OsStr>,
-    home: Option<&OsStr>,
-) -> PathBuf {
-    if let Some(dir) = host {
-        if !dir.is_empty() {
-            return PathBuf::from(dir);
-        }
-    }
+/// crate's tests run in threads inside one process. The relative last resort is a constant
+/// and needs no input. Empty values fall through.
+fn resolve_config_dir(tsk_env: Option<&OsStr>, home: Option<&OsStr>) -> PathBuf {
     if let Some(dir) = tsk_env {
         if !dir.is_empty() {
             return PathBuf::from(dir);
         }
     }
-    if let Some(xdg) = xdg_config_home {
-        if !xdg.is_empty() {
-            return PathBuf::from(xdg).join("tsk");
-        }
-    }
     if let Some(home) = home {
         if !home.is_empty() {
-            return PathBuf::from(home).join(".config/tsk");
+            return PathBuf::from(home).join(".tsk");
         }
     }
     // Last resort: relative per-process dir (still not shared /tmp/tsk-config).
@@ -316,86 +293,50 @@ mod tests {
     }
 
     #[test]
-    fn host_variable_wins_over_every_other_candidate() {
+    fn empty_override_never_resolves_to_the_current_directory() {
         assert_eq!(
-            resolve_config_dir(
-                Some(os("/host")),
-                None,
-                Some(os("/xdg")),
-                Some(os("/home/u"))
-            ),
-            PathBuf::from("/host")
+            resolve_config_dir(Some(os("")), Some(os("/home/u"))),
+            PathBuf::from("/home/u/.tsk"),
+            "an empty override must not resolve to the current working directory"
         );
     }
 
     #[test]
-    fn empty_host_variable_falls_through_to_xdg() {
+    fn tsk_env_wins_over_home() {
         assert_eq!(
-            resolve_config_dir(Some(os("")), None, Some(os("/xdg")), Some(os("/home/u"))),
-            PathBuf::from("/xdg/tsk"),
-            "an empty host variable must not resolve to the current working directory"
-        );
-    }
-
-    #[test]
-    fn standalone_env_sits_between_host_and_xdg() {
-        assert_eq!(
-            resolve_config_dir(
-                None,
-                Some(os("/tsk-env")),
-                Some(os("/xdg")),
-                Some(os("/home/u"))
-            ),
+            resolve_config_dir(Some(os("/tsk-env")), Some(os("/home/u"))),
             PathBuf::from("/tsk-env")
         );
+    }
+
+    #[test]
+    fn empty_tsk_env_falls_through_to_home() {
         assert_eq!(
-            resolve_config_dir(
-                Some(os("/host")),
-                Some(os("/tsk-env")),
-                Some(os("/xdg")),
-                Some(os("/home/u"))
-            ),
-            PathBuf::from("/host"),
-            "host injection keeps precedence over the standalone override"
+            resolve_config_dir(Some(os("")), Some(os("/home/u"))),
+            PathBuf::from("/home/u/.tsk")
         );
     }
 
     #[test]
-    fn xdg_config_home_wins_over_home() {
+    fn home_resolves_to_the_dot_tsk_store_root() {
         assert_eq!(
-            resolve_config_dir(None, None, Some(os("/xdg")), Some(os("/home/u"))),
-            PathBuf::from("/xdg/tsk")
-        );
-    }
-
-    #[test]
-    fn empty_xdg_config_home_falls_through_to_home() {
-        assert_eq!(
-            resolve_config_dir(None, None, Some(os("")), Some(os("/home/u"))),
-            PathBuf::from("/home/u/.config/tsk")
-        );
-    }
-
-    #[test]
-    fn home_resolves_under_dot_config_not_dot_local_share() {
-        assert_eq!(
-            resolve_config_dir(None, None, None, Some(os("/home/u"))),
-            PathBuf::from("/home/u/.config/tsk"),
-            "this is the config record, not the state store"
+            resolve_config_dir(None, Some(os("/home/u"))),
+            PathBuf::from("/home/u/.tsk"),
+            "config lives beside the board's data in one store root"
         );
     }
 
     #[test]
     fn empty_home_falls_through_to_the_relative_fallback() {
         assert_eq!(
-            resolve_config_dir(None, None, None, Some(os(""))),
+            resolve_config_dir(None, Some(os(""))),
             PathBuf::from(".tsk-config")
         );
     }
 
     #[test]
     fn no_candidate_resolves_to_a_relative_dir_never_a_shared_temp_path() {
-        let fallback = resolve_config_dir(None, None, None, None);
+        let fallback = resolve_config_dir(None, None);
 
         assert_eq!(fallback, PathBuf::from(".tsk-config"));
         assert!(
@@ -411,9 +352,7 @@ mod tests {
         assert_eq!(
             default_config_dir(),
             resolve_config_dir(
-                env::var_os("HERDR_PLUGIN_CONFIG_DIR").as_deref(),
                 env::var_os("TSK_CONFIG_DIR").as_deref(),
-                env::var_os("XDG_CONFIG_HOME").as_deref(),
                 env::var_os("HOME").as_deref(),
             )
         );

--- a/src/store.rs
+++ b/src/store.rs
@@ -310,29 +310,23 @@ impl Drop for StoreLockGuard {
     }
 }
 
-/// State dir from `HERDR_PLUGIN_STATE_DIR`, else `TSK_STATE_DIR`, else per-user data.
+/// State dir from `TSK_STATE_DIR`, else `~/.tsk`.
 ///
-/// Production herdr injects `HERDR_PLUGIN_STATE_DIR`. Standalone runs may set
-/// `TSK_STATE_DIR`. When neither is set (manual runs / tests without the host), use
-/// `$XDG_DATA_HOME/tsk` or `$HOME/.local/share/tsk`.
-/// Never falls back to a shared world path under `std::env::temp_dir()`.
+/// One store everywhere: the herdr plugin pane and a bare terminal run resolve to the same
+/// files, so there is exactly one board regardless of host. Herdr's injected
+/// `HERDR_PLUGIN_STATE_DIR` is deliberately ignored — herdr documents plugin state as
+/// plugin-owned ("it does not validate, sync, or delete their contents") and only recommends
+/// the injected location. Empty values fall through. Never falls back to a shared world path
+/// under `std::env::temp_dir()`.
 pub fn default_state_dir() -> PathBuf {
-    if let Some(dir) = env::var_os("HERDR_PLUGIN_STATE_DIR") {
-        return PathBuf::from(dir);
-    }
     if let Some(dir) = env::var_os("TSK_STATE_DIR") {
         if !dir.is_empty() {
             return PathBuf::from(dir);
         }
     }
-    if let Some(xdg) = env::var_os("XDG_DATA_HOME") {
-        if !xdg.is_empty() {
-            return PathBuf::from(xdg).join("tsk");
-        }
-    }
     if let Some(home) = env::var_os("HOME") {
         if !home.is_empty() {
-            return PathBuf::from(home).join(".local/share/tsk");
+            return PathBuf::from(home).join(".tsk");
         }
     }
     // Last resort: relative per-process dir (still not shared /tmp/tsk-state).
@@ -837,23 +831,22 @@ mod tests {
         fs::create_dir_all(&marker).expect("mkdir");
         let _guard = TempDirGuard(marker.clone());
 
-        // When set, env wins.
+        // When set, the override wins.
         // SAFETY: single-threaded under ENV_LOCK for the duration of this test.
-        env::set_var("HERDR_PLUGIN_STATE_DIR", &marker);
+        env::set_var("TSK_STATE_DIR", &marker);
         assert_eq!(default_state_dir(), marker);
-        env::remove_var("HERDR_PLUGIN_STATE_DIR");
+        env::remove_var("TSK_STATE_DIR");
 
-        // The standalone override sits between the host variable and XDG.
-        let standalone = marker.join("standalone");
-        env::set_var("TSK_STATE_DIR", &standalone);
-        assert_eq!(default_state_dir(), standalone);
-        env::set_var("HERDR_PLUGIN_STATE_DIR", &marker);
-        assert_eq!(
-            default_state_dir(),
-            marker,
-            "host injection beats TSK_STATE_DIR"
-        );
+        // Host injection is deliberately ignored: herdr documents plugin state as
+        // plugin-owned, and one store must stay one store under every host.
+        env::set_var("HERDR_PLUGIN_STATE_DIR", "/herdr/injected");
+        let ignored = default_state_dir();
         env::remove_var("HERDR_PLUGIN_STATE_DIR");
+        assert_ne!(
+            ignored,
+            PathBuf::from("/herdr/injected"),
+            "injected host state dirs must not fragment the single store"
+        );
         env::set_var("TSK_STATE_DIR", "");
         assert_ne!(
             default_state_dir(),

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -1604,7 +1604,7 @@ fn flag_add_rejects_flag_like_state_dir_and_file_values_without_mutating() {
 
     let state_dir_output = Command::new(&binary)
         .current_dir(&cwd)
-        .env("HERDR_PLUGIN_STATE_DIR", &state_dir)
+        .env("TSK_STATE_DIR", &state_dir)
         .args(["add", "--state-dir", "--global", "--title", "junk"])
         .output()
         .expect("run flag-like state-dir value");
@@ -1616,7 +1616,7 @@ fn flag_add_rejects_flag_like_state_dir_and_file_values_without_mutating() {
 
     let file = Command::new(binary)
         .current_dir(&cwd)
-        .env("HERDR_PLUGIN_STATE_DIR", &state_dir)
+        .env("TSK_STATE_DIR", &state_dir)
         .args(["add", "--file", "--global"])
         .output()
         .expect("run flag-like file value");
@@ -1717,9 +1717,9 @@ fn state_dir_flag_wins_over_environment() {
     let _env = env_lock();
     let environment_dir = temp_state_dir("environment");
     let argument_dir = temp_state_dir("argument");
-    let prior = std::env::var_os("HERDR_PLUGIN_STATE_DIR");
+    let prior = std::env::var_os("TSK_STATE_DIR");
     // SAFETY: ENV_LOCK serializes this test's process-wide environment mutation.
-    unsafe { std::env::set_var("HERDR_PLUGIN_STATE_DIR", &environment_dir) };
+    unsafe { std::env::set_var("TSK_STATE_DIR", &environment_dir) };
 
     let output = add(
         &[
@@ -1736,11 +1736,11 @@ fn state_dir_flag_wins_over_environment() {
     match prior {
         Some(value) => {
             // SAFETY: ENV_LOCK serializes this test's process-wide environment mutation.
-            unsafe { std::env::set_var("HERDR_PLUGIN_STATE_DIR", value) };
+            unsafe { std::env::set_var("TSK_STATE_DIR", value) };
         }
         None => {
             // SAFETY: ENV_LOCK serializes this test's process-wide environment mutation.
-            unsafe { std::env::remove_var("HERDR_PLUGIN_STATE_DIR") };
+            unsafe { std::env::remove_var("TSK_STATE_DIR") };
         }
     }
 

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -1131,7 +1131,7 @@ fn list_state_dir_flag_wins_over_environment() {
     TaskStore::new(&argument_dir)
         .save(&argument_state)
         .expect("save argument state");
-    let _state_dir = EnvironmentGuard::set("HERDR_PLUGIN_STATE_DIR", &environment_dir);
+    let _state_dir = EnvironmentGuard::set("TSK_STATE_DIR", &environment_dir);
 
     let output = list(&[
         "tsk".into(),
@@ -1165,7 +1165,7 @@ fn list_uses_environment_state_dir_by_default() {
     TaskStore::new(&dir)
         .save(&state)
         .expect("save default state");
-    let _state_dir = EnvironmentGuard::set("HERDR_PLUGIN_STATE_DIR", &dir);
+    let _state_dir = EnvironmentGuard::set("TSK_STATE_DIR", &dir);
 
     let output = list(&[
         "tsk".into(),

--- a/tests/queue_board_loop.rs
+++ b/tests/queue_board_loop.rs
@@ -25,7 +25,7 @@ impl Drop for TempDirGuard {
 }
 
 /// Restores an environment variable to whatever it held before the test touched it, so one
-/// test's `HERDR_PLUGIN_STATE_DIR` never leaks into the next.
+/// test's `TSK_STATE_DIR` never leaks into the next.
 struct EnvVarGuard {
     key: &'static str,
     previous: Option<OsString>,
@@ -161,7 +161,7 @@ fn instrumented_loop_idle_wait_never_sustained_below_25ms_without_animation() {
 fn load_board_and_draw_path_smoke_at_80x24() {
     let dir = temp_state_dir("smoke");
     let _dir_guard = TempDirGuard(dir.clone());
-    let _env_guard = EnvVarGuard::set("HERDR_PLUGIN_STATE_DIR", &dir);
+    let _env_guard = EnvVarGuard::set("TSK_STATE_DIR", &dir);
 
     let model = load_board_model().expect("load board model from an empty temp state dir");
 


### PR DESCRIPTION
## Summary

The store belongs to tsk, hosts are launchers. State and config unify at `~/.tsk` (`tasks.json` and `settings.json` side by side), so the herdr pane, any future multiplexer integration, and a bare terminal all edit one board.

## Changes

- `default_state_dir` / `default_config_dir`: `TSK_STATE_DIR` / `TSK_CONFIG_DIR`, else `$HOME/.tsk`. XDG branches and injected host variables removed from resolution.
- `HERDR_PLUGIN_STATE_DIR` / `HERDR_PLUGIN_CONFIG_DIR` deliberately ignored. Herdr's plugin docs: herdr "does not validate, sync, or delete" plugin state contents and "the plugin owns the file format and lifecycle"; using the injected dirs is a recommendation, not a requirement.
- `scripts/tsk-cli.sh` drops its state plumbing entirely; agents get the same store with zero setup.
- Resolver tests rewritten around the two candidates, including a test asserting host injection cannot fragment the store.
- README/AGENTS/CHANGELOG updated.

## Verification

Fresh green bar (fmt, clippy `-D warnings`, 27/27 test binaries). Live: launched the board through `herdr plugin pane open` with a scratch `$HOME`; herdr injected its own state dir, the board ignored it and showed only the scratch store's seeded task.

## Migration for existing data

Move current data once, with no board running:

```sh
mkdir -p ~/.tsk
mv ~/.local/state/herdr/plugins/herdr-tasks/tasks.json* ~/.tsk/
```
