### PR TITLE
feat: write the store as tsk.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,10 +107,10 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
 ## Conventions
 
 - Human status is source of truth. Never auto-complete tasks from agent status.
-- The projectless scope displays as `desk` but serializes as `global` in tasks.json and
+- The projectless scope displays as `desk` but serializes as `global` in tsk.json and
   keeps its internal name `TaskScope::Global`; do not "fix" either without a store
   migration.
-- State is `$HOME/.tsk/tasks.json`, config `$HOME/.tsk/settings.json`, overridable
+- State is `$HOME/.tsk/tsk.json`, config `$HOME/.tsk/settings.json`, overridable
   with `TSK_STATE_DIR` / `TSK_CONFIG_DIR`. Host-injected `HERDR_PLUGIN_*` dirs are
   ignored. Verb modifier is `settings.json`; the palette flips it.
 - Golden fixtures regenerate via `cargo test --test queue_board_render regenerate_golden_fixtures -- --ignored`; never hand-edit the `.txt` files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,20 @@
 
 ## Unreleased
 
+The live document is **`tsk.json`** (lock `tsk.json.lock`, previous `tsk.json.1`).
+A first run creates an empty `~/.tsk`; leftover `tasks.json` is not read.
+
 The projectless scope is now **desk**: board header, `tsk list` labels, and the new
 `--desk` flag. Stored scope values are unchanged,
 so no data migration is needed.
 
-Store hardening: `tasks.json` carries `format_version` (currently 1) and a
+Store hardening: `tsk.json` carries `format_version` (currently 1) and a
 newer document is refused rather than rewritten; each replace keeps the previous
-file as `tasks.json.1`; leftover `.tasks.json.tmp.*` files are swept under the
+file as `tsk.json.1`; leftover `.tsk.json.tmp.*` files are swept under the
 lock; the exclusive lock uses `std::fs::File::lock` instead of `fs2`.
 
 Rebrand to **tsk** ("a task board for your terminal"). The crate is now
-`tsk-tui` building the `tsk` binary. The store unifies at `~/.tsk` (`tasks.json`
+`tsk-tui` building the `tsk` binary. The store unifies at `~/.tsk` (`tsk.json`
 and `settings.json` side by side), overridable with `TSK_STATE_DIR` /
 `TSK_CONFIG_DIR`; injected host variables like `HERDR_PLUGIN_STATE_DIR` are
 ignored so the herdr pane and a bare terminal edit one board. There is no

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The built binary is `target/release/tsk`.
 
 ### Standalone
 
-Run `tsk` directly. The store is `~/.tsk`: `tasks.json` and `settings.json`
+Run `tsk` directly. The store is `~/.tsk`: `tsk.json` and `settings.json`
 live side by side. Override the locations with `TSK_STATE_DIR` /
 `TSK_CONFIG_DIR`.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -355,7 +355,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
     // drive them directly -- this loop simply stops calling them.
     //
     // the Idle branch below is not pure silence, though. Every idle tick revalidates the
-    // store -- a `stat` on tasks.json, and only when its mtime/size changed does it pay for
+    // store -- a `stat` on tsk.json, and only when its mtime/size changed does it pay for
     // `store.load()` + `merge_tasks_from_disk` + `sync_from_domain` (see
     // [`revalidate_board_from_store`]) -- so a quick-capture popup (a separate process writing
     // the same file) becomes visible on an open, idle board without this board ever running a
@@ -489,7 +489,7 @@ fn board_background_work_allowed(recovery: &SaveRecovery<DomainState>) -> bool {
 
 /// Cheap idle-tick change detector for the store's on-disk document.
 ///
-/// Holds only `tasks.json`'s last-seen modification time + length, so the frame loop's Idle
+/// Holds only `tsk.json`'s last-seen modification time + length, so the frame loop's Idle
 /// branch -- which runs about 4 times a second --
 /// pays for a `stat`, not a parse, on every tick where nothing changed.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -532,14 +532,14 @@ impl StoreWatch {
     }
 }
 
-/// `tasks.json`'s modification time + length. `None` when the file does not exist yet (a
+/// `tsk.json`'s modification time + length. `None` when the file does not exist yet (a
 /// fresh, never-saved store) or its metadata could not be read.
 ///
 /// Store internals (the lock protocol, the atomic-write path) are frozen; this only stats the
 /// document store.rs already names in its own doc comment, it does not reimplement any of
 /// store.rs's load/save/lock contract.
 fn store_state_signature(store: &TaskStore) -> Option<(SystemTime, u64)> {
-    let metadata = fs::metadata(store.path().join("tasks.json")).ok()?;
+    let metadata = fs::metadata(store.state_file()).ok()?;
     let modified = metadata.modified().ok()?;
     Some((modified, metadata.len()))
 }
@@ -548,7 +548,7 @@ fn store_state_signature(store: &TaskStore) -> Option<(SystemTime, u64)> {
 ///
 /// Only when [`StoreWatch::changed`] reports a changed mtime/size does this pay for
 /// `store.load()` + [`DomainState::merge_tasks_from_disk`] + [`BoardModel::sync_from_domain`],
-/// so a quick-capture popup (a separate process writing the same `tasks.json`) becomes
+/// so a quick-capture popup (a separate process writing the same `tsk.json`) becomes
 /// visible on an open, idle board without a persisting intent from this board and without a
 /// host call.
 ///
@@ -1323,7 +1323,7 @@ mod idle_store_revalidation_tests {
     }
 
     /// an open, idle board picks up a task a *separate* store writer (the standalone
-    /// quick-capture popup, per the manifest) saved to the same `tasks.json`, with no
+    /// quick-capture popup, per the manifest) saved to the same `tsk.json`, with no
     /// persisting intent run on this board at all.
     #[test]
     fn idle_tick_revalidates_task_written_by_a_separate_store_writer() {
@@ -1463,7 +1463,7 @@ mod idle_store_revalidation_tests {
     /// a failed `store.load()` must not burn the changed signature it never got to use --
     /// otherwise a single transient read failure leaves the board stale until some *later*
     /// write happens to produce yet another distinct signature, which is the exact failure
-    /// this watch exists to survive. Corrupts `tasks.json` in place (a stand-in for any
+    /// this watch exists to survive. Corrupts `tsk.json` in place (a stand-in for any
     /// transient read failure) so `store.load()` errors while the on-disk signature has
     /// already changed, then proves the watch still reports that same signature as changed on
     /// the next poll (it was never recorded), and that a later, valid write is picked up.
@@ -1481,7 +1481,7 @@ mod idle_store_revalidation_tests {
         // Corrupt the document in place: the signature changes (different length), but
         // `store.load()` fails to parse it -- standing in for any transient read failure on
         // an already-changed document.
-        let state_file = dir.join("tasks.json");
+        let state_file = store.state_file();
         fs::write(&state_file, b"not valid json").unwrap();
 
         let merged = revalidate_board_from_store(
@@ -3218,8 +3218,8 @@ mod tests {
             .unwrap();
         store.save(&domain).unwrap();
         let mut model = BoardModel::from_domain(&domain, None);
-        fs::remove_file(dir.join("tasks.json")).unwrap();
-        fs::create_dir(dir.join("tasks.json")).unwrap();
+        fs::remove_file(store.state_file()).unwrap();
+        fs::create_dir(store.state_file()).unwrap();
 
         let result = run_attention_cycle(
             &store,

--- a/src/store.rs
+++ b/src/store.rs
@@ -989,7 +989,7 @@ mod tests {
             .expect("create");
         store.save(&first).expect("first save");
         assert!(
-            !dir.join(BACKUP_FILE).exists(),
+            !dir.join("tsk.json.1").exists(),
             "the first save has no previous document to retain"
         );
 
@@ -997,9 +997,13 @@ mod tests {
         store.save(&second).expect("second save");
 
         let backup: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(dir.join(BACKUP_FILE)).expect("read backup"))
+            serde_json::from_str(&fs::read_to_string(dir.join("tsk.json.1")).expect("read backup"))
                 .expect("json");
         assert_eq!(backup["tasks"][0]["title"], "first");
+        assert!(
+            !dir.join("tasks.json.1").exists(),
+            "the pre-rebrand last-good name must not be written"
+        );
         let live = store.load().expect("load live");
         assert!(live.tasks().is_empty());
     }
@@ -1029,7 +1033,7 @@ mod tests {
             .expect("replace the corrupt live document");
 
         let backup: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(dir.join(BACKUP_FILE)).expect("read backup"))
+            serde_json::from_str(&fs::read_to_string(dir.join("tsk.json.1")).expect("read backup"))
                 .expect("backup must stay valid json");
         assert_eq!(backup["tasks"][0]["title"], "keep me");
     }
@@ -1058,10 +1062,69 @@ mod tests {
         let _guard = TempDirGuard(dir.clone());
         let store = TaskStore::new(&dir);
         store.save(&DomainState::new()).expect("save");
-        assert!(store.state_file().exists(), "the live document is tsk.json");
+        assert!(
+            dir.join("tsk.json").exists(),
+            "the live document is tsk.json"
+        );
         assert!(
             !dir.join("tasks.json").exists(),
             "the pre-rebrand name must not be written"
+        );
+    }
+
+    #[test]
+    fn save_creates_literal_tsk_json_lock() {
+        let dir = temp_dir("lock-name");
+        let _guard = TempDirGuard(dir.clone());
+        TaskStore::new(&dir)
+            .save(&DomainState::new())
+            .expect("save");
+        assert!(
+            dir.join("tsk.json.lock").exists(),
+            "the lock file is tsk.json.lock"
+        );
+        assert!(
+            !dir.join("tasks.json.lock").exists(),
+            "the pre-rebrand lock name must not be written"
+        );
+    }
+
+    #[test]
+    fn load_returns_empty_when_only_legacy_tasks_json_exists() {
+        let dir = temp_dir("legacy-filename");
+        let _guard = TempDirGuard(dir.clone());
+        fs::create_dir_all(&dir).expect("mkdir");
+        let mut leftover = DomainState::new();
+        leftover
+            .create(
+                "only in leftover tasks.json",
+                None,
+                TaskScope::Global,
+                None,
+                None,
+                ProvenanceOrigin::Manual,
+            )
+            .expect("create");
+        leftover.stamp_format_version();
+        let payload = serde_json::to_vec_pretty(&leftover).expect("json");
+        let legacy = dir.join("tasks.json");
+        fs::write(&legacy, &payload).expect("write leftover");
+
+        let loaded = TaskStore::new(&dir)
+            .load()
+            .expect("missing tsk.json is a first run");
+        assert!(
+            loaded.tasks().is_empty(),
+            "leftover tasks.json must not be read"
+        );
+        assert!(
+            !dir.join("tsk.json").exists(),
+            "load must not promote the leftover file"
+        );
+        assert_eq!(
+            fs::read(&legacy).expect("read leftover"),
+            payload,
+            "leftover tasks.json must be left untouched"
         );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,10 +1,10 @@
 //! Task Store: durable JSON under the plugin state dir.
 //!
 //! Atomic write: unique temp file in the same directory, then rename over the target.
-//! Concurrent writers take an exclusive lock on `tasks.json.lock` and merge by
+//! Concurrent writers take an exclusive lock on `tsk.json.lock` and merge by
 //! task/attempt id plus each record's revision, so writers do not drop sibling records.
 //! A store whose `format_version` is newer than this binary is refused rather than rewritten.
-//! Each successful replace retains the previous document as `tasks.json.1`.
+//! Each successful replace retains the previous document as `tsk.json.1`.
 
 use std::env;
 use std::fs::{self, File, OpenOptions};
@@ -15,11 +15,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::domain::{DomainState, LEGACY_STORE_FORMAT_VERSION, STORE_FORMAT_VERSION};
 
 /// On-disk document name under the state directory.
-const STATE_FILE: &str = "tasks.json";
+const STATE_FILE: &str = "tsk.json";
 /// Previous successful document, retained by hard-link before replace.
-const BACKUP_FILE: &str = "tasks.json.1";
+const BACKUP_FILE: &str = "tsk.json.1";
 /// Inter-process exclusive lock file (sibling of the state document).
-const LOCK_FILE: &str = "tasks.json.lock";
+const LOCK_FILE: &str = "tsk.json.lock";
 
 /// Filesystem operations that make atomic replacement durable.
 ///
@@ -103,6 +103,11 @@ impl TaskStore {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Live document path (`tsk.json` under the state directory).
+    pub fn state_file(&self) -> PathBuf {
+        self.path.join(STATE_FILE)
     }
 
     /// Load domain state. Missing file yields an empty state (first run).
@@ -255,11 +260,7 @@ impl TaskStore {
         Ok(StoreLockGuard { file })
     }
 
-    fn state_file(&self) -> PathBuf {
-        self.path.join(STATE_FILE)
-    }
-
-    /// Remove leftover `.tasks.json.tmp.*` files. Safe only under the exclusive lock.
+    /// Remove leftover `.tsk.json.tmp.*` files. Safe only under the exclusive lock.
     fn sweep_orphan_temps(&self) {
         let Ok(entries) = fs::read_dir(&self.path) else {
             return;
@@ -273,7 +274,7 @@ impl TaskStore {
         }
     }
 
-    /// Unique temp path so concurrent writers never share `.tasks.json.tmp`.
+    /// Unique temp path so concurrent writers never share `.tsk.json.tmp`.
     fn unique_tmp_path(&self) -> PathBuf {
         let pid = std::process::id();
         let nanos = SystemTime::now()
@@ -357,7 +358,7 @@ fn check_format_version(found: u32) -> Result<(), StoreError> {
     }
 }
 
-/// Keep the previous live document under `tasks.json.1` via hard-link so a crash
+/// Keep the previous live document under `tsk.json.1` via hard-link so a crash
 /// between link and rename leaves the backup identical to the still-live file.
 fn retain_last_good(live: &Path) -> Result<(), StoreError> {
     let backup = live.with_file_name(BACKUP_FILE);
@@ -1038,7 +1039,7 @@ mod tests {
         let dir = temp_dir("orphan-sweep");
         let _guard = TempDirGuard(dir.clone());
         fs::create_dir_all(&dir).expect("mkdir");
-        let orphan = dir.join(".tasks.json.tmp.1.1");
+        let orphan = dir.join(".tsk.json.tmp.1.1");
         fs::write(&orphan, b"stale").expect("seed orphan");
 
         TaskStore::new(&dir)
@@ -1048,6 +1049,19 @@ mod tests {
         assert!(
             !orphan.exists(),
             "a locked save must remove leftover temp files"
+        );
+    }
+
+    #[test]
+    fn save_writes_tsk_json_and_not_tasks_json() {
+        let dir = temp_dir("live-name");
+        let _guard = TempDirGuard(dir.clone());
+        let store = TaskStore::new(&dir);
+        store.save(&DomainState::new()).expect("save");
+        assert!(store.state_file().exists(), "the live document is tsk.json");
+        assert!(
+            !dir.join("tasks.json").exists(),
+            "the pre-rebrand name must not be written"
         );
     }
 }

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -467,7 +467,7 @@ fn flag_add_existing_trimmed_title_and_scope_is_a_successful_noop() {
         .set_status(id, HumanStatus::Done)
         .expect("set existing task status");
     task_store(&dir).save(&state).expect("save status");
-    let state_file = dir.join("tasks.json");
+    let state_file = dir.join("tsk.json");
     let before = std::fs::read(&state_file).expect("read seeded state");
     let before_mtime = std::fs::metadata(&state_file)
         .expect("stat seeded state")
@@ -987,7 +987,7 @@ fn plan_with_only_existing_tasks_is_a_successful_read_only_noop() {
         .set_status(id, HumanStatus::Review)
         .expect("set status");
     store.save(&seeded).expect("save seed");
-    let state_file = dir.join("tasks.json");
+    let state_file = dir.join("tsk.json");
     let before = std::fs::read(&state_file).expect("read seeded state");
     let before_mtime = std::fs::metadata(&state_file)
         .expect("stat seeded state")

--- a/tests/cli_steps.rs
+++ b/tests/cli_steps.rs
@@ -193,7 +193,7 @@ fn steps_toggle_unknown_or_ambiguous_prefix_refuses_without_mutation() {
     let dir = temp_state_dir("prefix-refusal");
     let (state, task) = state_with_shared_prefix_steps();
     TaskStore::new(&dir).save(&state).expect("seed store");
-    let state_file = dir.join("tasks.json");
+    let state_file = dir.join("tsk.json");
     let before = std::fs::read(&state_file).expect("read seeded state");
 
     let mut ambiguous = steps_args(&dir, task);
@@ -243,7 +243,7 @@ fn steps_toggle_empty_operand_refuses_without_mutation() {
         .expect("seed task");
     state.add_step(task, "only step").expect("seed one step");
     TaskStore::new(&dir).save(&state).expect("seed store");
-    let state_file = dir.join("tasks.json");
+    let state_file = dir.join("tsk.json");
     let before = std::fs::read(&state_file).expect("read seeded state");
 
     let mut empty = steps_args(&dir, task);
@@ -269,7 +269,7 @@ fn steps_toggle_empty_operand_refuses_without_mutation() {
 fn steps_add_refuses_empty_and_control_char_text_without_mutation() {
     let dir = temp_state_dir("text-refusal");
     let task = seed_task(&dir, "text refusal target");
-    let state_file = dir.join("tasks.json");
+    let state_file = dir.join("tsk.json");
     let before = std::fs::read(&state_file).expect("read seeded state");
 
     for (text, token) in [
@@ -326,7 +326,7 @@ fn steps_on_soft_deleted_task_refuses_without_mutation() {
         .expect("seed task");
     state.soft_delete(task).expect("soft delete seed");
     TaskStore::new(&dir).save(&state).expect("seed store");
-    let state_file = dir.join("tasks.json");
+    let state_file = dir.join("tsk.json");
     let before = std::fs::read(&state_file).expect("read seeded state");
 
     let mut add = steps_args(&dir, task);

--- a/tests/store_persist.rs
+++ b/tests/store_persist.rs
@@ -226,7 +226,7 @@ const PRE_RENAME_STEPS_JSON: &str = r#"{
 fn steps_alias_decodes_pre_rename_store_events_and_field() {
     let dir = temp_state_dir();
     let _guard = TempDirGuard(dir.clone());
-    fs::write(dir.join("tasks.json"), PRE_RENAME_STEPS_JSON).expect("install pre-rename store");
+    fs::write(dir.join("tsk.json"), PRE_RENAME_STEPS_JSON).expect("install pre-rename store");
 
     let state = TaskStore::new(&dir)
         .load()
@@ -279,7 +279,7 @@ fn steps_alias_decodes_pre_rename_store_events_and_field() {
 fn pre_steps_store_decodes_with_empty_steps() {
     let dir = temp_state_dir();
     let _guard = TempDirGuard(dir.clone());
-    fs::write(dir.join("tasks.json"), PRE_STEPS_TASKS_JSON).expect("install pre-steps store");
+    fs::write(dir.join("tsk.json"), PRE_STEPS_TASKS_JSON).expect("install pre-steps store");
 
     let state = TaskStore::new(&dir)
         .load()
@@ -301,7 +301,7 @@ fn pre_thread_store_decodes_with_no_thread() {
     let _guard = TempDirGuard(dir.clone());
     fs::copy(
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pre_thread_tasks.json"),
-        dir.join("tasks.json"),
+        dir.join("tsk.json"),
     )
     .expect("install pre-thread store");
 
@@ -502,7 +502,7 @@ fn pre_stabilize_fixture_survives_mutation_undo_and_dispatch_recovery_resurface(
     let _guard = TempDirGuard(dir.clone());
     fs::copy(
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pre_stabilize_tasks.json"),
-        dir.join("tasks.json"),
+        dir.join("tsk.json"),
     )
     .expect("install pre-stabilize fixture");
     let store = TaskStore::new(&dir);
@@ -747,7 +747,7 @@ fn legacy_serialized_tasks_and_undo_entries_decode_safely() {
         .expect("undo fields");
     undo.remove("expected_revision");
     fs::write(
-        dir.join("tasks.json"),
+        dir.join("tsk.json"),
         serde_json::to_string_pretty(&legacy).expect("encode legacy state"),
     )
     .expect("write legacy state");
@@ -785,7 +785,7 @@ fn legacy_serialized_domain_without_active_attempts_round_trips() {
         .expect("domain object")
         .remove("active_attempts");
     fs::write(
-        dir.join("tasks.json"),
+        dir.join("tsk.json"),
         serde_json::to_string_pretty(&legacy).expect("encode legacy state"),
     )
     .expect("write legacy state");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The board store is `tsk.json`, not `tasks.json`. Same family for the lock (`tsk.json.lock`) and last-good copy (`tsk.json.1`). `settings.json` is unchanged.

No migration: a first run of this build starts an empty `~/.tsk`. Leftover `tasks.json` is not read.

## Test plan

- [x] Regression `save_writes_tsk_json_and_not_tasks_json` fails when the live name is still `tasks.json`, then passes with the rename
- [x] `load_returns_empty_when_only_legacy_tasks_json_exists` fails if load falls back to `tasks.json`, then passes when it does not
- [x] `save_creates_literal_tsk_json_lock` and `second_save_hard_links_the_previous_document` fail when lock/backup constants still say `tasks.json.*`, then pass with the literal `tsk.json.lock` / `tsk.json.1` names
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release`
- [ ] Manual herdr open-board smoke (store-only; live smoke not run — `HERDR_ENV` unset)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03eb7-f96c-78af-86c2-71ae6fa89bfe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03eb7-f96c-78af-86c2-71ae6fa89bfe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

