### PR TITLE
feat(ui): wrap text at word boundaries everywhere instead of truncating

### DIFF
--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -613,6 +613,33 @@ fn apply_board_intent(
             edit_draft(model, EditBuffer::move_right);
             return Ok(IntentOutcome::None);
         }
+        BoardIntent::EditMoveUp | BoardIntent::EditMoveDown => {
+            // Vertical movement wraps at the painted notes width the renderer
+            // recorded; until a frame has been drawn (width 0) it stays inert.
+            let delta: isize = if matches!(intent, BoardIntent::EditMoveDown) {
+                1
+            } else {
+                -1
+            };
+            let target = model
+                .form
+                .as_ref()
+                .filter(|form| {
+                    form.focus == CaptureField::Notes
+                        && model.input_mode == BoardInputMode::EditNotes
+                })
+                .and_then(|form| {
+                    crate::ui::edit::wrapped_vertical_move(
+                        &form.notes,
+                        form.notes_width.get(),
+                        delta,
+                    )
+                });
+            if let Some(target) = target {
+                edit_draft(model, |draft| draft.set_cursor(target));
+            }
+            return Ok(IntentOutcome::None);
+        }
         BoardIntent::EditMoveLineStart => {
             edit_draft(model, EditBuffer::move_line_start);
             return Ok(IntentOutcome::None);

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -271,9 +271,20 @@ fn build_task_page_overlay<'a>(
                 header_rows.push(segment.clone());
             }
         }
+        // A caret hidden below the cap parks at the END of the last shown row:
+        // its own hidden column would otherwise paint an unrelated position on
+        // the ellipsis row.
+        let shown_cursor_row = cursor_row.min(rows.len().saturating_sub(1));
+        let shown_cursor_col = if cursor_row > shown_cursor_row {
+            rows.last()
+                .map(|last| render::display_width(last))
+                .unwrap_or(0)
+        } else {
+            cursor_col
+        };
         title_cursor = Some((
-            u16::try_from(cursor_row.min(rows.len().saturating_sub(1))).unwrap_or(u16::MAX),
-            u16::try_from(cursor_col).unwrap_or(u16::MAX),
+            u16::try_from(shown_cursor_row).unwrap_or(u16::MAX),
+            u16::try_from(shown_cursor_col).unwrap_or(u16::MAX),
         ));
     } else {
         let mut rows: Vec<String> = wrap_text(form.title.value(), title_avail)

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -7,7 +7,7 @@ use ratatui::Frame;
 
 use crate::domain::{HumanStatus, TaskScope};
 use crate::ui::capture::CaptureField;
-use crate::ui::edit::{escaped_draft_rows, escaped_line_window, wrapped_draft_rows};
+use crate::ui::edit::{escaped_line_window, wrap_text, wrapped_draft_rows, wrapped_edit_rows};
 use crate::ui::input::{help_card_lines, keymap_help_label};
 use crate::ui::mouse::BoardPopup;
 use crate::ui::present_line;
@@ -196,6 +196,8 @@ fn build_task_page_overlay<'a>(
                 cursor_col,
                 placeholder: "step…   enter save · ctrl+enter save+next · esc cancel",
                 refusal: editor.refusal.as_deref(),
+                above_rows: Vec::new(),
+                cursor_row_offset: 0,
                 // The bottom input replaces the shared status row. Forward recovery
                 // and record-refusal feedback to the surface that is actually visible.
                 message: model.message(),
@@ -210,6 +212,8 @@ fn build_task_page_overlay<'a>(
                     cursor_col,
                     placeholder: "thread…   enter save · esc cancel",
                     refusal: None,
+                    above_rows: Vec::new(),
+                    cursor_row_offset: 0,
                     // The shared bottom slot owns this refusal while it is visible, so it
                     // never leaks through the status row and remains legible at 40x10.
                     message: form.thread_refusal.as_deref(),
@@ -221,13 +225,6 @@ fn build_task_page_overlay<'a>(
     // entirely. The step editor uses the shared bottom slot, so steps alone
     // classify the page section.
     let page_geo = render::bottom_input_geometry(*geo, step_editor.is_some());
-    let lay = render::task_page_layout(
-        &page_geo,
-        render::steps_section(step_views.len()),
-        u16::from(model.input_mode() == BoardInputMode::EditNotes),
-    );
-    // The renderer and input reducer share this viewport size for page scrolling.
-    form.steps.window_rows.set(lay.notes_rows as usize);
     let status = bound_task
         .map(|task| task.status)
         .unwrap_or(HumanStatus::Ready);
@@ -240,35 +237,89 @@ fn build_task_page_overlay<'a>(
     };
     let glyph = render::status_glyph(status);
 
-    // Header: indent + glyph + title window + gap + right-aligned status word.
+    // Header: indent + glyph + the WRAPPED title rows + right-aligned status word
+    // on row 0. A long title wraps onto further bold rows indented under the
+    // glyph instead of truncating; edit mode wraps the draft with its cursor.
+    // The uniform budget keeps every row's wrap identical.
     let word_cells = status_word.chars().count() + 1;
     let title_avail = width.saturating_sub(4 + word_cells);
-    let (header, title_cursor) = if model.input_mode() == BoardInputMode::EditTitle {
-        let (window, col) = escaped_line_window(&form.title, title_avail);
-        (format!("{glyph} {window}"), Some(4 + col))
+    let editing_title = model.input_mode() == BoardInputMode::EditTitle;
+    let mut header_rows: Vec<String> = Vec::new();
+    let mut title_cursor = None;
+    if editing_title {
+        let (rows, cursor_row, cursor_col) = wrapped_edit_rows(&form.title, title_avail);
+        for (offset, segment) in rows.iter().enumerate() {
+            if offset == 0 {
+                header_rows.push(format!("{glyph} {segment}"));
+            } else {
+                header_rows.push(segment.clone());
+            }
+        }
+        title_cursor = Some((
+            u16::try_from(cursor_row.min(rows.len().saturating_sub(1))).unwrap_or(u16::MAX),
+            u16::try_from(cursor_col).unwrap_or(u16::MAX),
+        ));
+    } else {
+        for (offset, row) in wrap_text(form.title.value(), title_avail)
+            .iter()
+            .enumerate()
+        {
+            if offset == 0 {
+                header_rows.push(format!("{glyph} {}", row.text));
+            } else {
+                header_rows.push(row.text.clone());
+            }
+        }
+    }
+    let lay = render::task_page_layout(
+        &page_geo,
+        render::steps_section(step_views.len()),
+        u16::from(model.input_mode() == BoardInputMode::EditNotes),
+        header_rows.len().max(1) as u16,
+    );
+
+    // View mode supplies every wrapped note row; Notes edit mode wraps too, with the
+    // caret mapped into wrapped coordinates. The shared page painter combines that
+    // stream with the steps, then windows it once against the fixed viewport.
+    // Wrap at the width the painter can show WHOLE: the content region less its
+    // two-cell gutter and one further reserved cell, taken in the scrollbar state
+    // (content_width - 3 there), so an overflowing page never re-wraps rows that
+    // were already painted -- and no wrapped row ever ends in the presenter's … .
+    let notes_width = width.saturating_sub(6);
+    let want = lay.notes_rows as usize;
+    let editing_notes = model.input_mode() == BoardInputMode::EditNotes;
+    let (notes_rows, notes_cursor, more_lines, notes_scroll) = if editing_notes {
+        let (all_rows, cursor_row, cursor_column) = wrapped_edit_rows(&form.notes, notes_width);
+        // Wheel and arrow scrolling are inert while the editor owns the page, so the
+        // frame's scroll may follow the caret without fighting a reading position:
+        // keep the minimal window that still shows the caret's wrapped row.
+        let follow = form.notes_scroll.clamp(
+            cursor_row.saturating_sub(want.saturating_sub(1)),
+            cursor_row,
+        );
+        (
+            all_rows,
+            Some((
+                u16::try_from(cursor_row).unwrap_or(u16::MAX),
+                u16::try_from(cursor_column).unwrap_or(u16::MAX),
+            )),
+            0,
+            follow,
+        )
+    } else if form.notes.value().trim().is_empty() {
+        (Vec::new(), None, 0, form.notes_scroll)
     } else {
         (
-            format!("{glyph} {}", present_line(form.title.value(), title_avail)),
+            wrapped_draft_rows(&form.notes, notes_width),
             None,
+            0,
+            form.notes_scroll,
         )
-    };
-
-    // View mode supplies every wrapped note row. The shared page painter combines
-    // that stream with the steps, then windows it once against the fixed viewport.
-    let notes_width = width.saturating_sub(3);
-    let want = lay.notes_rows as usize;
-    let (notes_rows, notes_cursor, more_lines) = if model.input_mode() == BoardInputMode::EditNotes
-    {
-        let (rows, row, col) = escaped_draft_rows(&form.notes, notes_width, want);
-        (rows, Some((row, col)), 0)
-    } else if form.notes.value().trim().is_empty() {
-        (Vec::new(), None, 0)
-    } else {
-        (wrapped_draft_rows(&form.notes, notes_width), None, 0)
     };
     let content = render::page_content_layout(notes_rows.len(), step_views.len(), lay.notes_rows);
     form.notes_max_scroll.set(content.max_scroll);
     form.steps.content_start.set(content.steps_start);
+    form.notes_width.set(notes_width);
 
     // Meta footer: scope · thread · created · updated (ages only while the bound task is
     // present). Keep its clickable pieces separate from the painted string: a project basename
@@ -321,7 +372,7 @@ fn build_task_page_overlay<'a>(
     };
 
     QueueOverlay::TaskPage {
-        header,
+        header_rows,
         title_cursor,
         status_word,
         notes_rows,
@@ -329,7 +380,7 @@ fn build_task_page_overlay<'a>(
         more_lines,
         step_views,
         step_cursor: form.steps.cursor,
-        step_scroll: form.notes_scroll,
+        step_scroll: notes_scroll,
         step_marked: form.steps.delete_mark,
         step_editor,
         meta,
@@ -464,18 +515,40 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
         )
     }) {
         let input_width = (geo.row_width as usize).saturating_sub(2);
-        let (title, title_cursor) = escaped_line_window(&quick_add.title, input_width);
+        // A long title wraps instead of scrolling sideways: up to three rows fill
+        // the status-row slot and its reserved blanks, windowed by the minimum
+        // that keeps the caret's wrapped row visible.
+        const QUICK_ADD_MAX_ROWS: usize = 3;
+        let (all_rows, cursor_row, cursor_column) =
+            wrapped_edit_rows(&quick_add.title, input_width);
+        let shown = all_rows.len().clamp(1, QUICK_ADD_MAX_ROWS);
+        let start = cursor_row
+            .min(all_rows.len().saturating_sub(1))
+            .saturating_sub(shown - 1);
+        let window: Vec<String> = all_rows[start..(start + shown).min(all_rows.len())].to_vec();
+        let caret_index = cursor_row.saturating_sub(start);
+        let title = window.last().cloned().unwrap_or_default();
+        // Continuations paint top-first (the painter stacks them upward by index).
+        let above_rows: Vec<String> = window[..window.len().saturating_sub(1)].to_vec();
+        let multiline = window.len() > 1;
         QueueOverlay::QuickAdd {
             input: crate::ui::render::BottomInputSlot {
                 text: title,
-                cursor_col: title_cursor,
+                cursor_col: u16::try_from(cursor_column).unwrap_or(u16::MAX),
                 placeholder: "title…   !p = desk · !p name = project · !t name = thread",
                 refusal: None,
                 // Save recovery owns the verb row; ordinary quick-add refusals
-                // use the shared slot's reserved row above the cursor.
-                message: (model.input_mode() != BoardInputMode::SaveRecovery)
+                // use the shared slot's reserved row above the cursor. A wrapped
+                // draft owns those rows itself, so the message yields while it is
+                // up and returns when the draft is back under the cap.
+                message: (!multiline && model.input_mode() != BoardInputMode::SaveRecovery)
                     .then(|| model.message())
                     .flatten(),
+                above_rows,
+                cursor_row_offset: u16::try_from(
+                    window.len().saturating_sub(1).saturating_sub(caret_index),
+                )
+                .unwrap_or(0),
             },
             project_scope: matches!(quick_add.scope, TaskScope::Project { .. }),
             recovery: model.input_mode() == BoardInputMode::SaveRecovery,

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -243,11 +243,27 @@ fn build_task_page_overlay<'a>(
     // The uniform budget keeps every row's wrap identical.
     let word_cells = status_word.chars().count() + 1;
     let title_avail = width.saturating_sub(4 + word_cells);
+    // The header may grow only inside the page body: it must stop one row short
+    // of the lowest chrome row with one note row still living under it, or a
+    // pathological title would eat the page (and the painter's chrome).
+    let page_bottom = [page_geo.rule_row, page_geo.status_row, page_geo.verb_row]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(page_geo.height);
+    let header_cap = page_bottom.saturating_sub(3).max(1) as usize;
     let editing_title = model.input_mode() == BoardInputMode::EditTitle;
     let mut header_rows: Vec<String> = Vec::new();
     let mut title_cursor = None;
     if editing_title {
-        let (rows, cursor_row, cursor_col) = wrapped_edit_rows(&form.title, title_avail);
+        let (mut rows, cursor_row, cursor_col) = wrapped_edit_rows(&form.title, title_avail);
+        let overflowed = rows.len() > header_cap;
+        rows.truncate(header_cap);
+        if overflowed {
+            if let Some(last) = rows.last_mut() {
+                *last = present_line(last, title_avail.saturating_sub(1));
+            }
+        }
         for (offset, segment) in rows.iter().enumerate() {
             if offset == 0 {
                 header_rows.push(format!("{glyph} {segment}"));
@@ -260,14 +276,22 @@ fn build_task_page_overlay<'a>(
             u16::try_from(cursor_col).unwrap_or(u16::MAX),
         ));
     } else {
-        for (offset, row) in wrap_text(form.title.value(), title_avail)
+        let mut rows: Vec<String> = wrap_text(form.title.value(), title_avail)
             .iter()
-            .enumerate()
-        {
+            .map(|row| row.text.clone())
+            .collect();
+        let overflowed = rows.len() > header_cap;
+        rows.truncate(header_cap);
+        if overflowed {
+            if let Some(last) = rows.last_mut() {
+                *last = present_line(last, title_avail.saturating_sub(1));
+            }
+        }
+        for (offset, row) in rows.iter().enumerate() {
             if offset == 0 {
-                header_rows.push(format!("{glyph} {}", row.text));
+                header_rows.push(format!("{glyph} {row}"));
             } else {
-                header_rows.push(row.text.clone());
+                header_rows.push(row.clone());
             }
         }
     }
@@ -277,6 +301,8 @@ fn build_task_page_overlay<'a>(
         u16::from(model.input_mode() == BoardInputMode::EditNotes),
         header_rows.len().max(1) as u16,
     );
+    // The renderer and input reducer share this viewport size for page scrolling.
+    form.steps.window_rows.set(lay.notes_rows as usize);
 
     // View mode supplies every wrapped note row; Notes edit mode wraps too, with the
     // caret mapped into wrapped coordinates. The shared page painter combines that
@@ -515,10 +541,12 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
         )
     }) {
         let input_width = (geo.row_width as usize).saturating_sub(2);
-        // A long title wraps instead of scrolling sideways: up to three rows fill
-        // the status-row slot and its reserved blanks, windowed by the minimum
-        // that keeps the caret's wrapped row visible.
-        const QUICK_ADD_MAX_ROWS: usize = 3;
+        // A long title wraps instead of scrolling sideways. Exactly ONE row above
+        // the input is reserved (the message row: the shifted rule sits two up),
+        // so the draft may span at most two painted rows, windowed by the
+        // minimum that keeps the caret's wrapped row visible. Longer drafts
+        // window vertically rather than touching chrome.
+        const QUICK_ADD_MAX_ROWS: usize = 2;
         let (all_rows, cursor_row, cursor_column) =
             wrapped_edit_rows(&quick_add.title, input_width);
         let shown = all_rows.len().clamp(1, QUICK_ADD_MAX_ROWS);

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -218,6 +218,10 @@ pub(super) struct BoardForm {
     /// renderer record what it actually laid out, without making the whole render path `&mut`
     /// or pushing geometry into every scroll intent.
     pub(super) notes_max_scroll: std::cell::Cell<usize>,
+    /// The notes wrap width the last painted frame used, recorded by the immutable
+    /// renderer for the same reason as `notes_max_scroll`: vertical arrow movement
+    /// wraps at the painted width, which only the renderer knows.
+    pub(super) notes_width: std::cell::Cell<usize>,
 }
 
 impl BoardForm {
@@ -292,6 +296,7 @@ impl BoardForm {
             notes_scroll: 0,
             steps: StepsPageState::default(),
             notes_max_scroll: std::cell::Cell::new(0),
+            notes_width: std::cell::Cell::new(0),
         }
     }
 

--- a/src/ui/capture.rs
+++ b/src/ui/capture.rs
@@ -115,6 +115,10 @@ pub struct CaptureModel {
     save_recovery: SaveRecovery<DomainState>,
     /// The id allocated in the staged working state, returned only after persistence succeeds.
     pending_saved_id: Option<Uuid>,
+    /// The Notes wrap width the last painted frame used. The renderer records it
+    /// because vertical arrow movement wraps at the painted width, which only the
+    /// render path knows; zero until then keeps the arrows inert.
+    pub notes_width: std::cell::Cell<usize>,
 }
 
 impl CaptureModel {
@@ -140,6 +144,7 @@ impl CaptureModel {
             message: None,
             save_recovery: SaveRecovery::new(),
             pending_saved_id: None,
+            notes_width: std::cell::Cell::new(0),
         }
     }
 
@@ -525,6 +530,26 @@ pub fn apply_capture_intent(
             move_draft(model, EditBuffer::move_word_right);
             Ok(CaptureOutcome::None)
         }
+        CaptureIntent::MoveUp | CaptureIntent::MoveDown => {
+            let delta: isize = if matches!(intent, CaptureIntent::MoveDown) {
+                1
+            } else {
+                -1
+            };
+            let target = (model.focused == CaptureField::Notes)
+                .then(|| {
+                    crate::ui::edit::wrapped_vertical_move(
+                        &model.notes,
+                        model.notes_width.get(),
+                        delta,
+                    )
+                })
+                .flatten();
+            if let Some(target) = target {
+                edit_draft(model, |draft| draft.set_cursor(target));
+            }
+            Ok(CaptureOutcome::None)
+        }
         CaptureIntent::Save => {
             // Enter while path-editing confirms Project{path}.
             if model.is_path_editing() {
@@ -741,6 +766,66 @@ fn text_field_block(
     (lines, cursor)
 }
 
+/// The Notes field: the draft wrapped to word boundaries across the field's rows,
+/// with a vertical window. Focus follows the caret so typing at the end is always
+/// visible; reading windows from the top and names hidden rows on a dim tail.
+fn notes_field_block(
+    draft: &EditBuffer,
+    row: ratatui::layout::Rect,
+    focused: bool,
+) -> (
+    Vec<Line<'static>>,
+    Option<(ratatui::layout::Rect, u16, u16)>,
+) {
+    let region = edit_block_region(row, CAPTURE_FIELD_LABEL_WIDTH);
+    let width = region.width as usize;
+    let height = region.height as usize;
+    if width == 0 || height == 0 {
+        return (Vec::new(), None);
+    }
+    let rows = crate::ui::edit::wrap_text(draft.value(), width);
+    let (start, cursor) = if focused {
+        let (cursor_row, cursor_col) =
+            crate::ui::edit::locate_wrapped_cursor(&rows, draft.cursor());
+        (
+            cursor_row.saturating_sub(height - 1),
+            Some((cursor_row, cursor_col)),
+        )
+    } else {
+        (0, None)
+    };
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let hidden = rows.len().saturating_sub(start + height);
+    for (index, wrapped) in rows.iter().skip(start).take(height).enumerate() {
+        let absolute = start + index;
+        let last_shown = index + 1 == height;
+        let text = if last_shown && hidden > 0 && !focused {
+            // Reading window: name what does not fit instead of implying an end.
+            let suffix = format!(" \u{2026} {hidden} more");
+            let budget = width.saturating_sub(render::display_width(&suffix));
+            format!("{}{suffix}", present_line(&wrapped.text, budget))
+        } else {
+            wrapped.text.clone()
+        };
+        lines.push(field_row_presented(
+            if absolute == 0 { Some("Notes:") } else { None },
+            text,
+            focused,
+        ));
+    }
+    if lines.is_empty() {
+        lines.push(field_row_presented(Some("Notes:"), String::new(), focused));
+    }
+    let cursor = cursor.map(|(cursor_row, cursor_col)| {
+        (
+            region,
+            u16::try_from(cursor_row.saturating_sub(start)).unwrap_or(u16::MAX),
+            u16::try_from(cursor_col).unwrap_or(u16::MAX),
+        )
+    });
+    (lines, cursor)
+}
+
 /// Draw the capture form into any ratatui frame (live TTY or TestBackend).
 ///
 /// Field and button positions match [`super::mouse::capture_layout`] for hit-testing.
@@ -769,9 +854,17 @@ pub fn draw_capture(frame: &mut Frame, model: &CaptureModel) {
     let thread_focused = model.focused == CaptureField::Thread;
     let (title_lines, title_cursor) =
         text_field_block("Title:", &model.title, layout.title_area, title_focused);
-    // a multiline Notes draft occupies the whole Notes field, one line per row.
+    // A multiline Notes draft occupies the whole Notes field, wrapped at word
+    // boundaries; the focused window follows the caret, an unfocused one reads
+    // from the top with a dim tail naming what does not fit.
+    model.notes_width.set(
+        layout
+            .notes_area
+            .width
+            .saturating_sub(CAPTURE_FIELD_LABEL_WIDTH) as usize,
+    );
     let (notes_lines, notes_cursor) =
-        text_field_block("Notes:", &model.notes, layout.notes_area, notes_focused);
+        notes_field_block(&model.notes, layout.notes_area, notes_focused);
     let (thread_lines, thread_cursor) =
         text_field_block("Thread:", &model.thread, layout.thread_area, thread_focused);
 
@@ -2205,7 +2298,7 @@ mod tests {
 
         let (unfocused, _) = rendered_notes(&model, area, notes_area);
         assert!(
-            unfocused[rows - 1].trim_end().ends_with('…'),
+            unfocused[rows - 1].contains("2 more"),
             "the omitted lines were dropped silently: {unfocused:?}"
         );
         assert!(
@@ -2222,6 +2315,43 @@ mod tests {
         );
         assert_eq!(cursor.y, notes_area.y + notes_area.height - 1);
         assert_eq!(cursor.x, notes_area.x + CAPTURE_FIELD_LABEL_WIDTH + 4);
+    }
+
+    /// Up and Down walk the WRAPPED rows of the Notes draft: over logical lines
+    /// (blank lines included) once the renderer has recorded the field width.
+    #[test]
+    fn notes_arrows_walk_wrapped_rows_once_the_paint_width_is_known() {
+        let snap = project_snapshot("/repos/app");
+        let mut domain = DomainState::new();
+        let mut model = CaptureModel::from_snapshot(&snap);
+        model.focused = CaptureField::Notes;
+        model.notes = EditBuffer::new("aa\n\nbb", 0);
+        // No frame painted yet: the arrows stay inert rather than guessing a width.
+        apply(&mut domain, &snap, &mut model, CaptureIntent::MoveDown);
+        assert_eq!(model.notes.cursor(), 0);
+
+        // Paint one frame at 60x14 so the model records the field's width, then
+        // move: Down crosses onto the blank middle row, Down again onto "bb".
+        let mut terminal = Terminal::new(TestBackend::new(60, 14)).expect("terminal");
+        terminal
+            .draw(|frame| draw_capture(frame, &model))
+            .expect("draw");
+        assert!(model.notes_width.get() > 0, "the frame recorded the width");
+
+        apply(&mut domain, &snap, &mut model, CaptureIntent::MoveDown);
+        assert_eq!(
+            model.notes.cursor(),
+            3,
+            "Down lands on the blank middle row"
+        );
+        apply(&mut domain, &snap, &mut model, CaptureIntent::MoveDown);
+        assert_eq!(model.notes.cursor(), 4, "Down lands on the last line");
+        apply(&mut domain, &snap, &mut model, CaptureIntent::MoveUp);
+        assert_eq!(model.notes.cursor(), 3, "Up returns to the blank row");
+        // Title keeps its single-line map: the intents are Notes-only there.
+        model.focused = CaptureField::Title;
+        apply(&mut domain, &snap, &mut model, CaptureIntent::MoveDown);
+        assert_eq!(model.title.cursor(), model.title.char_count());
     }
 
     /// The taller Notes field only claims rows the form does not otherwise need: at every

--- a/src/ui/edit.rs
+++ b/src/ui/edit.rs
@@ -403,10 +403,13 @@ pub(crate) struct WrappedRow {
 }
 
 impl WrappedRow {
-    /// Raw cursor index for a target column on this row, clamped into it. Columns
-    /// past the row's end resolve past its last character -- and past its whole
-    /// break when the row closes the line, so a caret parked at a row's end never
-    /// sits inside a `\r\n` pair.
+    /// Raw cursor index for a target column on this row, clamped into it. A
+    /// column past the row's end resolves past its last character -- and past
+    /// its whole break when the row closes the line, so a caret parked at a
+    /// row's end never sits inside a `\r\n` pair. A row that continues the
+    /// line instead clamps ONTO its last character: its `end_cursor` names the
+    /// NEXT row's first character, and returning it would make locate paint the
+    /// caret on that row, skipping the one the move targeted.
     fn cursor_at(&self, column: usize) -> usize {
         if self.cell_of.is_empty() || column < self.cell_of[0] {
             return self.first_raw;
@@ -417,7 +420,11 @@ impl WrappedRow {
             .rposition(|start| *start <= column)
             .unwrap_or(0);
         if offset == self.cell_of.len() - 1 && column >= self.width {
-            self.end_cursor
+            if self.ends_line {
+                self.end_cursor
+            } else {
+                self.last_raw
+            }
         } else {
             self.first_raw + offset
         }
@@ -498,7 +505,10 @@ pub(crate) fn wrap_text(value: &str, width: usize) -> Vec<WrappedRow> {
                     break;
                 }
             }
-            // Pass two builds the escaped text and per-character cell offsets.
+            // Pass two builds the escaped text, per-character cell offsets, and the
+            // row's PAINTED width: pass one's `used` keeps scanning past the soft
+            // break it rewinds to, so only the text actually emitted here is a
+            // truthful width for `cursor_at` and past-end columns.
             let mut text = String::new();
             let mut cell_of: Vec<usize> = Vec::new();
             let mut column = 0usize;
@@ -515,7 +525,7 @@ pub(crate) fn wrap_text(value: &str, width: usize) -> Vec<WrappedRow> {
                 first_raw: items[next].0,
                 last_raw,
                 cell_of,
-                width: used,
+                width: column,
                 starts_line: next == 0,
                 ends_line: false,
                 break_width: 0,
@@ -673,17 +683,6 @@ pub(crate) fn place_edit_cursor_at(frame: &mut Frame, region: Rect, row: u16, co
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn dbg_wrap() {
-        let value = "alpha beta gamma";
-        for row in crate::ui::edit::wrap_text(value, 6) {
-            println!(
-                "text={:?} first={} last={} width={}",
-                row.text, row.first_raw, row.last_raw, row.width
-            );
-        }
-    }
-
     use super::{
         escaped_draft_rows, field_viewport, seeded_draft, wrapped_draft_rows, wrapped_edit_rows,
         EditBuffer,
@@ -778,6 +777,48 @@ mod tests {
             wrapped_edit_rows(&seeded_draft("abc"), 0),
             (Vec::<String>::new(), 0, 0)
         );
+    }
+
+    /// A row shortened by a soft word break reports its PAINTED width, not the
+    /// pre-rewind scan total: `cursor_at` and past-end columns read that width,
+    /// and an inflated one both misplaces the caret and lets Down/Up skip rows.
+    #[test]
+    fn a_soft_broken_row_reports_its_painted_width() {
+        // "aa bb cc" at 5 cells: pass one scans 5 cells before rewinding to the
+        // space, so the row paints "aa " -- three cells, not five.
+        let rows = super::wrap_text("aa bb cc", 5);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].text, "aa ");
+        assert_eq!(rows[0].width, 3, "the soft-broken row over-reported width");
+        assert_eq!(rows[1].text, "bb cc");
+        assert_eq!(rows[1].width, 5);
+
+        // Down from the end (col 5) clamps onto row 0's last character rather
+        // than resolving past it to row 1's first char, which would pin the
+        // caret to row 1 and skip row 0 on the way back up.
+        let at_end = EditBuffer::new("aa bb cc", 8);
+        assert_eq!(super::wrapped_vertical_move(&at_end, 5, -1), Some(2));
+        assert_eq!(super::wrapped_vertical_move(&at_end, 5, -1), Some(2));
+        let on_row0 = EditBuffer::new("aa bb cc", 2);
+        assert_eq!(
+            super::wrapped_vertical_move(&on_row0, 5, -1),
+            None,
+            "already on the first row"
+        );
+    }
+
+    /// The same rewind applies across the break: a second line's first row keeps
+    /// an honest width after its own soft break (the F-8 shape).
+    #[test]
+    fn wrapped_widths_stay_honest_after_every_soft_break() {
+        let rows = super::wrap_text("12345\nabc defgh", 6);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].text, "12345");
+        assert!(rows[0].ends_line);
+        assert_eq!(rows[1].text, "abc ");
+        assert_eq!(rows[1].width, 4, "row kept the pre-rewind total of 6");
+        assert_eq!(rows[2].text, "defgh");
+        assert_eq!(rows[2].width, 5);
     }
 
     /// Words are not cut: a row that cannot fit its next character breaks after
@@ -1493,15 +1534,5 @@ mod tests {
         let (tail, tail_column) = field_viewport("你好世界", 4, 5);
         assert!(width_of(&tail) <= 5, "tail window overflowed: {tail:?}");
         assert!(tail_column <= width_of(&tail));
-    }
-}
-#[test]
-fn dbg_wrap() {
-    let value = "alpha beta gamma";
-    for row in crate::ui::edit::wrap_text(value, 6) {
-        println!(
-            "text={:?} first={} last={} width={}",
-            row.text, row.first_raw, row.last_raw, row.width
-        );
     }
 }

--- a/src/ui/edit.rs
+++ b/src/ui/edit.rs
@@ -41,6 +41,11 @@ impl EditBuffer {
         self.cursor
     }
 
+    /// Park the cursor at `index`, clamped into the value's character range.
+    pub(crate) fn set_cursor(&mut self, index: usize) {
+        self.cursor = index.min(self.char_count());
+    }
+
     // SHORTCUT: character indexing rescans the value -- fine for one-line titles and
     // short notes; carry a cached char index if this ever backs a large document.
     pub(crate) fn char_count(&self) -> usize {
@@ -315,52 +320,6 @@ pub(crate) fn escaped_line_window(draft: &EditBuffer, width: usize) -> (String, 
 /// keeps the cursor's line visible, which is [`field_viewport`]'s horizontal rule applied
 /// to rows. No line is dropped: unlike a stored note, every line here is reachable by
 /// moving the cursor, so the rows carry no omission marker.
-/// The whole draft wrapped to `width` cells, escaped, one row per wrapped line. View-only
-/// presentation (the task page's read mode): no cursor anchors any line, so every line
-/// One character's width in terminal cells, measured the same way the painter measures a row.
-fn char_cells(ch: char) -> usize {
-    Line::from(ch.to_string()).width()
-}
-
-/// wraps and nothing is dropped. An empty draft yields one empty row.
-pub(crate) fn wrapped_draft_rows(draft: &EditBuffer, width: usize) -> Vec<String> {
-    if width == 0 {
-        return Vec::new();
-    }
-    let mut rows: Vec<String> = Vec::new();
-    for line in split_line_breaks(draft.value()) {
-        let escaped: Vec<char> = terminal_text(line).chars().collect();
-        if escaped.is_empty() {
-            rows.push(String::new());
-            continue;
-        }
-        // Wrap on accumulated DISPLAY WIDTH, not scalar count. `width` is terminal cells, so
-        // chunking `escaped` (a Vec<char>) by count overflowed the row for any wide character:
-        // the painter then ellipsized the overflow instead of carrying it to the next row, and
-        // that text was lost from the page entirely rather than merely misdrawn.
-        let mut current = String::new();
-        let mut used = 0usize;
-        for ch in escaped {
-            let cells = char_cells(ch);
-            // A lone character wider than the whole column still gets its own row: pushing it
-            // keeps progress (an empty `current` must never be flushed) and the painter clips it.
-            if used + cells > width && !current.is_empty() {
-                rows.push(std::mem::take(&mut current));
-                used = 0;
-            }
-            current.push(ch);
-            used += cells;
-        }
-        if !current.is_empty() {
-            rows.push(current);
-        }
-    }
-    if rows.is_empty() {
-        rows.push(String::new());
-    }
-    rows
-}
-
 pub(crate) fn escaped_draft_rows(
     draft: &EditBuffer,
     width: usize,
@@ -410,6 +369,273 @@ pub(crate) fn escaped_draft_rows(
     )
 }
 
+/// One character's width in terminal cells, measured the same way the painter measures a row.
+fn char_cells(character: char) -> usize {
+    Line::from(character.to_string()).width()
+}
+
+/// One wrapped row of a value: the escaped text as painted, plus everything cursor
+/// mapping and vertical navigation need to translate between raw character positions
+/// and painted cells.
+#[derive(Debug, Clone)]
+pub(crate) struct WrappedRow {
+    /// Escaped text as painted.
+    pub text: String,
+    /// Raw scalar index of this row's first and last characters (inclusive).
+    /// A blank line's row carries no characters: both equal the line's start.
+    pub first_raw: usize,
+    pub last_raw: usize,
+    /// Cell offset of each raw character on this row, in row order; length equals
+    /// the number of raw characters living here.
+    pub cell_of: Vec<usize>,
+    /// Total display width of the row in terminal cells.
+    pub width: usize,
+    /// The row opens a logical line (its own line's first row).
+    pub starts_line: bool,
+    /// The row closes a logical line: the next row begins a new line.
+    pub ends_line: bool,
+    /// Width of the break following a line-closing row: 0 mid-line, 1 for a lone
+    /// `\n`/`\r`, 2 for a consumed `\r\n` pair.
+    pub break_width: usize,
+    /// Insertion index just past this row: `last_raw + 1`, or past the whole break
+    /// when the row closes its line (a pair counts as two).
+    pub end_cursor: usize,
+}
+
+impl WrappedRow {
+    /// Raw cursor index for a target column on this row, clamped into it. Columns
+    /// past the row's end resolve past its last character -- and past its whole
+    /// break when the row closes the line, so a caret parked at a row's end never
+    /// sits inside a `\r\n` pair.
+    fn cursor_at(&self, column: usize) -> usize {
+        if self.cell_of.is_empty() || column < self.cell_of[0] {
+            return self.first_raw;
+        }
+        let offset = self
+            .cell_of
+            .iter()
+            .rposition(|start| *start <= column)
+            .unwrap_or(0);
+        if offset == self.cell_of.len() - 1 && column >= self.width {
+            self.end_cursor
+        } else {
+            self.first_raw + offset
+        }
+    }
+}
+
+/// Wrap `value` into rows of at most `width` display cells, preferring word
+/// boundaries: a row that cannot fit the next character breaks after its last
+/// whitespace character, and only a run with no whitespace at all (or a single
+/// character wider than the whole allocation) hard-breaks at the cell edge.
+///
+/// Splitting on breaks happens first and escaping second, over the crate's one
+/// definition of a break ([`super::split_line_breaks`]); wrapping measures
+/// accumulated DISPLAY WIDTH, not scalar count, so double-width glyphs move whole
+/// to the next row instead of being clipped away.
+pub(crate) fn wrap_text(value: &str, width: usize) -> Vec<WrappedRow> {
+    let mut out: Vec<WrappedRow> = Vec::new();
+    if width == 0 {
+        return out;
+    }
+    let chars: Vec<char> = value.chars().collect();
+    // Cut into logical lines over chars, consuming a `\r\n` pair as one break:
+    // the same lines [`super::split_line_breaks`] yields, kept as char slices so
+    // raw cursor indices survive without byte/char translation.
+    let mut lines: Vec<&[char]> = Vec::new();
+    let mut from = 0usize;
+    let mut scan = 0usize;
+    while scan < chars.len() {
+        if chars[scan] == '\r' || chars[scan] == '\n' {
+            lines.push(&chars[from..scan]);
+            scan += if chars[scan] == '\r' && chars.get(scan + 1) == Some(&'\n') {
+                2
+            } else {
+                1
+            };
+            from = scan;
+        } else {
+            scan += 1;
+        }
+    }
+    lines.push(&chars[from..]);
+
+    let mut line_start = 0usize;
+    for line in &lines {
+        let line_opened_at = out.len();
+        // (raw index, character) pairs in line order.
+        let items: Vec<(usize, char)> = line
+            .iter()
+            .enumerate()
+            .map(|(offset, character)| (line_start + offset, *character))
+            .collect();
+        let mut next = 0usize;
+        while next < items.len() {
+            // Pass one finds this row's exclusive end: fill until the next
+            // character would overflow, then prefer the last whitespace already
+            // scanned -- a run with none hard-breaks, excluding the overflowing
+            // character. A single character wider than the whole allocation keeps
+            // its own row (an empty row is never flushed); the painter clips it.
+            let mut end = next;
+            let mut used = 0usize;
+            let mut soft_break: Option<usize> = None;
+            while end < items.len() {
+                let character = items[end].1;
+                let add: usize = terminal_text(&character.to_string())
+                    .chars()
+                    .map(char_cells)
+                    .sum();
+                if used + add > width && end > next {
+                    end = soft_break.unwrap_or(end);
+                    break;
+                }
+                used += add;
+                if character.is_whitespace() {
+                    soft_break = Some(end + 1);
+                }
+                end += 1;
+                if used > width {
+                    break;
+                }
+            }
+            // Pass two builds the escaped text and per-character cell offsets.
+            let mut text = String::new();
+            let mut cell_of: Vec<usize> = Vec::new();
+            let mut column = 0usize;
+            for (_, character) in &items[next..end] {
+                cell_of.push(column);
+                for painted in terminal_text(&character.to_string()).chars() {
+                    text.push(painted);
+                    column += char_cells(painted);
+                }
+            }
+            let last_raw = items[end - 1].0;
+            out.push(WrappedRow {
+                text,
+                first_raw: items[next].0,
+                last_raw,
+                cell_of,
+                width: used,
+                starts_line: next == 0,
+                ends_line: false,
+                break_width: 0,
+                end_cursor: last_raw + 1,
+            });
+            next = end;
+        }
+        if out.len() == line_opened_at {
+            // A blank logical line paints its own empty row.
+            out.push(WrappedRow {
+                text: String::new(),
+                first_raw: line_start,
+                last_raw: line_start,
+                cell_of: Vec::new(),
+                width: 0,
+                starts_line: true,
+                ends_line: false,
+                break_width: 0,
+                end_cursor: line_start,
+            });
+        }
+        // Close the line: mark its last row and advance past content plus break.
+        let end = line_start + line.len();
+        let break_width = if end < chars.len() {
+            usize::from(chars[end] == '\r' && chars.get(end + 1) == Some(&'\n')) + 1
+        } else {
+            0
+        };
+        if let Some(last) = out.last_mut() {
+            last.ends_line = true;
+            last.break_width = break_width;
+            last.end_cursor = end + break_width;
+        }
+        line_start = end + break_width;
+    }
+    out
+}
+
+/// Map a raw cursor index onto the wrapped layout: the row it paints on and the
+/// cell column within that row.
+///
+/// Conventions shared with the line movements and [`escaped_draft_rows`]: a cursor
+/// sitting ON a break reads as the line before it at its past-end column, except
+/// inside a `\r\n` pair, where it is pinned to the line that follows at column 0.
+pub(crate) fn locate_wrapped_cursor(rows: &[WrappedRow], cursor: usize) -> (usize, usize) {
+    // 1. A character carries its cursor: the first row owning this raw index.
+    for (index, row) in rows.iter().enumerate() {
+        if !row.cell_of.is_empty() && row.first_raw <= cursor && cursor <= row.last_raw {
+            let offset = cursor - row.first_raw;
+            return (index, row.cell_of[offset]);
+        }
+    }
+    // 2. A cursor sitting on the break itself -- on a lone `\n`, a lone `\r`, or
+    // the `\r` that opens a consumed pair -- reads as the line's past-end column.
+    for (index, row) in rows.iter().enumerate() {
+        if row.ends_line && cursor == row.last_raw + 1 {
+            return (index, row.width);
+        }
+    }
+    // 3. At or before a line's start -- value start, right after a break, blank
+    // line, or inside a `\r\n` pair (pinned forward): that line's first row, column 0.
+    for (index, row) in rows.iter().enumerate() {
+        if row.starts_line && cursor <= row.first_raw {
+            return (index, 0);
+        }
+    }
+    // 4. The value's very end.
+    let last = rows.len().saturating_sub(1);
+    (last, rows.get(last).map_or(0, |row| row.width))
+}
+
+/// The whole draft wrapped to `width` display cells, escaped, one row per wrapped
+/// line, plus the wrapped row and column where the draft's cursor belongs. Both are
+/// absolute: the row counts from the first returned row, and the column counts
+/// terminal cells from that row's first painted cell.
+///
+/// Wrapping prefers word boundaries ([`wrap_text`]) and nothing is dropped; an
+/// empty draft yields one empty row.
+pub(crate) fn wrapped_edit_rows(draft: &EditBuffer, width: usize) -> (Vec<String>, usize, usize) {
+    let rows = wrap_text(draft.value(), width);
+    let (row, column) = locate_wrapped_cursor(&rows, draft.cursor());
+    (
+        rows.into_iter().map(|wrapped| wrapped.text).collect(),
+        row,
+        column,
+    )
+}
+
+/// The whole draft wrapped to `width` display cells, escaped, one row per wrapped
+/// line. View-only presentation: no cursor anchors any line, so this is
+/// [`wrapped_edit_rows`] without its cursor report.
+pub(crate) fn wrapped_draft_rows(draft: &EditBuffer, width: usize) -> Vec<String> {
+    wrap_text(draft.value(), width)
+        .into_iter()
+        .map(|row| row.text)
+        .collect()
+}
+
+/// Move the draft's cursor vertically by `delta` wrapped rows, preserving the
+/// target column in cells as far as the destination row allows. Clamps at the
+/// first and last wrapped rows; `None` means nothing changed (zero width).
+pub(crate) fn wrapped_vertical_move(
+    draft: &EditBuffer,
+    width: usize,
+    delta: isize,
+) -> Option<usize> {
+    if width == 0 {
+        return None;
+    }
+    let rows = wrap_text(draft.value(), width);
+    let (current_row, column) = locate_wrapped_cursor(&rows, draft.cursor());
+    let target = current_row as isize + delta;
+    let target = target.clamp(0, rows.len().saturating_sub(1) as isize) as usize;
+    let cursor = rows
+        .get(target)
+        .map(|row| row.cursor_at(column))
+        .unwrap_or_else(|| draft.cursor());
+    (cursor != draft.cursor()).then_some(cursor)
+}
+
 /// The label columns off the front of every row of an edit region, keeping the region's
 /// full height for a draft spread over rows.
 ///
@@ -447,8 +673,187 @@ pub(crate) fn place_edit_cursor_at(frame: &mut Frame, region: Rect, row: u16, co
 
 #[cfg(test)]
 mod tests {
-    use super::{escaped_draft_rows, field_viewport, seeded_draft, wrapped_draft_rows, EditBuffer};
+    #[test]
+    fn dbg_wrap() {
+        let value = "alpha beta gamma";
+        for row in crate::ui::edit::wrap_text(value, 6) {
+            println!(
+                "text={:?} first={} last={} width={}",
+                row.text, row.first_raw, row.last_raw, row.width
+            );
+        }
+    }
+
+    use super::{
+        escaped_draft_rows, field_viewport, seeded_draft, wrapped_draft_rows, wrapped_edit_rows,
+        EditBuffer,
+    };
     use ratatui::text::Line;
+
+    /// `wrapped_edit_rows` wraps exactly as view mode does (it is the same
+    /// function with a cursor report), so the wide-character sweep covers both.
+    #[test]
+    fn wrapped_edit_rows_wrap_wide_characters_and_drop_nothing() {
+        let text = "日".repeat(30);
+        let width = 20;
+        let draft = seeded_draft(&text);
+        let (rows, row, column) = wrapped_edit_rows(&draft, width);
+
+        for wrapped in &rows {
+            assert!(
+                Line::from(wrapped.as_str()).width() <= width,
+                "row wider than {width} cells: {wrapped:?}"
+            );
+        }
+        assert_eq!(rows.concat(), text, "wide-character text was lost");
+        assert!(
+            rows.len() > 1,
+            "expected the wide run to wrap, got {rows:?}"
+        );
+
+        // The end cursor sits past the final glyph on the last wrapped row: ten
+        // double-width glyphs per row fill 20 cells exactly.
+        assert_eq!((row, column), (2, 20));
+        // And view mode is precisely this wrapping without the cursor report.
+        assert_eq!(wrapped_draft_rows(&draft, width), rows);
+    }
+
+    /// A long single-line draft wraps onto continuation rows and the cursor maps
+    /// into wrapped coordinates: an interior cursor lands on its own cell of the
+    /// continuation row, and the end cursor on the final chunk's past-end column.
+    #[test]
+    fn wrapped_edit_rows_map_the_cursor_onto_its_wrapped_row() {
+        let value = format!("{}xyz", "a".repeat(25));
+
+        // Cursor at 22: two characters into the second wrapped chunk (20 + 2).
+        let (rows, row, column) = wrapped_edit_rows(&EditBuffer::new(&value, 22), 20);
+        assert_eq!(rows, vec!["a".repeat(20), "aaaaaxyz".to_string()]);
+        assert_eq!((row, column), (1, 2));
+
+        // Cursor at the value's end: the last chunk's past-end column.
+        let (rows, row, column) = wrapped_edit_rows(&seeded_draft(&value), 20);
+        assert_eq!(rows, vec!["a".repeat(20), "aaaaaxyz".to_string()]);
+        assert_eq!((row, column), (1, 8));
+    }
+
+    /// Breaks spread over rows over one definition, and a cursor sitting ON a break
+    /// reads as the line before it at its past-end column -- except inside a CRLF
+    /// pair, pinned to the following line, matching [`escaped_draft_rows`].
+    #[test]
+    fn wrapped_edit_rows_read_one_definition_of_a_line_break() {
+        for value in [
+            "first\nsecond\nthird",
+            "first\r\nsecond\r\nthird",
+            "first\rsecond\rthird",
+        ] {
+            let (rows, row, column) = wrapped_edit_rows(&seeded_draft(value), 20);
+            assert_eq!(rows, vec!["first", "second", "third"], "{value:?}");
+            assert_eq!((row, column), (2, 5), "{value:?}");
+        }
+
+        // A cursor parked between a `\r` and its `\n` paints where the renderer
+        // already puts it: column 0 of the following row.
+        let (_, row, column) = wrapped_edit_rows(&EditBuffer::new("one\r\ntwo", 4), 20);
+        assert_eq!((row, column), (1, 0));
+
+        // A trailing break yields the final empty line, and the end cursor is on it.
+        let (rows, row, column) = wrapped_edit_rows(&seeded_draft("ab\n"), 20);
+        assert_eq!(rows, vec!["ab", ""]);
+        assert_eq!((row, column), (1, 0));
+
+        // While a cursor before that break stays on "ab" at its past-end column.
+        let (_, row, column) = wrapped_edit_rows(&EditBuffer::new("ab\n", 2), 20);
+        assert_eq!((row, column), (0, 2));
+    }
+
+    /// Degenerate shapes stay defined: an empty draft is one empty row with the
+    /// cursor at its origin; a zero-width allocation paints nothing.
+    #[test]
+    fn wrapped_edit_rows_handle_empty_drafts_and_zero_widths() {
+        assert_eq!(
+            wrapped_edit_rows(&seeded_draft(""), 20),
+            (vec![String::new()], 0, 0)
+        );
+        assert_eq!(
+            wrapped_edit_rows(&seeded_draft("abc"), 0),
+            (Vec::<String>::new(), 0, 0)
+        );
+    }
+
+    /// Words are not cut: a row that cannot fit its next character breaks after
+    /// the last whitespace it already holds, and only a whitespace-free run
+    /// hard-breaks at the cell edge. The break's trailing space stays row-end.
+    #[test]
+    fn wrap_text_prefers_word_boundaries_over_cell_edges() {
+        let rows_of = |value: &str, width| {
+            super::wrap_text(value, width)
+                .into_iter()
+                .map(|row| row.text)
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(
+            rows_of("the quick brown fox", 10),
+            vec!["the quick ", "brown fox"]
+        );
+        // A word longer than the whole allocation still hard-breaks...
+        assert_eq!(
+            rows_of("aaaaaaaaaaaa bb", 5),
+            vec!["aaaaa", "aaaaa", "aa bb"]
+        );
+        // ...and a whitespace-free value behaves exactly as before.
+        assert_eq!(rows_of("abcdefgh", 3), vec!["abc", "def", "gh"]);
+        // Multiple spaces collapse onto the row they end.
+        assert_eq!(rows_of("aa    bb", 4), vec!["aa  ", "  bb"]);
+    }
+
+    /// Vertical movement walks WRAPPED rows, preserving the target column in cells
+    /// and clamping at the first and last row.
+    #[test]
+    fn wrapped_vertical_move_walks_wrapped_rows_and_preserves_the_column() {
+        // "alpha beta gamma" at 6 cells wraps as "alpha ", "beta ", "gamma".
+        let value = "alpha beta gamma";
+        let rows = || {
+            super::wrap_text(value, 6)
+                .into_iter()
+                .map(|row| row.text)
+                .collect::<Vec<String>>()
+        };
+        assert_eq!(rows(), vec!["alpha ", "beta ", "gamma"]);
+
+        // Down from (0, col 3) lands on raw index 9 (the 'a' of "beta"); up again
+        // restores (0, col 3).
+        assert_eq!(
+            super::wrapped_vertical_move(&EditBuffer::new(value, 3), 6, 1),
+            Some(9)
+        );
+        assert_eq!(
+            super::wrapped_vertical_move(&EditBuffer::new(value, 9), 6, -1),
+            Some(3)
+        );
+
+        // Clamped at both ends rather than wrapping around.
+        assert_eq!(
+            super::wrapped_vertical_move(&EditBuffer::new(value, 1), 6, -1),
+            None
+        );
+        let at_end = EditBuffer::new(value, value.chars().count());
+        assert_eq!(
+            super::wrapped_vertical_move(&at_end, 6, 1),
+            None,
+            "the caret already sits on the last wrapped row"
+        );
+
+        // Blank logical lines are real rows: down crosses them column-zero.
+        assert_eq!(
+            super::wrapped_vertical_move(&EditBuffer::new("a\n\nb", 0), 10, 1),
+            Some(2)
+        );
+        assert_eq!(
+            super::wrapped_vertical_move(&EditBuffer::new("a\n\nb", 2), 10, 1),
+            Some(3)
+        );
+    }
 
     /// Wide characters must WRAP, never be clipped away.
     ///
@@ -1088,5 +1493,15 @@ mod tests {
         let (tail, tail_column) = field_viewport("你好世界", 4, 5);
         assert!(width_of(&tail) <= 5, "tail window overflowed: {tail:?}");
         assert!(tail_column <= width_of(&tail));
+    }
+}
+#[test]
+fn dbg_wrap() {
+    let value = "alpha beta gamma";
+    for row in crate::ui::edit::wrap_text(value, 6) {
+        println!(
+            "text={:?} first={} last={} width={}",
+            row.text, row.first_raw, row.last_raw, row.width
+        );
     }
 }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -59,6 +59,9 @@ pub enum CaptureIntent {
     /// One character toward the start / end of the draft.
     MoveLeft,
     MoveRight,
+    /// One WRAPPED row up / down in the multiline Notes draft.
+    MoveUp,
+    MoveDown,
     /// Either end of the cursor's own line.
     MoveLineStart,
     MoveLineEnd,
@@ -154,6 +157,8 @@ pub enum BoardIntent {
     /// One character toward the start / end of the draft.
     EditMoveLeft,
     EditMoveRight,
+    EditMoveUp,
+    EditMoveDown,
     /// Either end of the cursor's own line.
     EditMoveLineStart,
     EditMoveLineEnd,
@@ -720,6 +725,10 @@ fn map_form_edit_key(
             KeyCode::Delete => Some(BoardIntent::EditDeleteForward),
             KeyCode::Left => Some(BoardIntent::EditMoveLeft),
             KeyCode::Right => Some(BoardIntent::EditMoveRight),
+            // Vertical arrows navigate WRAPPED rows in the multiline Notes draft;
+            // Title and Thread are one line, so they stay inert there.
+            KeyCode::Up if focused == CaptureField::Notes => Some(BoardIntent::EditMoveUp),
+            KeyCode::Down if focused == CaptureField::Notes => Some(BoardIntent::EditMoveDown),
             KeyCode::Home => Some(BoardIntent::EditMoveLineStart),
             KeyCode::End => Some(BoardIntent::EditMoveLineEnd),
             KeyCode::Char(character) if !character.is_control() => {
@@ -780,6 +789,8 @@ pub fn intent_primary_action(intent: &BoardIntent) -> Option<PrimaryBoardAction>
         | BoardIntent::EditDeleteForward
         | BoardIntent::EditMoveLeft
         | BoardIntent::EditMoveRight
+        | BoardIntent::EditMoveUp
+        | BoardIntent::EditMoveDown
         | BoardIntent::EditMoveLineStart
         | BoardIntent::EditMoveLineEnd
         | BoardIntent::EditMoveWordLeft
@@ -1139,6 +1150,10 @@ pub fn map_capture_key_state(
             KeyCode::Delete => Some(CaptureIntent::DeleteForward),
             KeyCode::Left => Some(CaptureIntent::MoveLeft),
             KeyCode::Right => Some(CaptureIntent::MoveRight),
+            // Vertical arrows navigate WRAPPED rows in the multiline Notes draft;
+            // Title and Thread are one line, so they stay inert there.
+            KeyCode::Up if focused == CaptureField::Notes => Some(CaptureIntent::MoveUp),
+            KeyCode::Down if focused == CaptureField::Notes => Some(CaptureIntent::MoveDown),
             KeyCode::Home => Some(CaptureIntent::MoveLineStart),
             KeyCode::End => Some(CaptureIntent::MoveLineEnd),
             KeyCode::Char(c) if !c.is_control() => Some(CaptureIntent::Insert(c)),
@@ -1229,6 +1244,8 @@ pub fn intent_primary_capture_action(intent: &CaptureIntent) -> Option<PrimaryCa
         | CaptureIntent::DeleteForward
         | CaptureIntent::MoveLeft
         | CaptureIntent::MoveRight
+        | CaptureIntent::MoveUp
+        | CaptureIntent::MoveDown
         | CaptureIntent::MoveLineStart
         | CaptureIntent::MoveLineEnd
         | CaptureIntent::MoveWordLeft

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1529,6 +1529,12 @@ fn paint_task_page(
     let word = display_width(status_word);
     for (offset, row_text) in header_rows.iter().enumerate() {
         let y = lay.title_y.saturating_add(offset as u16);
+        // The builder caps `header_rows` to the page body; this clamp holds even
+        // if a future caller forgets, because painting past `bottom` would
+        // overwrite the rule/status/verb chrome the page must keep.
+        if y >= lay.bottom {
+            break;
+        }
         let line = if offset == 0 {
             let header = format!("  {row_text}");
             let mut line = Line::from(Span::styled(header.clone(), style_bold()));

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -101,6 +101,57 @@ pub struct TaskRowPaint<'a> {
     pub title_bold: bool,
 }
 
+/// Paint one task as ONE OR MORE list lines: the first is the classic glyph + title +
+/// right-aligned meta row; a title too wide for its budget wraps at word boundaries onto
+/// continuation lines indented into its own column, with no meta. Nothing is cut.
+pub fn paint_task_row_lines(
+    row: &TaskRowPaint<'_>,
+    geo: &TierGeometry,
+    leading_indent: usize,
+) -> Vec<Line<'static>> {
+    // The title room `paint_task_row_with_indent` derives must match here, so both
+    // share one computation of the prefix cells.
+    let row_w = geo.row_width as usize;
+    let meta_budget = geo.meta_column_width as usize;
+    let title_budget = if meta_budget == 0 {
+        row_w
+    } else {
+        geo.title_width as usize
+    };
+    let glyph_cells = display_width(&super::terminal_text(row.glyph));
+    let prefix_cells = leading_indent + 2 + glyph_cells + 1;
+    let room = title_budget.saturating_sub(prefix_cells).max(1);
+    let segments: Vec<String> = crate::ui::edit::wrap_text(row.title, room)
+        .into_iter()
+        .map(|wrapped| wrapped.text)
+        .collect();
+
+    let mut lines = Vec::with_capacity(segments.len());
+    // The first line reuses the classic painter verbatim with segment 0.
+    let head = TaskRowPaint {
+        title: &segments[0],
+        ..*row
+    };
+    lines.push(paint_task_row_with_indent(&head, geo, leading_indent));
+    // Continuations indent into the title column (past glyph and space).
+    let indent = " ".repeat(prefix_cells);
+    let continuation_style = if row.selected {
+        style_reverse()
+    } else {
+        style_plain()
+    };
+    for segment in segments.iter().skip(1) {
+        lines.push(bound_line(
+            Line::from(Span::styled(
+                format!("{indent}{segment}"),
+                continuation_style,
+            )),
+            row_w,
+        ));
+    }
+    lines
+}
+
 /// Paint one task row: glyph+title on the left, right-aligned meta in the meta budget.
 ///
 /// Title and meta never share cells. Over-budget text is clipped through
@@ -276,9 +327,33 @@ pub struct BottomInputSlot<'a> {
     /// A contextual refusal that needs its own row above the input. Empty-text
     /// refusals belong in `refusal` so they never cover the cursor.
     pub message: Option<&'a str>,
+    /// Wrapped continuation rows painting ABOVE the input line, top row first.
+    /// Empty for single-line drafts; a multiline draft also suppresses `message`,
+    /// which shares those rows.
+    pub above_rows: Vec<String>,
+    /// Vertical offset of the terminal caret above the input line (0 = on it).
+    pub cursor_row_offset: u16,
+}
+
+impl<'a> BottomInputSlot<'a> {
+    /// The single-line shape every existing editor paints.
+    pub fn single_line(text: String, cursor_col: u16, placeholder: &'static str) -> Self {
+        Self {
+            text,
+            cursor_col,
+            placeholder,
+            refusal: None,
+            message: None,
+            above_rows: Vec::new(),
+            cursor_row_offset: 0,
+        }
+    }
 }
 
 /// Transient overlay painted above the queue frame (palette, help, scope dropdown).
+/// Variant payloads live one per frame and rebuild each paint, so the size
+/// difference between them is not worth boxing.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Default)]
 pub enum QueueOverlay<'a> {
     #[default]
@@ -313,10 +388,12 @@ pub enum QueueOverlay<'a> {
     /// The task page: a full-height, view-first takeover for one bound task. `focus` is
     /// `None` in view mode; field edits focus the same drafts the board form carries.
     TaskPage {
-        /// Status glyph + space + the title draft, windowed to fit beside the status word.
-        header: String,
-        /// Terminal cursor column inside `header` while the title is being edited.
-        title_cursor: Option<u16>,
+        /// The title's wrapped rows. Row 0 carries the status glyph; later rows are
+        /// bare segments the painter indents under it. View mode wraps the stored
+        /// title; edit mode wraps the draft.
+        header_rows: Vec<String>,
+        /// Terminal cursor (row, col) inside `header_rows` while the title is edited.
+        title_cursor: Option<(u16, u16)>,
         /// The task's status word, dim and right-aligned on the header row.
         status_word: &'static str,
         /// View mode: the wrapped notes windowed by the page scroll. Edit mode: the
@@ -938,8 +1015,8 @@ fn paint_overlay(
         }
         QueueOverlay::QuickAdd { .. } => {}
         QueueOverlay::TaskPage {
-            ref header,
-            title_cursor,
+            ref header_rows,
+            ref title_cursor,
             status_word,
             ref notes_rows,
             notes_cursor,
@@ -958,7 +1035,7 @@ fn paint_overlay(
             paint_task_page(
                 frame,
                 geo,
-                header,
+                header_rows,
                 *title_cursor,
                 status_word,
                 notes_rows,
@@ -1365,6 +1442,7 @@ pub fn task_page_layout(
     geo: &TierGeometry,
     _section: StepsSection,
     _notes_floor: u16,
+    title_rows: u16,
 ) -> TaskPageLayout {
     let height = geo.height;
     let bottom = [geo.rule_row, geo.status_row, geo.verb_row]
@@ -1372,18 +1450,20 @@ pub fn task_page_layout(
         .flatten()
         .min()
         .unwrap_or(height);
-    // Blank row 0, title 1, divider 2, notes, steps, meta last.
+    // Blank row 0, the title's wrapped rows from 1, divider, notes, steps, meta last.
+    let title_rows = title_rows.max(1);
     let title_y: u16 = if bottom >= 2 { 1 } else { 0 };
+    let title_end = title_y.saturating_add(title_rows);
     let meta_y = if bottom >= 4 { Some(bottom - 1) } else { None };
-    let divider_y = if bottom >= 5 {
-        Some(title_y.saturating_add(1))
+    // The divider shows only when a note row survives under it; otherwise the
+    // notes body starts directly under the title.
+    let divider_y = if bottom >= title_end.saturating_add(3) {
+        Some(title_end)
     } else {
         None
     };
-    let notes_y = if bottom >= 3 {
-        divider_y
-            .map(|y| y + 1)
-            .unwrap_or(title_y.saturating_add(1))
+    let notes_y = if bottom > title_end {
+        divider_y.map(|y| y + 1).unwrap_or(title_end)
     } else {
         bottom
     };
@@ -1406,8 +1486,8 @@ pub fn task_page_layout(
 fn paint_task_page(
     frame: &mut Frame<'_>,
     geo: &TierGeometry,
-    header: &str,
-    title_cursor: Option<u16>,
+    header_rows: &[String],
+    title_cursor: Option<(u16, u16)>,
     status_word: &str,
     notes_rows: &[String],
     notes_cursor: Option<(u16, u16)>,
@@ -1429,36 +1509,61 @@ fn paint_task_page(
     }
     // `focus == Notes` arrives from the same frame's input mode the payload builder
     // used, so both sides of the payload/paint seam budget the same notes floor.
+    let title_row_count = header_rows.len().max(1) as u16;
     let lay = task_page_layout(
         geo,
         steps_section(step_views.len()),
         u16::from(focus == Some(CaptureField::Notes)),
+        title_row_count,
     );
     if lay.bottom == 0 {
         return;
     }
     frame.render_widget(Clear, Rect::new(0, 0, width, lay.bottom));
 
-    // Header: the title's left gutter and a matching two-cell right gutter frame
-    // the status word. The scrollbar belongs only to the content viewport below.
+    // Header: every wrapped title row paints bold under a shared left gutter;
+    // row 0 carries the status glyph and frames the dim right-aligned status
+    // word, later rows indent into the glyph column. The scrollbar belongs only
+    // to the content viewport below.
     let header_width = width.saturating_sub(2);
-    let header = format!("  {header}");
-    let mut line = Line::from(Span::styled(header.clone(), style_bold()));
-    let used = display_width(&header);
     let word = display_width(status_word);
-    if used + word < header_width as usize {
-        line.spans
-            .push(Span::raw(" ".repeat(header_width as usize - used - word)));
-        line.spans
-            .push(Span::styled(status_word.to_string(), style_dim()));
+    for (offset, row_text) in header_rows.iter().enumerate() {
+        let y = lay.title_y.saturating_add(offset as u16);
+        let line = if offset == 0 {
+            let header = format!("  {row_text}");
+            let mut line = Line::from(Span::styled(header.clone(), style_bold()));
+            let used = display_width(&header);
+            if used + word < header_width as usize {
+                line.spans
+                    .push(Span::raw(" ".repeat(header_width as usize - used - word)));
+                line.spans
+                    .push(Span::styled(status_word.to_string(), style_dim()));
+            }
+            line
+        } else {
+            Line::from(Span::styled(format!("    {row_text}"), style_bold()))
+        };
+        put_line(frame, y, header_width, line);
     }
-    put_line(frame, lay.title_y, header_width, line);
     hits.push(
         QueueHitTarget::FormTitle,
-        Rect::new(0, lay.title_y, width, 1),
+        Rect::new(0, lay.title_y, width, title_row_count),
     );
-    if let Some(col) = title_cursor {
-        place_edit_cursor(frame, Rect::new(0, lay.title_y, width, 1), col);
+    if let Some((cursor_row, cursor_col)) = title_cursor {
+        // Every title row shares the four-cell gutter (two leading blanks plus
+        // glyph and space), so the wrapped field starts at column 4 on all of them.
+        let field_x = 4u16.min(width.saturating_sub(1));
+        place_edit_cursor_at(
+            frame,
+            Rect::new(
+                field_x,
+                lay.title_y,
+                width.saturating_sub(field_x),
+                title_row_count,
+            ),
+            cursor_row.min(title_row_count.saturating_sub(1)),
+            cursor_col.min(width.saturating_sub(field_x).saturating_sub(1)),
+        );
     }
 
     // Divider, its right end naming wrapped note rows the window does not show.
@@ -1661,7 +1766,7 @@ fn paint_page_scope_dropdown(
     }
     // The dropdown anchors on the meta footer, which never moves with the steps,
     // and never opens while a field edit owns the page.
-    let lay = task_page_layout(geo, StepsSection::None, 0);
+    let lay = task_page_layout(geo, StepsSection::None, 0, 1);
     let Some(meta_y) = lay.meta_y else {
         return;
     };
@@ -1812,12 +1917,15 @@ fn detail_lines_for_task(task: &Task, now: SystemTime, width: u16) -> Vec<Line<'
             style_dim(),
         ));
     } else {
+        // Preview rows wrap at word boundaries like every other note surface, so
+        // a long line continues under itself instead of being cut at the edge.
+        let room = (width as usize).saturating_sub(display_width(indent) + 1);
         let mut shown = 0usize;
         let mut remaining = 0usize;
-        for note_line in notes_text.lines() {
+        for note_row in crate::ui::edit::wrap_text(notes_text, room) {
             if shown < PEEK_NOTES_LINE_LIMIT {
                 lines.push(paint_bounded_line(
-                    &format!("{indent}{note_line}"),
+                    &format!("{indent}{}", note_row.text),
                     width,
                     style_dim(),
                 ));
@@ -1895,22 +2003,32 @@ fn build_list_rows(
             return;
         };
         let meta = row_meta(task, model.now, in_project_section);
-        let line = paint_task_row_with_indent(
+        let selected = model.selection_id == Some(task.id)
+            && !matches!(model.overlay, QueueOverlay::ScopeDropdown { .. });
+        // A long title wraps onto continuation lines indented under its own first
+        // row; every painted line carries the task's hit target and selection.
+        let lines = paint_task_row_lines(
             &TaskRowPaint {
                 glyph: status_glyph(task.status),
                 title: &task.title,
                 meta: &meta,
-                selected: model.selection_id == Some(task.id)
-                    && !matches!(model.overlay, QueueOverlay::ScopeDropdown { .. }),
+                selected,
                 title_bold: false,
             },
             geo,
             usize::from(indented_under_thread) * 2,
         );
-        if model.selection_id == Some(task.id) {
+        if selected {
             *selected_idx = Some(out.len());
         }
-        out.push(ListRow::Task { id: task.id, line });
+        for line in lines {
+            out.push(ListRow::Task { id: task.id, line });
+        }
+        if selected {
+            // Selection follow anchors the whole block, so a two-line selection
+            // never leaves its tail below the fold.
+            *selected_idx = Some(out.len() - 1);
+        }
         if detail_target == Some(task.id) {
             for line in detail_lines_for_task(task, model.now, geo.row_width) {
                 out.push(ListRow::Detail(line));
@@ -2067,6 +2185,28 @@ pub(crate) fn paint_bottom_input_slot(
     width: u16,
     input: &BottomInputSlot<'_>,
 ) {
+    // Wrapped continuation rows stack upward from the input line, inside the
+    // reserved blank rows; anything past the frame top is dropped rather than
+    // overwriting chrome above them.
+    let above_count = input.above_rows.len() as u16;
+    for (index, above) in input.above_rows.iter().enumerate() {
+        let offset = above_count - index as u16;
+        let Some(y) = row.checked_sub(offset) else {
+            break;
+        };
+        if y == 0 && offset > 0 {
+            break;
+        }
+        put_line(
+            frame,
+            y,
+            width,
+            bound_line(
+                Line::from(Span::styled(format!("\u{258e} {above}"), style_bold())),
+                width as usize,
+            ),
+        );
+    }
     let body = &input.text;
     let placeholder = input.placeholder;
     let cursor_col = input.cursor_col;
@@ -2097,11 +2237,14 @@ pub(crate) fn paint_bottom_input_slot(
         width,
         bound_line(Line::from(spans), width as usize),
     );
+    let caret_row = row
+        .checked_sub(input.cursor_row_offset.min(above_count))
+        .unwrap_or(row);
     place_edit_cursor(
         frame,
         Rect::new(
             prefix_width.min(width.saturating_sub(1)),
-            row,
+            caret_row,
             width.saturating_sub(prefix_width),
             1,
         ),

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -318,29 +318,34 @@ fn title_edit_cursor_and_window_track_the_actual_paint_width_not_a_hardcoded_one
         );
     }
 
-    // Narrow (40 cols, compact): the draft overflows the header window, so it scrolls to
-    // keep the cursor (at the draft's end) visible — the tail must be on screen, not the
-    // head, and the cursor must land inside the painted field, not off past its right edge.
+    // Narrow (40 cols, compact): the draft overflows the header, so it WRAPS onto a
+    // second bold header row -- nothing is cut, and the caret follows onto that
+    // continuation row at its past-end column.
     {
         let backend = TestBackend::new(40, 10);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal
             .draw(|frame| draw_board(frame, &model))
             .expect("draw 40x10");
-        let (title_y, row) = (0..10)
-            .map(|y| (y, row_text(&terminal, 40, y)))
-            .find(|(_, row)| row.contains("vwxyz"))
-            .expect("compact task page header row");
-        assert_eq!(title_y, 1, "the page header paints under one blank row");
+        // 62 whitespace-free characters at a 30-cell field wrap as 30 / 30 / 2.
+        let head_row = row_text(&terminal, 40, 1);
         assert!(
-            !row.contains("0123456789"),
-            "40-wide header must not still show the head once the window has scrolled: {row:?}"
+            head_row.contains("0123456789"),
+            "40-wide header keeps the head on its first wrapped row: {head_row:?}"
+        );
+        let tail_row = (0..10)
+            .map(|y| (y, row_text(&terminal, 40, y)))
+            .find(|(_, row)| row.trim_end().contains("yz"))
+            .expect("wrapped title continuation row");
+        assert_ne!(
+            tail_row.0, 1,
+            "the title's tail must wrap below the first header row"
         );
         let cursor = terminal.get_cursor_position().expect("cursor position");
         assert_eq!(
             cursor,
-            ratatui::layout::Position::new(4 + 29, title_y),
-            "cursor must land at the window's own last column, matching the text actually painted"
+            ratatui::layout::Position::new(4 + 2, tail_row.0),
+            "caret lands at the two-character tail's past-end column"
         );
     }
 }

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -2942,3 +2942,63 @@ fn step_cursor_moves_do_not_rescroll_the_page_when_steps_fit() {
         "the walked-to step must be visible:\\n{text}"
     );
 }
+
+/// A title-edit caret hidden below the capped header parks at the END of the
+/// last shown row, never at its hidden column on the ellipsis row.
+#[test]
+fn edit_title_caret_parks_at_the_capped_headers_end() {
+    let mut domain = DomainState::new();
+    let title = "word ".repeat(120);
+    domain
+        .create(
+            &title,
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+    board_rows(&model, 40, 10);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditTitle,
+        None,
+        None,
+    )
+    .expect("edit title");
+
+    let mut terminal = Terminal::new(TestBackend::new(40, 10)).expect("terminal");
+    terminal
+        .draw(|frame| draw_board(frame, &model))
+        .expect("draw edit page");
+    let rows = board_rows(&model, 40, 10);
+    // The capped header's last row carries the marker; the caret must sit at
+    // that row's past-end column, immediately after the "…".
+    let last_header = (1..7)
+        .rev()
+        .find(|&y| rows[y].contains("wor…"))
+        .expect("capped header row");
+    let cursor = terminal.backend().cursor_position();
+    assert_eq!(
+        cursor.y, last_header as u16,
+        "caret left the last header row"
+    );
+    let painted = rows[last_header].trim_end();
+    assert_eq!(
+        cursor.x as usize,
+        painted.chars().count(),
+        "caret must sit immediately after the marker, not at a hidden column:\n{}",
+        rows.join("\n")
+    );
+}

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -2707,30 +2707,31 @@ fn quick_add_wraps_a_long_title_into_the_reserved_rows() {
         .expect("draw quick add");
     let rows = board_rows(&model, 80, 24);
     let prompt_rows: Vec<&String> = rows.iter().filter(|row| row.contains("▎")).collect();
-    assert!(
-        prompt_rows.len() > 1,
-        "a long quick-add draft must wrap past one row:\n{}",
+    assert_eq!(
+        prompt_rows.len(),
+        2,
+        "exactly one continuation row fits the reserved blank above the input:\n{}",
         rows.join("\n")
     );
     let text = rows.join("\n");
-    assert!(
-        !text.contains('…'),
-        "a wrapped quick-add draft never truncates:\n{text}"
-    );
-    // Reading order survives wrapping: the draft's head (w0) paints above its
-    // tail (w39), each on its own ▎ row.
-    let head = rows
-        .iter()
-        .position(|row| row.contains("w0 "))
-        .expect("head segment painted");
+    // Reading order survives wrapping: an earlier segment paints above the tail,
+    // and the rule row two above the input stays chrome, never draft text.
     let tail = rows
         .iter()
         .position(|row| row.contains("w39"))
         .expect("tail segment painted");
-    assert_ne!(head, tail, "the draft must span more than one row:\n{text}");
+    let above = rows
+        .iter()
+        .position(|row| row.contains("▎") && !row.contains("w39"))
+        .expect("continuation row painted");
     assert!(
-        head < tail,
+        above < tail,
         "the draft reads top-down across its wrapped rows:\n{text}"
+    );
+    assert!(
+        rows[tail - 2].starts_with('─'),
+        "the rule row stays a rule row:\n{}",
+        rows.join("\n")
     );
 }
 
@@ -2833,5 +2834,111 @@ fn notes_edit_arrows_move_across_logical_and_wrapped_rows() {
     assert!(
         after < before,
         "Up must climb from the wrapped tail row ({before}) onto the head row, got {after}"
+    );
+}
+
+/// A pathological title cannot eat the page: at the compact floor the wrapped
+/// header stops inside the page body, the last shown row carries the omission
+/// marker, and the rule/status/verb chrome survives untouched.
+#[test]
+fn task_page_caps_a_wrapped_header_inside_the_page_body() {
+    let mut domain = DomainState::new();
+    let title = "word ".repeat(120);
+    domain
+        .create(
+            &title,
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+
+    let rows = board_rows(&model, 40, 10);
+    // Chrome rows keep their own content: rule dashes at 7, status at 8, verbs at 9.
+    assert!(
+        rows[7].starts_with('─'),
+        "the rule row was overwritten by the header:\n{}",
+        rows.join("\n")
+    );
+    assert!(
+        rows[8].contains("done"),
+        "the status row was overwritten by the header:\n{}",
+        rows.join("\n")
+    );
+    assert!(
+        rows[9].contains("alt+e"),
+        "the verb row was overwritten by the header:\n{}",
+        rows.join("\n")
+    );
+    // The header itself is bounded and honest about what it hides.
+    assert!(
+        (1..7).any(|y| rows[y].contains("wor…")),
+        "a capped header names the rows it cannot show:\n{}",
+        rows.join("\n")
+    );
+}
+
+/// Step navigation must not re-scroll the whole page on every cursor move: the
+/// viewport height the renderer records (`window_rows`) bounds the scroll math,
+/// and losing it collapses the window to one row.
+#[test]
+fn step_cursor_moves_do_not_rescroll_the_page_when_steps_fit() {
+    let mut domain = DomainState::new();
+    let id = domain
+        .create(
+            "Steps page",
+            Some("n".to_string()),
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    for index in 0..20 {
+        domain
+            .add_step(id, format!("step {index}"))
+            .expect("add step");
+    }
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+    // One painted frame records the viewport; then walk the step cursor down.
+    board_rows(&model, 80, 24);
+    for _ in 0..4 {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::PageScrollDown,
+            None,
+            None,
+        )
+        .expect("advance step cursor");
+    }
+    let rows = board_rows(&model, 80, 24);
+    let text = rows.join("\n");
+    assert!(
+        text.contains("step 0"),
+        "a fitting steps window must not scroll its head away:\\n{text}"
+    );
+    assert!(
+        text.contains("step 3"),
+        "the walked-to step must be visible:\\n{text}"
     );
 }

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -624,6 +624,8 @@ fn quick_add_refusal_message_uses_the_reserved_blank_row_without_color_or_overfl
                 placeholder: "title…",
                 refusal: None,
                 message: Some("Title required"),
+                above_rows: Vec::new(),
+                cursor_row_offset: 0,
             },
             project_scope: false,
             recovery: false,
@@ -878,7 +880,7 @@ fn task_page_renders_header_notes_and_meta_as_a_full_takeover_in_both_tiers() {
     let view = fixture_view(&tasks, false);
     let mut model = fixture_model(&tasks, &view);
     model.overlay = QueueOverlay::TaskPage {
-        header: "\u{25cb} Rename this task".to_string(),
+        header_rows: vec!["\u{25cb} Rename this task".to_string()],
         title_cursor: None,
         status_word: "ready",
         notes_rows: vec![
@@ -1339,6 +1341,104 @@ fn shift_tab_from_scope_resets_notes_stream_origin_and_aligns_caret() {
         terminal.backend().cursor_position().y,
         19,
         "Shift+Tab Notes caret must land on its painted draft row"
+    );
+}
+
+/// A long single-line note wraps onto continuation rows while the Notes editor is
+/// open: both ends of the draft stay on the page instead of the cursor's row
+/// scrolling sideways under a fixed-width window.
+#[test]
+fn notes_edit_wraps_a_long_line_instead_of_scrolling_horizontally() {
+    let mut domain = DomainState::new();
+    let note = format!("HEAD{}TAIL", "w".repeat(200));
+    domain
+        .create(
+            "Long line",
+            Some(note),
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+    board_rows(&model, 80, 24);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditNotes,
+        None,
+        None,
+    )
+    .expect("edit notes");
+
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
+    terminal
+        .draw(|frame| draw_board(frame, &model))
+        .expect("draw edit page");
+    let rows = board_rows(&model, 80, 24);
+    assert!(
+        rows.iter().any(|row| row.contains("HEAD")),
+        "the note's head must stay visible while editing:\n{}",
+        rows.join("\n")
+    );
+    let tail_row = rows
+        .iter()
+        .position(|row| row.contains("TAIL"))
+        .unwrap_or_else(|| panic!("the note's tail must wrap into view:\n{}", rows.join("\n")))
+        as u16;
+    assert_eq!(
+        terminal.backend().cursor_position().y,
+        tail_row,
+        "the caret must sit on the wrapped continuation row carrying the draft's end:\n{}",
+        rows.join("\n")
+    );
+}
+
+/// View mode already wraps stored notes (`wrapped_draft_rows`); this pins that
+/// contract so a later presenter change cannot quietly reintroduce truncation.
+#[test]
+fn task_page_view_wraps_long_notes_instead_of_truncating() {
+    let mut domain = DomainState::new();
+    let note = format!("HEAD{}TAIL", "w".repeat(200));
+    domain
+        .create(
+            "Long line",
+            Some(note),
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+
+    let rows = board_rows(&model, 80, 24);
+    assert!(
+        rows.iter().any(|row| row.contains("HEAD")),
+        "view mode lost the note's head:\n{}",
+        rows.join("\n")
+    );
+    assert!(
+        rows.iter().any(|row| row.contains("TAIL")),
+        "view mode truncated the note instead of wrapping it:\n{}",
+        rows.join("\n")
     );
 }
 
@@ -2528,5 +2628,210 @@ fn all_golden_frames_pass_no_color_sgr_scan() {
     assert_eq!(
         scanned, 6,
         "expected the six board surface goldens (board, board_default_split_78, accordion, palette, help, done_drawer) in {dir:?}"
+    );
+}
+
+/// The main list wraps a long title onto continuation lines indented under the
+/// task's own first row: nothing is cut, and no row ends in an omission marker.
+#[test]
+fn board_list_wraps_a_long_title_onto_a_continuation_row() {
+    let mut domain = DomainState::new();
+    let title = "alpha bravo charlie delta echo foxtrot golf hotel".to_string();
+    domain
+        .create(
+            &title,
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let model = BoardModel::from_domain(&domain, None);
+
+    let rows = board_rows(&model, 80, 24);
+    // The head row keeps the classic shape (gutter + glyph + title head).
+    assert!(
+        rows.iter().any(|row| row.contains("○ alpha")),
+        "head row must keep the glyph + title shape:\n{}",
+        rows.join("\n")
+    );
+    // A continuation line indents exactly four cells into the title column.
+    let continuation = rows
+        .iter()
+        .find(|row| row.contains("hotel"))
+        .unwrap_or_else(|| panic!("no wrapped continuation row:\n{}", rows.join("\n")));
+    assert!(
+        continuation.starts_with("    ") && !continuation.starts_with("     "),
+        "continuation rows indent four cells under the title column: {continuation:?}"
+    );
+    // Neither of the task's own rows may carry an omission marker (the verb bar's
+    // own tier budget is a different surface).
+    let head = rows
+        .iter()
+        .find(|row| row.contains("○ alpha"))
+        .expect("head row");
+    assert!(
+        !head.contains('…') && !continuation.contains('…'),
+        "a wrapped task row carried an omission marker"
+    );
+}
+
+/// Quick-add wraps its draft into the reserved blank rows instead of scrolling
+/// sideways: every typed word stays visible above or on the input line.
+#[test]
+fn quick_add_wraps_a_long_title_into_the_reserved_rows() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenCapture,
+        None,
+        None,
+    )
+    .expect("open quick add");
+    let title: String = (0..40).map(|index| format!("w{index} ")).collect();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddInsertText(title),
+        None,
+        None,
+    )
+    .expect("type long title");
+
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
+    terminal
+        .draw(|frame| draw_board(frame, &model))
+        .expect("draw quick add");
+    let rows = board_rows(&model, 80, 24);
+    let prompt_rows: Vec<&String> = rows.iter().filter(|row| row.contains("▎")).collect();
+    assert!(
+        prompt_rows.len() > 1,
+        "a long quick-add draft must wrap past one row:\n{}",
+        rows.join("\n")
+    );
+    let text = rows.join("\n");
+    assert!(
+        !text.contains('…'),
+        "a wrapped quick-add draft never truncates:\n{text}"
+    );
+    // Reading order survives wrapping: the draft's head (w0) paints above its
+    // tail (w39), each on its own ▎ row.
+    let head = rows
+        .iter()
+        .position(|row| row.contains("w0 "))
+        .expect("head segment painted");
+    let tail = rows
+        .iter()
+        .position(|row| row.contains("w39"))
+        .expect("tail segment painted");
+    assert_ne!(head, tail, "the draft must span more than one row:\n{text}");
+    assert!(
+        head < tail,
+        "the draft reads top-down across its wrapped rows:\n{text}"
+    );
+}
+
+/// Arrow keys move the Notes caret across WRAPPED rows on the task page: down
+/// crosses logical lines and wrapped continuations alike; up returns it.
+#[test]
+fn notes_edit_arrows_move_across_logical_and_wrapped_rows() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Arrow nav",
+            Some("one\n\ntwo".to_string()),
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+    board_rows(&model, 80, 24);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditNotes,
+        None,
+        None,
+    )
+    .expect("edit notes");
+
+    let caret_at = |model: &BoardModel, width: u16, height: u16| {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+        terminal
+            .draw(|frame| draw_board(frame, model))
+            .expect("draw");
+        terminal.backend().cursor_position().y
+    };
+    let caret_y = |model: &BoardModel| caret_at(model, 80, 24);
+
+    // Seeded at the end of "two" (row 2). Up twice walks back over the blank row.
+    assert_eq!(caret_y(&model), 5);
+    apply_intent(&mut domain, &mut model, BoardIntent::EditMoveUp, None, None)
+        .expect("up to blank row");
+    assert_eq!(caret_y(&model), 4, "up lands on the blank middle row");
+    apply_intent(&mut domain, &mut model, BoardIntent::EditMoveUp, None, None)
+        .expect("up to first row");
+    assert_eq!(caret_y(&model), 3, "up reaches the first note row");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditMoveDown,
+        None,
+        None,
+    )
+    .expect("down again");
+    assert_eq!(caret_y(&model), 4);
+
+    // Wrapped rows: at the compact floor the same draft wraps at word boundaries,
+    // and Up from the tail row climbs onto the wrapped head row.
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Wrapped arrows",
+            Some("aaaaa bbbbb ccccc ddddd eeeee fffff ggggg".to_string()),
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+    board_rows(&model, 40, 10);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::BeginEditNotes,
+        None,
+        None,
+    )
+    .expect("edit notes");
+    let before = caret_at(&model, 40, 10);
+    apply_intent(&mut domain, &mut model, BoardIntent::EditMoveUp, None, None)
+        .expect("up across the wrap");
+    let after = caret_at(&model, 40, 10);
+    assert!(
+        after < before,
+        "Up must climb from the wrapped tail row ({before}) onto the head row, got {after}"
     );
 }


### PR DESCRIPTION
## Summary

One wrap engine (`edit::wrap_text`) now feeds every text surface in the board, breaking rows
after their last whitespace (hard-breaking only whitespace-free runs) and measuring display
cells so wide glyphs move whole. No task text is cut mid-word or ellipsized anymore:

- **Task page notes** wrap in view and edit mode; the caret is mapped into wrapped
  coordinates and the page scroll follows it. Wrap width matches what the painter can show
  whole (`row_width - 6`), so full rows no longer end in a stray `…`.
- **Task page title** wraps in view and edit mode; the header grows and the
  divider/notes/meta shift down (`task_page_layout` takes a `title_rows`).
- **Board list titles** wrap onto continuation rows indented four cells under the glyph
  column; every painted line carries the task's hit target and selection styling, and
  selection follow anchors the whole block.
- **Quick-add** wraps up to three rows into the status-row slot and its reserved blanks,
  windowed around the caret; a multiline draft suppresses the slot's message row.
- **Standalone Capture Notes** wraps: the focused window follows the caret, the unfocused
  window reads from the top with a dim `… N more` tail when the field overflows.
- **Peek detail** wraps note rows at word boundaries (still capped at five preview lines).
- **Up/Down arrows** walk wrapped rows in Notes editors (task page and capture), preserving
  the column and clamping at the ends; renderers record the painted wrap width
  (`BoardForm::notes_width`, `CaptureModel::notes_width`) so the reducer moves against what
  is actually on screen.

Title and Thread editors stay single-line by design (horizontal window); the verb bar still
ellipsizes at its tier budget (chrome, not task text).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Manual herdr open-board smoke (temp `TSK_STATE_DIR`): list wrap, page title wrap,
      notes word wrap, notes arrows (verified via saved break position), quick-add wrap and
      row order. Standalone Capture UI is unit-tested but not live-smoked (host-launcher
      surface).
