### PR TITLE
UI polish: text selection + modal overlays for P / ? / :

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,11 @@ surface: board rows, task page, overlays) and release copies the painted text
 to the system clipboard via OSC 52: the terminal or host multiplexer performs
 the copy, so terminals without OSC 52 support ignore it. Clicks are deferred
 until mouse-up so a drag on a board row does not also peek; a bare click still
-behaves as before. A brief `copied` status clears itself after two seconds.
+behaves as before. Painters declare content-only copyable rects (task titles
+past the glyph, peek notes past the `│` gutter, page notes past their indent),
+so chrome never reaches the clipboard. A Down→Up move without intermediate
+Drag events still counts as a selection. A brief `copied` status clears itself
+after two seconds.
 
 The live document is **`tsk.json`** (lock `tsk.json.lock`, previous `tsk.json.1`).
 A first run creates an empty `~/.tsk`; leftover `tasks.json` is not read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ old documents may still carry (`capsule`, `agent_meta`, `last_observed`,
 `active_attempts`, related event kinds) keep loading. Local reference only:
 `archive/dark-engine-pre-v1`.
 
+Mouse text selection: a left-button drag highlights the cells it covers (any
+surface: board rows, task page, overlays) and release copies the painted text
+to the system clipboard via OSC 52: the terminal or host multiplexer performs
+the copy, so terminals without OSC 52 support ignore it. A bare click copies
+nothing and behaves exactly as before; the status row reports the copied
+count.
+
 The live document is **`tsk.json`** (lock `tsk.json.lock`, previous `tsk.json.1`).
 A first run creates an empty `~/.tsk`; leftover `tasks.json` is not read.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ blank while one is open since the card's footer already names its own keys.
 Mouse text selection: a left-button drag highlights the cells it covers (any
 surface: board rows, task page, overlays) and release copies the painted text
 to the system clipboard via OSC 52: the terminal or host multiplexer performs
-the copy, so terminals without OSC 52 support ignore it. A bare click copies
-nothing and behaves exactly as before; the status row reports the copied
-count.
+the copy, so terminals without OSC 52 support ignore it. Clicks are deferred
+until mouse-up so a drag on a board row does not also peek; a bare click still
+behaves as before. A brief `copied` status clears itself after two seconds.
 
 The live document is **`tsk.json`** (lock `tsk.json.lock`, previous `tsk.json.1`).
 A first run creates an empty `~/.tsk`; leftover `tasks.json` is not read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ the copy, so terminals without OSC 52 support ignore it. Clicks are deferred
 until mouse-up so a drag on a board row does not also peek; a bare click still
 behaves as before. Painters declare content-only copyable rects (task titles
 past the glyph, peek notes past the `│` gutter, page notes past their indent),
-so chrome never reaches the clipboard. A Down→Up move without intermediate
-Drag events still counts as a selection. A brief `copied` status clears itself
-after two seconds.
+so chrome never reaches the clipboard. The reverse highlight uses those same
+rects, so a multi-line drag does not paint through the peek `│` gutter. A
+Down→Up move without intermediate Drag events still counts as a selection. A
+brief `copied` status clears itself after two seconds.
 
 The live document is **`tsk.json`** (lock `tsk.json.lock`, previous `tsk.json.1`).
 A first run creates an empty `~/.tsk`; leftover `tasks.json` is not read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ old documents may still carry (`capsule`, `agent_meta`, `last_observed`,
 `archive/dark-engine-pre-v1`.
 
 Modal overlays: `?` help, `:` command palette, and `P` project scope now open
-as a shared, centered mono card (dim box-drawing border, bold title with an
-`[x]` close control, and a footer key legend) instead of their own bespoke
-layouts. The board stays visible around the card, and the verb bar goes
+as a shared, centered mono card (dim box-drawing border on all four sides, bold
+title with an `[x]` close control, and a footer key legend) instead of their own
+bespoke layouts. The board stays visible around the card, and the verb bar goes
 blank while one is open since the card's footer already names its own keys.
 
 Mouse text selection: a left-button drag highlights the cells it covers (any
@@ -19,12 +19,14 @@ surface: board rows, task page, overlays) and release copies the painted text
 to the system clipboard via OSC 52: the terminal or host multiplexer performs
 the copy, so terminals without OSC 52 support ignore it. Clicks are deferred
 until mouse-up so a drag on a board row does not also peek; a bare click still
-behaves as before. Painters declare content-only copyable rects (task titles
-past the glyph, peek notes past the `│` gutter, page notes past their indent),
-so chrome never reaches the clipboard. The reverse highlight uses those same
-rects, so a multi-line drag does not paint through the peek `│` gutter. A
-Down→Up move without intermediate Drag events still counts as a selection. A
-brief `copied` status clears itself after two seconds.
+behaves as before. A one-cell pointer wobble stays a click. Painters declare
+content-only copyable rects (task titles past the glyph, peek notes past the
+`│` gutter, page notes past their indent, task-page title past glyph and
+status word), so chrome never reaches the clipboard. The reverse highlight uses
+those same rects, so a multi-line drag does not paint through the peek `│`
+gutter. A Down→Up move without intermediate Drag events still counts as a
+selection. A brief `copied` status clears itself after two seconds and restores
+any sticky status it covered (e.g. save-recovery).
 
 The live document is **`tsk.json`** (lock `tsk.json.lock`, previous `tsk.json.1`).
 A first run creates an empty `~/.tsk`; leftover `tasks.json` is not read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ old documents may still carry (`capsule`, `agent_meta`, `last_observed`,
 `active_attempts`, related event kinds) keep loading. Local reference only:
 `archive/dark-engine-pre-v1`.
 
+Modal overlays: `?` help, `:` command palette, and `P` project scope now open
+as a shared, centered mono card (dim box-drawing border, bold title with an
+`[x]` close control, and a footer key legend) instead of their own bespoke
+layouts. The board stays visible around the card, and the verb bar goes
+blank while one is open since the card's footer already names its own keys.
+
 Mouse text selection: a left-button drag highlights the cells it covers (any
 surface: board rows, task page, overlays) and release copies the painted text
 to the system clipboard via OSC 52: the terminal or host multiplexer performs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "unicode-width",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ crossterm = "0.29.0"
 ratatui = "0.30.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.151"
+unicode-width = "0.2"
 uuid = { version = "1.24", features = ["v4", "serde"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,9 +7,7 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
-use crossterm::event::{
-    self, Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
-};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::layout::{Position, Rect};
 use ratatui::DefaultTerminal;
 
@@ -373,20 +371,14 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                     match mouse.kind {
                         MouseEventKind::Drag(MouseButton::Left) => {
                             model.drag_text_selection(Position::new(mouse.column, mouse.row));
-                            if model
-                                .text_selection()
-                                .is_some_and(crate::ui::text_select::TextSelection::has_area)
-                            {
+                            if model.text_selection().is_some_and(|sel| sel.has_area()) {
                                 pending_click = None;
                             }
                             continue;
                         }
                         MouseEventKind::Up(MouseButton::Left) => {
                             model.end_mouse_press();
-                            if model
-                                .text_selection()
-                                .is_some_and(crate::ui::text_select::TextSelection::has_area)
-                            {
+                            if model.text_selection().is_some_and(|sel| sel.has_area()) {
                                 copy_drag_selection(&mut model, &frame_rows, &frame_copyable);
                                 pending_click = None;
                                 continue;

--- a/src/app.rs
+++ b/src/app.rs
@@ -377,6 +377,13 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                             continue;
                         }
                         MouseEventKind::Up(MouseButton::Left) => {
+                            let up = Position::new(mouse.column, mouse.row);
+                            // Some hosts omit Drag and only move between Down and Up.
+                            // Grow the selection from the press cell before clearing it
+                            // so copy still works there (and peek is not fired instead).
+                            if model.text_selection().is_none() {
+                                model.drag_text_selection(up);
+                            }
                             model.end_mouse_press();
                             if model.text_selection().is_some_and(|sel| sel.has_area()) {
                                 copy_drag_selection(&mut model, &frame_rows, &frame_copyable);

--- a/src/app.rs
+++ b/src/app.rs
@@ -302,7 +302,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
         // Left Down is deferred until Up (or abandoned when a text drag grows): firing
         // the click on Down made every board-row drag also peek/toggle, so copy only
         // felt reliable on the task page where Down is inert over notes.
-        let mut pending_click: Option<crossterm::event::MouseEvent> = None;
+        let mut drag_gesture = crate::ui::text_select::DragSelectGesture::new();
         loop {
             // Settle, paint, then wait. The board frame path does no host polling, so the
             // wait is only the Frame Scheduler's idle floor. All three are one call because
@@ -334,7 +334,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     // A key while the mouse button is held abandons the deferred click so
                     // Up does not fire a stale peek/select after the keyboard moved on.
-                    pending_click = None;
+                    drag_gesture.clear();
                     let area = terminal_area(terminal)?;
                     // The painted mode owns the keyboard: `resolve_board_surface` resolves the
                     // same input mode at every terminal size (`board_input_mode_for_area` no
@@ -366,40 +366,56 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                     // (highlight and copy text come from the last painted snapshot), and
                     // release hands that text to the clipboard. Clicks are deferred to Up
                     // so a drag does not also fire the Down-time peek/select path.
+                    use crate::ui::text_select::{DragSelectOutcome, DragSelectPhase};
                     use crossterm::event::{MouseButton, MouseEventKind};
                     let mut click = mouse;
                     match mouse.kind {
                         MouseEventKind::Drag(MouseButton::Left) => {
-                            model.drag_text_selection(Position::new(mouse.column, mouse.row));
-                            if model.text_selection().is_some_and(|sel| sel.has_area()) {
-                                pending_click = None;
-                            }
+                            let pos = Position::new(mouse.column, mouse.row);
+                            model.drag_text_selection(pos);
+                            let _ = drag_gesture.handle(
+                                DragSelectPhase::Move,
+                                pos,
+                                model.text_selection(),
+                            );
                             continue;
                         }
                         MouseEventKind::Up(MouseButton::Left) => {
-                            let up = Position::new(mouse.column, mouse.row);
+                            let pos = Position::new(mouse.column, mouse.row);
                             // Some hosts omit Drag and only move between Down and Up.
                             // Grow the selection from the press cell before clearing it
                             // so copy still works there (and peek is not fired instead).
                             if model.text_selection().is_none() {
-                                model.drag_text_selection(up);
+                                model.drag_text_selection(pos);
                             }
                             model.end_mouse_press();
-                            if model.text_selection().is_some_and(|sel| sel.has_area()) {
-                                copy_drag_selection(&mut model, &frame_rows, &frame_copyable);
-                                pending_click = None;
-                                continue;
+                            match drag_gesture.handle(
+                                DragSelectPhase::Release,
+                                pos,
+                                model.text_selection(),
+                            ) {
+                                DragSelectOutcome::Copy => {
+                                    copy_drag_selection(&mut model, &frame_rows, &frame_copyable);
+                                    continue;
+                                }
+                                DragSelectOutcome::Click(down) => {
+                                    model.clear_text_selection();
+                                    click = crossterm::event::MouseEvent {
+                                        kind: MouseEventKind::Down(MouseButton::Left),
+                                        column: down.x,
+                                        row: down.y,
+                                        modifiers: mouse.modifiers,
+                                    };
+                                }
+                                DragSelectOutcome::Continue => continue,
                             }
-                            let Some(down) = pending_click.take() else {
-                                continue;
-                            };
-                            click = down;
                         }
                         MouseEventKind::Down(MouseButton::Left) => {
                             // Anchor a would-be selection and stash the Down for Up;
                             // do not map the click yet.
-                            model.begin_mouse_press(Position::new(mouse.column, mouse.row));
-                            pending_click = Some(mouse);
+                            let pos = Position::new(mouse.column, mouse.row);
+                            model.begin_mouse_press(pos);
+                            let _ = drag_gesture.handle(DragSelectPhase::Press, pos, None);
                             continue;
                         }
                         _ => {}

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,8 +7,10 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
-use ratatui::layout::Rect;
+use crossterm::event::{
+    self, Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
+};
+use ratatui::layout::{Position, Rect};
 use ratatui::DefaultTerminal;
 
 use crate::config::{default_config_dir, SettingsRecord, WalkthroughRecord};
@@ -33,6 +35,7 @@ use crate::ui::mouse::{
 };
 use crate::ui::queue::BoardTab;
 use crate::ui::scheduler;
+use crate::ui::text_select::{copy_to_clipboard, frame_text_rows, selection_text};
 
 /// Env var set by open-capture launcher for Capture UI mode.
 pub const MODE_ENV: &str = "TSK_MODE";
@@ -291,6 +294,12 @@ fn run_board() -> Result<(), Box<dyn Error>> {
     ratatui::run(|terminal| -> io::Result<()> {
         let _input = enable_terminal_input(keyboard_enhancement)?;
         let mut save_recovery = SaveRecovery::new();
+        // The painted frame's text and its declared copyable rects, refreshed by
+        // every board paint: the snapshot a finished drag selection slices its
+        // copied text from ("copy what you see", inside what the painters declared
+        // as content).
+        let mut frame_rows: Vec<String> = Vec::new();
+        let mut frame_copyable: Vec<Rect> = Vec::new();
         loop {
             // Settle, paint, then wait. The board frame path does no host polling, so the
             // wait is only the Frame Scheduler's idle floor. All three are one call because
@@ -300,7 +309,15 @@ fn run_board() -> Result<(), Box<dyn Error>> {
             let poll = board_idle_tick(
                 &mut model,
                 || walkthrough.record_dismissed(),
-                |model: &BoardModel| terminal.draw(|frame| draw_board(frame, model)).map(|_| ()),
+                |model: &BoardModel| {
+                    terminal
+                        .draw(|frame| {
+                            let hits = draw_board(frame, model);
+                            frame_rows = frame_text_rows(frame.buffer_mut());
+                            frame_copyable = hits.copyable;
+                        })
+                        .map(|_| ())
+                },
                 event::poll,
                 &store,
                 &mut domain,
@@ -339,6 +356,27 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                     }
                 }
                 Event::Mouse(mouse) => {
+                    // A left-button drag grows a text selection over the painted frame
+                    // (highlight and copy text come from the last painted snapshot), and
+                    // release hands that text to the clipboard. Clicks (Down) still
+                    // keep their exact Down-time behavior, drags were dead weight before.
+                    match mouse.kind {
+                        MouseEventKind::Drag(MouseButton::Left) => {
+                            model.drag_text_selection(Position::new(mouse.column, mouse.row));
+                            continue;
+                        }
+                        MouseEventKind::Up(MouseButton::Left) => {
+                            model.end_mouse_press();
+                            copy_drag_selection(&mut model, &frame_rows, &frame_copyable);
+                            continue;
+                        }
+                        _ => {}
+                    }
+                    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+                        // The press anchors a would-be selection and clears the previous
+                        // highlight before the click mapper runs.
+                        model.begin_mouse_press(Position::new(mouse.column, mouse.row));
+                    }
                     let area = terminal_area(terminal)?;
                     let Some(intent) = board_mouse_intent(area, &mut model, mouse) else {
                         continue;
@@ -375,6 +413,27 @@ fn run_board() -> Result<(), Box<dyn Error>> {
         Ok(())
     })?;
     Ok(())
+}
+
+/// Copy a finished drag selection from the last painted frame to the clipboard.
+///
+/// Only cells the painters declared copyable are taken, so scrollbars, borders,
+/// and other chrome never reach the clipboard. A selection with no text (a bare
+/// click, or a drag over blank cells) copies nothing; a real one reports on the
+/// status row, since the only other feedback (the terminal's own clipboard
+/// toast, if any) is outside this process.
+fn copy_drag_selection(model: &mut BoardModel, frame_rows: &[String], copyable: &[Rect]) {
+    let Some(selection) = model.text_selection() else {
+        return;
+    };
+    let Some(text) = selection_text(frame_rows, copyable, &selection) else {
+        return;
+    };
+    if copy_to_clipboard(&text) {
+        model.set_message(format!("copied {} chars", text.chars().count()));
+    } else {
+        model.set_message("copy failed");
+    }
 }
 
 /// Whether save recovery permits the board to apply background state changes.

--- a/src/app.rs
+++ b/src/app.rs
@@ -229,6 +229,7 @@ pub fn board_idle_tick(
     watch: &mut StoreWatch,
     save_recovery: &SaveRecovery<DomainState>,
 ) -> io::Result<FramePoll> {
+    model.expire_ephemeral_message();
     let poll = board_frame(model, write, paint, wait)?;
     if poll == FramePoll::Idle {
         revalidate_board_from_store(store, domain, model, watch, save_recovery);
@@ -300,6 +301,10 @@ fn run_board() -> Result<(), Box<dyn Error>> {
         // as content).
         let mut frame_rows: Vec<String> = Vec::new();
         let mut frame_copyable: Vec<Rect> = Vec::new();
+        // Left Down is deferred until Up (or abandoned when a text drag grows): firing
+        // the click on Down made every board-row drag also peek/toggle, so copy only
+        // felt reliable on the task page where Down is inert over notes.
+        let mut pending_click: Option<crossterm::event::MouseEvent> = None;
         loop {
             // Settle, paint, then wait. The board frame path does no host polling, so the
             // wait is only the Frame Scheduler's idle floor. All three are one call because
@@ -329,6 +334,9 @@ fn run_board() -> Result<(), Box<dyn Error>> {
             }
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    // A key while the mouse button is held abandons the deferred click so
+                    // Up does not fire a stale peek/select after the keyboard moved on.
+                    pending_click = None;
                     let area = terminal_area(terminal)?;
                     // The painted mode owns the keyboard: `resolve_board_surface` resolves the
                     // same input mode at every terminal size (`board_input_mode_for_area` no
@@ -358,27 +366,47 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                 Event::Mouse(mouse) => {
                     // A left-button drag grows a text selection over the painted frame
                     // (highlight and copy text come from the last painted snapshot), and
-                    // release hands that text to the clipboard. Clicks (Down) still
-                    // keep their exact Down-time behavior, drags were dead weight before.
+                    // release hands that text to the clipboard. Clicks are deferred to Up
+                    // so a drag does not also fire the Down-time peek/select path.
+                    use crossterm::event::{MouseButton, MouseEventKind};
+                    let mut click = mouse;
                     match mouse.kind {
                         MouseEventKind::Drag(MouseButton::Left) => {
                             model.drag_text_selection(Position::new(mouse.column, mouse.row));
+                            if model
+                                .text_selection()
+                                .is_some_and(crate::ui::text_select::TextSelection::has_area)
+                            {
+                                pending_click = None;
+                            }
                             continue;
                         }
                         MouseEventKind::Up(MouseButton::Left) => {
                             model.end_mouse_press();
-                            copy_drag_selection(&mut model, &frame_rows, &frame_copyable);
+                            if model
+                                .text_selection()
+                                .is_some_and(crate::ui::text_select::TextSelection::has_area)
+                            {
+                                copy_drag_selection(&mut model, &frame_rows, &frame_copyable);
+                                pending_click = None;
+                                continue;
+                            }
+                            let Some(down) = pending_click.take() else {
+                                continue;
+                            };
+                            click = down;
+                        }
+                        MouseEventKind::Down(MouseButton::Left) => {
+                            // Anchor a would-be selection and stash the Down for Up;
+                            // do not map the click yet.
+                            model.begin_mouse_press(Position::new(mouse.column, mouse.row));
+                            pending_click = Some(mouse);
                             continue;
                         }
                         _ => {}
                     }
-                    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
-                        // The press anchors a would-be selection and clears the previous
-                        // highlight before the click mapper runs.
-                        model.begin_mouse_press(Position::new(mouse.column, mouse.row));
-                    }
                     let area = terminal_area(terminal)?;
-                    let Some(intent) = board_mouse_intent(area, &mut model, mouse) else {
+                    let Some(intent) = board_mouse_intent(area, &mut model, click) else {
                         continue;
                     };
                     if handle_board_intent(
@@ -419,21 +447,22 @@ fn run_board() -> Result<(), Box<dyn Error>> {
 ///
 /// Only cells the painters declared copyable are taken, so scrollbars, borders,
 /// and other chrome never reach the clipboard. A selection with no text (a bare
-/// click, or a drag over blank cells) copies nothing; a real one reports on the
-/// status row, since the only other feedback (the terminal's own clipboard
-/// toast, if any) is outside this process.
+/// click, or a drag over blank cells) copies nothing. Success flashes a short
+/// ephemeral status that clears itself; the highlight drops so it does not stick.
 fn copy_drag_selection(model: &mut BoardModel, frame_rows: &[String], copyable: &[Rect]) {
     let Some(selection) = model.text_selection() else {
         return;
     };
     let Some(text) = selection_text(frame_rows, copyable, &selection) else {
+        model.clear_text_selection();
         return;
     };
     if copy_to_clipboard(&text) {
-        model.set_message(format!("copied {} chars", text.chars().count()));
+        model.set_ephemeral_message("copied", Duration::from_secs(2));
     } else {
-        model.set_message("copy failed");
+        model.set_ephemeral_message("copy failed", Duration::from_secs(2));
     }
+    model.clear_text_selection();
 }
 
 /// Whether save recovery permits the board to apply background state changes.

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -433,8 +433,12 @@ fn build_task_page_overlay<'a>(
 /// the paints the queue frame via [`render::draw_queue_frame`]. Classic master-detail
 /// chrome is retired; overlays that still need the classic layout (edit band, save
 /// recovery banner via message) are layered lightly on top where session mode requires it.
-pub fn draw_board(frame: &mut Frame, model: &BoardModel) {
-    let _hits = draw_board_impl(frame, model);
+pub fn draw_board(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap {
+    let hits = draw_board_impl(frame, model);
+    if let Some(selection) = model.text_selection() {
+        crate::ui::text_select::paint_selection(frame, &selection);
+    }
+    hits
 }
 
 /// The mouse hit-map for one board frame, without a live terminal.

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -436,7 +436,7 @@ fn build_task_page_overlay<'a>(
 pub fn draw_board(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap {
     let hits = draw_board_impl(frame, model);
     if let Some(selection) = model.text_selection() {
-        crate::ui::text_select::paint_selection(frame, &selection);
+        crate::ui::text_select::paint_selection(frame, &selection, &hits.copyable);
     }
     hits
 }

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -574,6 +574,9 @@ pub struct BoardModel {
     pub(super) mouse_press: Option<Position>,
     /// The live drag-selected screen region, cleared on the next press.
     pub(super) text_selection: Option<TextSelection>,
+    /// When set, [`Self::message`] clears itself on the next idle tick after this instant.
+    /// Sticky messages (errors, delete notices) leave this `None`.
+    pub(super) message_expires_at: Option<Instant>,
     /// Palette query.
     pub(super) command_query: String,
     /// Selection into the currently visible command set.
@@ -630,6 +633,7 @@ impl BoardModel {
             command_selected: 0,
             mouse_press: None,
             text_selection: None,
+            message_expires_at: None,
             verb_modifier: VerbModifier::Alt,
         };
         model.seed_selection();
@@ -945,10 +949,15 @@ impl BoardModel {
         }
     }
 
-    /// Clear the press on release; the selection itself stays painted (its copied
-    /// cells remain visible) until the next press replaces it.
+    /// Clear the press on release; the selection itself stays until copy clears it
+    /// or the next press replaces it.
     pub fn end_mouse_press(&mut self) {
         self.mouse_press = None;
+    }
+
+    /// Drop a finished text selection highlight (after copy, Esc, or cancel).
+    pub fn clear_text_selection(&mut self) {
+        self.text_selection = None;
     }
 
     /// The live drag selection, if a drag is (or was) in progress.
@@ -1429,10 +1438,28 @@ impl BoardModel {
 
     pub fn set_message(&mut self, msg: impl Into<String>) {
         self.message = Some(terminal_text(&msg.into()));
+        self.message_expires_at = None;
+    }
+
+    /// Status feedback that clears itself after `ttl` (copy confirmation, brief notices).
+    pub fn set_ephemeral_message(&mut self, msg: impl Into<String>, ttl: std::time::Duration) {
+        self.message = Some(terminal_text(&msg.into()));
+        self.message_expires_at = Some(Instant::now() + ttl);
     }
 
     pub fn clear_message(&mut self) {
         self.message = None;
+        self.message_expires_at = None;
+    }
+
+    /// Drop an ephemeral status line whose TTL has elapsed. Sticky messages are untouched.
+    pub fn expire_ephemeral_message(&mut self) {
+        if self
+            .message_expires_at
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            self.clear_message();
+        }
     }
 
     /// Title carried by the visible delete recovery notice, if one is armed.
@@ -1672,6 +1699,25 @@ mod tests {
         domain
             .create(title, None, scope, None, None, ProvenanceOrigin::Manual)
             .expect("create")
+    }
+
+    #[test]
+    fn ephemeral_status_clears_after_deadline() {
+        let mut model = BoardModel::from_tasks(Vec::new(), None);
+        model.set_ephemeral_message("copied", std::time::Duration::from_millis(1));
+        assert_eq!(model.message(), Some("copied"));
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        model.expire_ephemeral_message();
+        assert!(model.message().is_none());
+        assert!(model.message_expires_at.is_none());
+    }
+
+    #[test]
+    fn sticky_status_survives_expire_tick() {
+        let mut model = BoardModel::from_tasks(Vec::new(), None);
+        model.set_message("save failed");
+        model.expire_ephemeral_message();
+        assert_eq!(model.message(), Some("save failed"));
     }
 
     #[test]

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -577,6 +577,9 @@ pub struct BoardModel {
     /// When set, [`Self::message`] clears itself on the next idle tick after this instant.
     /// Sticky messages (errors, delete notices) leave this `None`.
     pub(super) message_expires_at: Option<Instant>,
+    /// Sticky status restored when an ephemeral toast expires (e.g. save-recovery banner
+    /// under a brief `copied` notice). Cleared by [`Self::set_message`] / [`Self::clear_message`].
+    pub(super) message_restore: Option<String>,
     /// Palette query.
     pub(super) command_query: String,
     /// Selection into the currently visible command set.
@@ -634,6 +637,7 @@ impl BoardModel {
             mouse_press: None,
             text_selection: None,
             message_expires_at: None,
+            message_restore: None,
             verb_modifier: VerbModifier::Alt,
         };
         model.seed_selection();
@@ -1439,10 +1443,17 @@ impl BoardModel {
     pub fn set_message(&mut self, msg: impl Into<String>) {
         self.message = Some(terminal_text(&msg.into()));
         self.message_expires_at = None;
+        self.message_restore = None;
     }
 
     /// Status feedback that clears itself after `ttl` (copy confirmation, brief notices).
+    ///
+    /// A sticky status already on the line (save-recovery banner, etc.) is stashed and
+    /// restored when the toast expires, so a `copied` flash cannot erase it.
     pub fn set_ephemeral_message(&mut self, msg: impl Into<String>, ttl: std::time::Duration) {
+        if self.message_expires_at.is_none() {
+            self.message_restore = self.message.clone();
+        }
         self.message = Some(terminal_text(&msg.into()));
         self.message_expires_at = Some(Instant::now() + ttl);
     }
@@ -1450,15 +1461,18 @@ impl BoardModel {
     pub fn clear_message(&mut self) {
         self.message = None;
         self.message_expires_at = None;
+        self.message_restore = None;
     }
 
-    /// Drop an ephemeral status line whose TTL has elapsed. Sticky messages are untouched.
+    /// Drop an ephemeral status line whose TTL has elapsed. Sticky messages are untouched;
+    /// a stashed sticky under a toast is restored.
     pub fn expire_ephemeral_message(&mut self) {
         if self
             .message_expires_at
             .is_some_and(|deadline| Instant::now() >= deadline)
         {
-            self.clear_message();
+            self.message = self.message_restore.take();
+            self.message_expires_at = None;
         }
     }
 
@@ -1709,6 +1723,22 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(5));
         model.expire_ephemeral_message();
         assert!(model.message().is_none());
+        assert!(model.message_expires_at.is_none());
+    }
+
+    #[test]
+    fn ephemeral_toast_restores_sticky_save_recovery_banner() {
+        let mut model = BoardModel::from_tasks(Vec::new(), None);
+        model.set_message("save failed: disk full · Retry or Cancel");
+        model.set_ephemeral_message("copied", std::time::Duration::from_millis(1));
+        assert_eq!(model.message(), Some("copied"));
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        model.expire_ephemeral_message();
+        assert_eq!(
+            model.message(),
+            Some("save failed: disk full · Retry or Cancel"),
+            "sticky banner must return after the toast, not vanish"
+        );
         assert!(model.message_expires_at.is_none());
     }
 

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use ratatui::layout::Position;
 use uuid::Uuid;
 
 use crate::config::VerbModifier;
@@ -22,6 +23,7 @@ use crate::ui::queue::{
 use crate::ui::render::StepView;
 use crate::ui::selection;
 use crate::ui::terminal_text;
+use crate::ui::text_select::TextSelection;
 
 use super::commands::CommandSurface;
 
@@ -567,6 +569,11 @@ pub struct BoardModel {
     pub(super) project_picker: Option<ProjectPickerState>,
     /// Open palette (presentation only).
     pub(super) surface: CommandSurface,
+    /// The last left-button press cell, held until release so a drag can grow a text
+    /// selection out of it. Presentation-only; a plain click never reads it.
+    pub(super) mouse_press: Option<Position>,
+    /// The live drag-selected screen region, cleared on the next press.
+    pub(super) text_selection: Option<TextSelection>,
     /// Palette query.
     pub(super) command_query: String,
     /// Selection into the currently visible command set.
@@ -621,6 +628,8 @@ impl BoardModel {
             surface: CommandSurface::None,
             command_query: String::new(),
             command_selected: 0,
+            mouse_press: None,
+            text_selection: None,
             verb_modifier: VerbModifier::Alt,
         };
         model.seed_selection();
@@ -915,6 +924,36 @@ impl BoardModel {
     /// intervenes. Mouse-boundary state only, never persisted.
     pub(crate) fn cancel_project_header_double_click(&mut self) {
         self.last_project_header_click = None;
+    }
+
+    /// Record a left-button press cell and drop any finished selection's highlight.
+    ///
+    /// The press cell is what a following drag grows the selection from; a plain
+    /// click never reads it. Called for every left press, whatever the input mode.
+    pub fn begin_mouse_press(&mut self, position: Position) {
+        self.mouse_press = Some(position);
+        self.text_selection = None;
+    }
+
+    /// Extend the drag selection to `position`, anchored at the press cell.
+    ///
+    /// Inert without a live press (a drag that starts mid-gesture, e.g. before tsk
+    /// saw the press), so it can never invent an anchor.
+    pub fn drag_text_selection(&mut self, position: Position) {
+        if let Some(anchor) = self.mouse_press {
+            self.text_selection = Some(TextSelection::new(anchor, position));
+        }
+    }
+
+    /// Clear the press on release; the selection itself stays painted (its copied
+    /// cells remain visible) until the next press replaces it.
+    pub fn end_mouse_press(&mut self) {
+        self.mouse_press = None;
+    }
+
+    /// The live drag selection, if a drag is (or was) in progress.
+    pub fn text_selection(&self) -> Option<TextSelection> {
+        self.text_selection
     }
 
     /// Options the session project selector offers, in presentation order.

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -508,8 +508,11 @@ fn help_chord_shown(chord: &str, verbs: VerbModifier) -> String {
 }
 
 /// Help-card body lines painted by the renderer (derived from [`normal_help_bindings`]).
+///
+/// No heading or trailing close instruction: the shared modal card's own title (`help`)
+/// and footer legend (`any key close`) already say both.
 pub fn help_card_lines(verbs: VerbModifier) -> Vec<String> {
-    let mut lines = vec!["keys".to_string(), String::new()];
+    let mut lines = Vec::new();
     let bindings = normal_help_bindings();
     let mut i = 0;
     while i < bindings.len() {
@@ -526,8 +529,6 @@ pub fn help_card_lines(verbs: VerbModifier) -> Vec<String> {
             i += 1;
         }
     }
-    lines.push(String::new());
-    lines.push(" any key to close".to_string());
     lines
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod queue;
 pub mod render;
 pub mod scheduler;
 pub mod selection;
+pub mod text_select;
 pub mod tier;
 
 /// Render untrusted values without allowing C0/C1 terminal control sequences through.

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -420,6 +420,10 @@ pub fn map_board_mouse(
                 .get(index)
                 .map(|_| BoardIntent::SelectCommand(index)),
             Some(QueueHitTarget::CommandChrome) => None,
+            // The card's own border/title/footer rule: inert, the same as the palette's
+            // pre-card `CommandChrome` furniture just above.
+            Some(QueueHitTarget::ModalChrome) => None,
+            Some(QueueHitTarget::ModalClose) => Some(BoardIntent::CloseCommandSurface),
             Some(QueueHitTarget::Verb(index)) => palette_verb_intent(index),
             _ => Some(BoardIntent::CloseCommandSurface),
         },
@@ -427,10 +431,18 @@ pub fn map_board_mouse(
             Some(QueueHitTarget::ProjectOption(index)) => {
                 Some(BoardIntent::SelectProjectOption(index))
             }
+            Some(QueueHitTarget::ModalChrome) => None,
+            Some(QueueHitTarget::ModalClose) => Some(BoardIntent::CancelProjectPicker),
             Some(QueueHitTarget::Verb(index)) => scope_dropdown_verb_intent(index),
             _ => Some(BoardIntent::CancelProjectPicker),
         },
-        BoardInputMode::Help => Some(BoardIntent::CloseLayer),
+        // The card's border/title/footer are inert; every other hit -- the `[x]` close
+        // control, the card's own body text, `HelpDismiss`'s full-frame fallback, or no
+        // hit at all -- closes, matching the keyboard's "any key closes".
+        BoardInputMode::Help => match hit_at(hits, pos) {
+            Some(QueueHitTarget::ModalChrome) => None,
+            _ => Some(BoardIntent::CloseLayer),
+        },
         BoardInputMode::QuickAdd => match hit_at(hits, pos) {
             // The line already owns keyboard focus, so its click is intentionally inert.
             Some(QueueHitTarget::QuickAddInput) => None,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -518,8 +518,10 @@ pub enum QueueHitTarget {
         section_idx: usize,
         subgroup_idx: usize,
     },
-    /// The open help card: painted full-frame so any click inside it closes it, matching
-    /// the keyboard's "any key closes".
+    /// The open help card's full-frame dismiss hit -- a click anywhere the card's own
+    /// `ModalClose`/`ModalChrome`/body hits do not shadow closes it, matching the
+    /// keyboard's "any key closes". The board behind the card stays visible and painted;
+    /// only [`paint_modal_card`]'s own rect is cleared and repainted.
     HelpDismiss,
     /// Shared-form title row. A click focuses Title without recreating the form.
     FormTitle,
@@ -553,6 +555,15 @@ pub enum QueueHitTarget {
     /// dismisses the surface), matching the pre-rewrite behavior a click on the palette's
     /// own furniture had; only a click genuinely outside the whole surface closes it.
     CommandChrome,
+    /// The shared modal card's `[x]` close control (Help / Palette / project-scope
+    /// picker; [`paint_modal_card`]). Dismisses whatever overlay painted it -- the same
+    /// effect the surface's own Esc/close route already has.
+    ModalClose,
+    /// The shared modal card's own chrome -- its border, title row, and footer rule +
+    /// legend -- that is neither `ModalClose` nor the caller's own body hit. A click here
+    /// is deliberately inert, the same rule `CommandChrome` already applies to the
+    /// palette's pre-card furniture.
+    ModalChrome,
 }
 
 /// One hit-testable region produced beside the paint.
@@ -755,9 +766,11 @@ pub fn draw_queue_frame(
     if let Some(row) = geo.verb_row {
         let budget = geo.verb_bar_entry_budget as usize;
         let verb_items = match &model.overlay {
-            QueueOverlay::Palette { .. } => PALETTE_VERBS,
-            QueueOverlay::Help { .. } => HELP_VERBS,
-            QueueOverlay::ScopeDropdown { .. } => SCOPE_VERBS,
+            // The modal card painted for each of these owns its own footer legend now;
+            // the board's verb bar stays blank underneath it.
+            QueueOverlay::Palette { .. }
+            | QueueOverlay::Help { .. }
+            | QueueOverlay::ScopeDropdown { .. } => &[],
             QueueOverlay::QuickAdd { recovery, .. } if *recovery => &[],
             QueueOverlay::QuickAdd { .. } => QUICK_ADD_VERBS,
             // The page's field edits keep the form legends; its view mode reads the
@@ -1001,11 +1014,6 @@ const EDIT_NOTES_VERBS: &[VerbEntry<'static>] = &[
     },
 ];
 
-const HELP_VERBS: &[VerbEntry<'static>] = &[VerbEntry {
-    key: "any",
-    label: "close",
-}];
-
 pub(crate) const SCOPE_VERBS: &[VerbEntry<'static>] = &[
     VerbEntry {
         key: "j/k",
@@ -1039,14 +1047,7 @@ fn paint_overlay(
             paint_help_overlay(frame, geo, lines, hits);
         }
         QueueOverlay::ScopeDropdown { options, selected } => {
-            paint_scope_dropdown(
-                frame,
-                geo,
-                options,
-                *selected,
-                QueueHitTarget::ProjectOption,
-                hits,
-            );
+            paint_scope_dropdown(frame, geo, options, *selected, hits);
         }
         QueueOverlay::EditTitle {
             ref draft,
@@ -1208,6 +1209,254 @@ fn paint_edit_notes_overlay(
     }
 }
 
+/// Shared centered mono modal card for `P` / `?` / `:` (help / command palette / project
+/// scope): a bordered box with the title and `[x]` close control integrated into the top
+/// border, an optional footer rule + dim key legend, and the board still visible behind
+/// it (only the card's own rect is cleared and repainted).
+///
+/// `bounds` is the region the card may center within -- a caller with nothing worth
+/// preserving underneath (Help, project-scope) passes the full frame; the palette passes
+/// a shorter band so its own query row (painted separately, on the status row) stays
+/// clear. Compact tier drops the blank padding row/column around the content but always
+/// keeps the border and footer; the card otherwise sizes itself to `content_rows`,
+/// clamped to what `bounds` can hold.
+///
+/// Hits are pushed in this order -- later pushes win under `hit_at`'s reverse search --
+/// so a caller's own body hits (and `push_copyable` calls) painted after this returns
+/// correctly shadow the blanket chrome below for their own rects:
+/// 1. A full-frame `dismiss` hit (when given), so a click anywhere on the board behind
+///    the card resolves to it unless something more specific shadows it.
+/// 2. A blanket `ModalChrome` hit over the whole card, so every cell defaults to inert.
+/// 3. `ModalClose` on the `[x]` control.
+///
+/// Per-call content for [`paint_modal_card`]: everything that varies between Help /
+/// Palette / project-scope beyond the shared `frame` / `geo` / `bounds` / `hits` plumbing.
+struct ModalCardSpec<'a> {
+    title: &'a str,
+    content_rows: u16,
+    legend: &'a [VerbEntry<'a>],
+    /// A full-frame dismiss hit to push first, before the card's own chrome (see below).
+    dismiss: Option<QueueHitTarget>,
+}
+
+/// Fixed row overhead a [`paint_modal_card`] with a footer legend (or not) spends on its
+/// own chrome -- border top+bottom, the footer's rule+legend rows when it has one, and
+/// blank vertical padding outside `Tier::Compact`. Callers that need to know how many
+/// body rows will actually be visible *before* the card paints (e.g. to decide whether a
+/// title needs a `▼` scroll marker) go through this, so that decision can never drift
+/// from what the card itself later carves out of `bounds`.
+fn modal_chrome_rows(tier: Tier, has_footer: bool) -> u16 {
+    let pad: u16 = if tier == Tier::Compact { 0 } else { 1 };
+    let footer_rows: u16 = if has_footer { 2 } else { 0 };
+    2 + footer_rows + 2 * pad
+}
+
+/// Returns the content `Rect` the caller paints its body into (zero-area when nothing
+/// fits, e.g. a zero-sized frame).
+fn paint_modal_card(
+    frame: &mut Frame<'_>,
+    geo: &TierGeometry,
+    bounds: Rect,
+    spec: ModalCardSpec<'_>,
+    hits: &mut QueueHitMap,
+) -> Rect {
+    let ModalCardSpec {
+        title,
+        content_rows,
+        legend,
+        dismiss,
+    } = spec;
+    if geo.row_width == 0 || geo.height == 0 || bounds.width == 0 || bounds.height == 0 {
+        return Rect::default();
+    }
+    if let Some(target) = dismiss {
+        hits.push(target, Rect::new(0, 0, geo.row_width, geo.height));
+    }
+
+    let card_w = bounds.width.saturating_sub(4).clamp(1, 62);
+    // Blank inset around the content, shed on both axes in compact so its scarce cells
+    // go to actual body text instead of decorative breathing room.
+    let pad: u16 = if geo.tier == Tier::Compact { 0 } else { 1 };
+    let chrome_rows = modal_chrome_rows(geo.tier, !legend.is_empty());
+    let shown_content = content_rows.min(bounds.height.saturating_sub(chrome_rows));
+    let card_h = (chrome_rows + shown_content).min(bounds.height).max(1);
+    let x0 = bounds.x + bounds.width.saturating_sub(card_w) / 2;
+    let y0 = bounds.y + bounds.height.saturating_sub(card_h) / 2;
+    let area = Rect::new(x0, y0, card_w, card_h);
+
+    frame.render_widget(Clear, area);
+    hits.push(QueueHitTarget::ModalChrome, area);
+
+    let (top_line, close_x) = modal_title_border_row(title, card_w);
+    paint_row_in(frame, area, 0, top_line);
+    if close_x < card_w {
+        let close_w = 3.min(card_w.saturating_sub(close_x));
+        hits.push(
+            QueueHitTarget::ModalClose,
+            Rect::new(x0 + close_x, y0, close_w, 1),
+        );
+    }
+
+    let bottom_offset = card_h.saturating_sub(1);
+    if bottom_offset > 0 {
+        paint_row_in(
+            frame,
+            area,
+            bottom_offset,
+            modal_plain_border_row('└', '─', '┘', card_w),
+        );
+    }
+    if !legend.is_empty() {
+        let rule_offset = bottom_offset.saturating_sub(2);
+        let legend_offset = bottom_offset.saturating_sub(1);
+        paint_row_in(
+            frame,
+            area,
+            rule_offset,
+            modal_plain_border_row('├', '─', '┤', card_w),
+        );
+        paint_row_in(
+            frame,
+            area,
+            legend_offset,
+            modal_legend_line(legend, card_w as usize),
+        );
+    }
+
+    Rect::new(
+        x0.saturating_add(1 + pad),
+        y0.saturating_add(1 + pad),
+        card_w.saturating_sub(2 + 2 * pad),
+        shown_content,
+    )
+}
+
+/// One row of a modal card's border/legend, painted at `area`'s `row_offset`-th row
+/// (never past `area`'s own height).
+fn paint_row_in(frame: &mut Frame<'_>, area: Rect, row_offset: u16, line: Line<'static>) {
+    if row_offset >= area.height {
+        return;
+    }
+    let rect = Rect::new(area.x, area.y.saturating_add(row_offset), area.width, 1);
+    put_line_at(frame, rect, line);
+}
+
+/// A plain dim border row: one corner glyph, a fill of `card_w - 2` cells, the other
+/// corner glyph (`┌─…─┐` / `├─…─┤` / `└─…─┘`).
+fn modal_plain_border_row(left: char, fill: char, right: char, card_w: u16) -> Line<'static> {
+    let width = card_w as usize;
+    let inner = width.saturating_sub(2);
+    let mut text = String::with_capacity(width.max(1));
+    text.push(left);
+    text.extend(std::iter::repeat_n(fill, inner));
+    text.push(right);
+    bound_line(Line::from(Span::styled(text, style_dim())), width)
+}
+
+/// The card's top border, with its title and `[x]` close control integrated
+/// (`┌─ Title ──…── [x]─┐`). Returns the painted line plus the close control's column
+/// offset from the card's own left edge, so the caller can push a hit region that can
+/// never drift from what was actually painted.
+fn modal_title_border_row(title: &str, card_w: u16) -> (Line<'static>, u16) {
+    let width = card_w as usize;
+    let inner = width.saturating_sub(2);
+    // Fixed furniture around the title and close control: "─ " + " " + " " + "[x]" + "─".
+    const FIXED: usize = 8;
+    let title_budget = inner.saturating_sub(FIXED + 1);
+    let shown_title = present_line(title, title_budget);
+    let title_w = display_width(&shown_title);
+    let fill = inner.saturating_sub(FIXED + title_w).max(1);
+    let close_x = (1 + 2 + title_w + 1 + fill + 1) as u16;
+
+    let spans = vec![
+        Span::styled("┌".to_string(), style_dim()),
+        Span::styled("─ ".to_string(), style_dim()),
+        Span::styled(shown_title, style_bold()),
+        Span::styled(" ".to_string(), style_dim()),
+        Span::styled("─".repeat(fill), style_dim()),
+        Span::styled(" ".to_string(), style_dim()),
+        Span::styled("[x]".to_string(), style_bold()),
+        Span::styled("─".to_string(), style_dim()),
+        Span::styled("┐".to_string(), style_dim()),
+    ];
+    (bound_line(Line::from(spans), width), close_x)
+}
+
+/// A modal card's footer legend line: dim separators and labels, bold keys, e.g.
+/// `  esc close · enter run`.
+fn modal_legend_line(entries: &[VerbEntry<'_>], width: usize) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = vec![Span::styled("  ".to_string(), style_plain())];
+    for (i, entry) in entries.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" · ".to_string(), style_dim()));
+        }
+        spans.push(Span::styled(entry.key.to_string(), style_bold()));
+        spans.push(Span::styled(format!(" {}", entry.label), style_dim()));
+    }
+    bound_line(Line::from(spans), width)
+}
+
+/// The vertical band a modal card ( [`paint_modal_card`] ) may center within: the whole
+/// row width, but never the rule/status/verb rows underneath -- the palette keeps its
+/// query on the status row exactly as before, and the (now-blank) verb row stays intact
+/// for every card so the board's own bottom chrome never gets painted over.
+fn modal_bounds(geo: &TierGeometry) -> Rect {
+    Rect::new(0, 0, geo.row_width, geo.rule_row.unwrap_or(geo.height))
+}
+
+/// Legend footer for the Help card: any key (Esc included) closes it.
+const HELP_FOOTER: &[VerbEntry<'static>] = &[VerbEntry {
+    key: "any key",
+    label: "close",
+}];
+
+/// Legend footer for the command palette card.
+const PALETTE_FOOTER: &[VerbEntry<'static>] = &[
+    VerbEntry {
+        key: "↑/↓",
+        label: "move",
+    },
+    VerbEntry {
+        key: "enter",
+        label: "run",
+    },
+    VerbEntry {
+        key: "esc",
+        label: "close",
+    },
+];
+
+/// Legend footer for the project-scope card.
+const SCOPE_FOOTER: &[VerbEntry<'static>] = &[
+    VerbEntry {
+        key: "↑/↓",
+        label: "move",
+    },
+    VerbEntry {
+        key: "enter",
+        label: "choose",
+    },
+    VerbEntry {
+        key: "esc",
+        label: "close",
+    },
+];
+
+/// Append a scroll marker to a card title when its body is windowed (`▲`/`▼`/both).
+fn titled_with_scroll_marker(title: &str, above: bool, below: bool) -> String {
+    if !above && !below {
+        return title.to_string();
+    }
+    let mut owned = format!("{title} ");
+    if above {
+        owned.push('▲');
+    }
+    if below {
+        owned.push('▼');
+    }
+    owned
+}
+
 fn paint_palette_overlay(
     frame: &mut Frame<'_>,
     geo: &TierGeometry,
@@ -1220,83 +1469,70 @@ fn paint_palette_overlay(
     if width == 0 || height < 3 {
         return;
     }
+    let bounds = modal_bounds(geo);
+    // Derived from the same chrome math `paint_modal_card` itself uses, rather than a
+    // separate guess (`viewport_height` belongs to the board list, not this card) -- a
+    // mismatch here would either scroll past what the card can paint (leaving the
+    // "selected" row visually missing) or paint into the card's own footer.
+    let capacity = bounds
+        .height
+        .saturating_sub(modal_chrome_rows(geo.tier, true));
     let max_rows = if geo.tier == Tier::Compact {
-        // Compact: fill the list viewport when present, else as many rows as fit above chrome.
-        geo.viewport_height.max(1) as usize
+        capacity.max(1) as usize
     } else {
-        6usize
+        6usize.min(capacity.max(1) as usize)
     };
-    // Query sits on the status row when present; otherwise the last content row.
-    let query_row = geo.status_row.unwrap_or(height.saturating_sub(2));
-    // The dim rule row is base chrome every other the scene keeps: stop the command
-    // list one row above it instead of one row above the query, which reached into the
-    // rule row and overwrote it with command text.
-    let list_bottom = geo
-        .rule_row
-        .map(|r| r.saturating_sub(1))
-        .unwrap_or_else(|| query_row.saturating_sub(1));
-    // Reserve one row for the `command` header directly above the list, and never paint
-    // above `viewport_top`: `list_bottom` is a row *index*, not a row
-    // *count*, so windowing straight off it let the header climb onto (or above) the
-    // selector row on short/compact terminals once the command count passed the
-    // available space. The rows actually available for header + list is the span between
-    // `viewport_top` and `list_bottom` inclusive; the header eats one of them.
-    let available = list_bottom.saturating_sub(geo.viewport_top) as usize;
-    let rows = available.min(max_rows).min(commands.len());
-    if rows > 0 {
-        let selected = commands
-            .iter()
-            .position(|command| command.selected)
-            .unwrap_or(0);
-        let scroll = if selected < rows {
-            0
-        } else {
-            (selected + 1 - rows).min(commands.len() - rows)
-        };
-        let first_cmd = list_bottom + 1 - rows as u16;
-        let above = scroll > 0;
-        let below = scroll + rows < commands.len();
-        let marker = match (above, below) {
-            (true, true) => " ▲▼",
-            (true, false) => " ▲",
-            (false, true) => " ▼",
-            (false, false) => "",
-        };
-        let header_row = first_cmd.saturating_sub(1);
-        put_line(
-            frame,
-            header_row,
-            width,
-            paint_bounded_line(&format!(" command{marker}"), width, style_underline()),
-        );
-        // the header row is the palette's own chrome, not a command
-        // row and not outside the surface either -- a click here must neither run a
-        // command (there is none to run) nor dismiss the surface, matching the
-        // pre-rewrite behavior of a click on the palette's own furniture.
-        hits.push(
-            QueueHitTarget::CommandChrome,
-            Rect::new(0, header_row, width, 1),
-        );
-        for (j, cmd) in commands.iter().skip(scroll).take(rows).enumerate() {
-            let y = first_cmd.saturating_add(j as u16);
-            let pre = if cmd.selected { " ▸ " } else { "   " };
+    let rows = max_rows.min(commands.len());
+    let selected = commands
+        .iter()
+        .position(|command| command.selected)
+        .unwrap_or(0);
+    let scroll = if rows == 0 || selected < rows {
+        0
+    } else {
+        (selected + 1 - rows).min(commands.len() - rows)
+    };
+    let above = scroll > 0;
+    let below = rows > 0 && scroll + rows < commands.len();
+    let title = titled_with_scroll_marker("command", above, below);
+
+    let content = paint_modal_card(
+        frame,
+        geo,
+        bounds,
+        ModalCardSpec {
+            title: &title,
+            content_rows: rows as u16,
+            legend: PALETTE_FOOTER,
+            dismiss: None,
+        },
+        hits,
+    );
+    if content.width > 0 && content.height > 0 {
+        let paintable = rows.min(content.height as usize);
+        for (j, cmd) in commands.iter().skip(scroll).take(paintable).enumerate() {
+            let y = content.y.saturating_add(j as u16);
+            let pre = if cmd.selected { "▸ " } else { "  " };
             let text = format!("{pre}{}", cmd.label);
             let style = if cmd.selected {
                 style_reverse()
             } else {
                 style_plain()
             };
-            put_line(frame, y, width, paint_bounded_line(&text, width, style));
+            let rect = Rect::new(content.x, y, content.width, 1);
+            put_line_at(frame, rect, paint_bounded_line(&text, content.width, style));
             // Index into the full (unscrolled) command list, so a click resolves to the
             // same command `BoardModel::visible_commands()` would name at that position
             // regardless of which window is currently painted.
-            hits.push(
-                QueueHitTarget::Command(scroll + j),
-                Rect::new(0, y, width, 1),
-            );
-            hits.push_copyable(Rect::new(0, y, width, 1));
+            hits.push(QueueHitTarget::Command(scroll + j), rect);
+            hits.push_copyable(rect);
         }
     }
+
+    // Query sits on the status row when present; otherwise the last content row -- the
+    // card's own bounds stop above this row, so caret placement here stays exactly as
+    // simple as before the card existed.
+    let query_row = geo.status_row.unwrap_or(height.saturating_sub(2));
     let q = format!(" :{query}");
     put_line(
         frame,
@@ -1318,62 +1554,63 @@ fn paint_help_overlay(
     lines: &[String],
     hits: &mut QueueHitMap,
 ) {
-    let width = geo.row_width;
-    let height = geo.height;
-    if width == 0 || height == 0 || lines.is_empty() {
+    if geo.row_width == 0 || geo.height == 0 || lines.is_empty() {
         return;
     }
-    // Any click anywhere in the frame closes the card, matching the keyboard's "any key":
-    // one full-frame region rather than one per painted line, so a click in the
-    // padding around a short card still closes it.
-    hits.push(QueueHitTarget::HelpDismiss, Rect::new(0, 0, width, height));
-    frame.render_widget(Clear, Rect::new(0, 0, width, height));
-    let body_w = (width.saturating_sub(2)).min(62) as usize;
-    // Compact is a takeover: omit decorative blank rows so the title, every binding,
-    // and the close instruction fit at the 40x10 minimum.
-    let shown: Vec<&String> = if geo.tier == Tier::Compact {
-        lines.iter().filter(|line| !line.is_empty()).collect()
+    // Compact: omit decorative blank rows, and drop each line's leading indent column --
+    // the card's own border already insets the body, so the width that bought is worth
+    // more here than the indent. Neither line up needs an inset from the other; the
+    // card's `pad` already covers it.
+    let shown: Vec<String> = if geo.tier == Tier::Compact {
+        lines
+            .iter()
+            .filter(|line| !line.is_empty())
+            .map(|line| line.trim_start().to_string())
+            .collect()
     } else {
-        // Keep standard card spacing, while sharing the loop below.
-        lines.iter().collect()
+        lines.to_vec()
     };
-    let show = shown.len().min(height as usize);
-    let y0 = if geo.tier == Tier::Compact {
-        0
-    } else {
-        ((height as usize).saturating_sub(show) / 2).max(1) as u16
-    };
-    let x_pad = width.saturating_sub(body_w as u16) / 2;
-    for (j, ln) in shown.iter().take(show).enumerate() {
-        let y = y0.saturating_add(j as u16);
-        if y >= height {
-            break;
-        }
-        let body = present_line(ln, body_w);
-        let pad = " ".repeat(x_pad as usize);
-        if ln.contains("any key") {
-            // Reverse only the words. Padding stays plain so the bar does not run to the left.
-            let trail = (width as usize).saturating_sub(x_pad as usize + display_width(&body));
-            put_line(
-                frame,
-                y,
-                width,
-                bound_line(
-                    Line::from(vec![
-                        Span::styled(pad, style_plain()),
-                        Span::styled(body, style_reverse()),
-                        Span::styled(" ".repeat(trail), style_plain()),
-                    ]),
-                    width as usize,
-                ),
-            );
-        } else {
-            let padded = format!("{pad}{body}");
-            let style = if j == 0 { style_bold() } else { style_plain() };
-            put_line(frame, y, width, paint_bounded_line(&padded, width, style));
-        }
-        // Body lines only — not the full-frame dismiss chrome.
-        hits.push_copyable(Rect::new(x_pad, y, body_w as u16, 1));
+
+    // Help has nothing worth preserving underneath it (no query row like the palette),
+    // so it takes the whole frame as its ceiling -- the one place that actually matters:
+    // a narrow compact terminal, where every row the border+footer would otherwise leave
+    // idle buys another binding into view.
+    let bounds = Rect::new(0, 0, geo.row_width, geo.height);
+    let capacity = bounds
+        .height
+        .saturating_sub(modal_chrome_rows(geo.tier, true));
+    // Never scrolls -- there is no selection to seek with, and closing on any key rules
+    // out a dedicated scroll chord -- so `▼` here means "more exists" (resize to see it),
+    // not "more is reachable".
+    let title = titled_with_scroll_marker("help", false, (shown.len() as u16) > capacity);
+    let content = paint_modal_card(
+        frame,
+        geo,
+        bounds,
+        ModalCardSpec {
+            title: &title,
+            content_rows: shown.len() as u16,
+            legend: HELP_FOOTER,
+            dismiss: Some(QueueHitTarget::HelpDismiss),
+        },
+        hits,
+    );
+    // The card's blanket `ModalChrome` (pushed for the whole card, border included) would
+    // otherwise make the body text itself inert too. Help's body is not an interactive
+    // surface like the palette's command rows or the picker's options -- there is nothing
+    // to select inside it -- so it keeps mouse parity with the keyboard's "any key" by
+    // reclaiming its own content rect as a `HelpDismiss` hit, the same close its own `[x]`
+    // and the frame outside the card already resolve to.
+    hits.push(QueueHitTarget::HelpDismiss, content);
+    for (j, ln) in shown.iter().take(content.height as usize).enumerate() {
+        let y = content.y.saturating_add(j as u16);
+        let rect = Rect::new(content.x, y, content.width, 1);
+        put_line_at(
+            frame,
+            rect,
+            paint_bounded_line(ln, content.width, style_plain()),
+        );
+        hits.push_copyable(rect);
     }
 }
 
@@ -1874,32 +2111,32 @@ fn paint_page_scope_dropdown(
     }
 }
 
+/// The board's `P` project-scope picker: a centered modal card, not the chip-anchored
+/// dropdown this used to paint. [`paint_page_scope_dropdown`] (the task-page form's own
+/// scope control) is a separate, unrelated painter and keeps its chip-anchored panel.
 fn paint_scope_dropdown(
     frame: &mut Frame<'_>,
     geo: &TierGeometry,
     options: &[String],
     selected: usize,
-    option_target: impl Fn(usize) -> QueueHitTarget,
     hits: &mut QueueHitMap,
 ) {
-    let width = geo.row_width;
-    if width == 0 || options.is_empty() {
+    if geo.row_width == 0 || options.is_empty() {
         return;
     }
-    // Align under the project chip on the right of the selector row.
-    let max_label = options
-        .iter()
-        .map(|o| display_width(o))
-        .max()
-        .unwrap_or(0)
-        .max(display_width("projects"));
-    let col_w = (max_label + 4).min(geo.selector_chip_max as usize).max(8);
-    let x0 = width.saturating_sub(col_w as u16);
-    let top = geo.selector_row.map(|r| r.saturating_add(1)).unwrap_or(0);
+    // Help/project-scope have nothing worth preserving underneath (no query row like the
+    // palette), so the full frame is the ceiling: a narrow compact terminal gets every row
+    // the border+footer would otherwise leave idle.
+    let bounds = Rect::new(0, 0, geo.row_width, geo.height);
+    // Derived from the same chrome math `paint_modal_card` itself uses (see the palette's
+    // identical comment) so the window this picks always matches what actually paints.
+    let capacity = bounds
+        .height
+        .saturating_sub(modal_chrome_rows(geo.tier, true));
     let max_n = if geo.tier == Tier::Compact {
-        geo.viewport_height.max(1) as usize
+        capacity.max(1) as usize
     } else {
-        options.len().min(12)
+        options.len().min(12).min(capacity.max(1) as usize)
     };
     let rows = max_n.min(options.len());
     let selected = selected.min(options.len().saturating_sub(1));
@@ -1908,36 +2145,41 @@ fn paint_scope_dropdown(
     } else {
         (selected + 1 - rows).min(options.len() - rows)
     };
-    let panel_h = rows.min((geo.height.saturating_sub(top).saturating_sub(2)) as usize) as u16;
-    if panel_h > 0 {
-        frame.render_widget(Clear, Rect::new(x0, top, col_w as u16, panel_h));
+    let above = scroll > 0;
+    let below = scroll + rows < options.len();
+    let title = titled_with_scroll_marker("project", above, below);
+
+    let content = paint_modal_card(
+        frame,
+        geo,
+        bounds,
+        ModalCardSpec {
+            title: &title,
+            content_rows: rows as u16,
+            legend: SCOPE_FOOTER,
+            dismiss: None,
+        },
+        hits,
+    );
+    if content.width == 0 || content.height == 0 {
+        return;
     }
-    for (j, opt) in options.iter().enumerate().skip(scroll).take(rows) {
-        let y = top.saturating_add((j - scroll) as u16);
-        if y >= geo.height.saturating_sub(2) {
-            break;
-        }
+    let paintable = rows.min(content.height as usize);
+    for (j, opt) in options.iter().enumerate().skip(scroll).take(paintable) {
+        let y = content.y.saturating_add((j - scroll) as u16);
         let marker = if j == selected { "▸ " } else { "  " };
-        let body = present_line(&format!("{marker}{opt}"), col_w);
-        // Pad to col_w so the dropdown cell fully overwrites base row content under it.
-        let w = col_w;
-        let text = if display_width(&body) >= w {
-            body
-        } else {
-            format!("{}{}", body, " ".repeat(w - display_width(&body)))
-        };
+        let text = format!("{marker}{opt}");
         let style = if j == selected {
             style_reverse()
         } else {
             style_plain()
         };
-        // Paint only the right-hand chip column.
-        let area = Rect::new(x0, y, col_w as u16, 1);
-        frame.render_widget(Paragraph::new(Line::from(Span::styled(text, style))), area);
+        let rect = Rect::new(content.x, y, content.width, 1);
+        put_line_at(frame, rect, paint_bounded_line(&text, content.width, style));
         // `j` remains the source index after windowing, so a click selects the same option
         // Up/Down plus Enter would confirm rather than its position within this paint slice.
-        hits.push(option_target(j), area);
-        hits.push_copyable(area);
+        hits.push(QueueHitTarget::ProjectOption(j), rect);
+        hits.push_copyable(rect);
     }
 }
 
@@ -2731,22 +2973,25 @@ pub(crate) fn short_project(path: &str) -> &str {
 }
 
 fn put_line(frame: &mut Frame<'_>, row: u16, width: u16, line: Line<'static>) {
-    if width == 0 {
+    put_line_at(frame, Rect::new(0, row, width, 1), line);
+}
+
+/// Paint `line` at an arbitrary single-row `rect`, padding with plain spaces to `rect.width`
+/// so whatever the base frame painted underneath cannot bleed through a short line.
+fn put_line_at(frame: &mut Frame<'_>, rect: Rect, line: Line<'static>) {
+    if rect.width == 0 {
         return;
     }
-    let w = width as usize;
-    let area = Rect::new(0, row, width, 1);
+    let w = rect.width as usize;
     if line.width() >= w {
-        frame.render_widget(Paragraph::new(line), area);
+        frame.render_widget(Paragraph::new(line), rect);
         return;
     }
-    // Pad to full row width with plain spaces so base frame content cannot bleed through
-    // (overlays paint short content; trailing cells must be overwritten).
     let pad = w - line.width();
     let mut spans: Vec<Span<'static>> = line.spans.into_iter().collect();
     spans.push(Span::styled(" ".repeat(pad), style_plain()));
     let padded = Line::from(spans);
-    frame.render_widget(Paragraph::new(padded), area);
+    frame.render_widget(Paragraph::new(padded), rect);
 }
 
 pub(crate) fn display_width(s: &str) -> usize {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -566,12 +566,24 @@ pub struct QueueHit {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct QueueHitMap {
     pub regions: Vec<QueueHit>,
+    /// Rects the painters declared as copyable content (task rows, page title,
+    /// notes, steps, drawer body, options). Text selection copies only cells
+    /// inside these, so chrome — scrollbars, borders, verb bars, dividers — is
+    /// excluded by construction.
+    pub copyable: Vec<Rect>,
 }
 
 impl QueueHitMap {
     fn push(&mut self, target: QueueHitTarget, area: Rect) {
         if area.width > 0 && area.height > 0 {
             self.regions.push(QueueHit { target, area });
+        }
+    }
+
+    /// Declare a rect as copyable content, beside the paint that drew it.
+    pub fn push_copyable(&mut self, area: Rect) {
+        if area.width > 0 && area.height > 0 {
+            self.copyable.push(area);
         }
     }
 }
@@ -695,8 +707,13 @@ pub fn draw_queue_frame(
                     if base_list_interactive {
                         hits.push(QueueHitTarget::Task(id), Rect::new(0, y, width, 1));
                     }
+                    // Task title text is a hit target, but exactly what a text selection is for.
+                    hits.push_copyable(Rect::new(0, y, width, 1));
                 }
-                ListRow::Detail(line) => put_line(frame, y, width, line),
+                ListRow::Detail(line) => {
+                    put_line(frame, y, width, line);
+                    hits.push_copyable(Rect::new(0, y, width, 1));
+                }
             }
         }
     }
@@ -1277,6 +1294,7 @@ fn paint_palette_overlay(
                 QueueHitTarget::Command(scroll + j),
                 Rect::new(0, y, width, 1),
             );
+            hits.push_copyable(Rect::new(0, y, width, 1));
         }
     }
     let q = format!(" :{query}");
@@ -1354,6 +1372,8 @@ fn paint_help_overlay(
             let style = if j == 0 { style_bold() } else { style_plain() };
             put_line(frame, y, width, paint_bounded_line(&padded, width, style));
         }
+        // Body lines only — not the full-frame dismiss chrome.
+        hits.push_copyable(Rect::new(x_pad, y, body_w as u16, 1));
     }
 }
 
@@ -1586,6 +1606,7 @@ fn paint_task_page(
         QueueHitTarget::FormTitle,
         Rect::new(0, lay.title_y, width, title_row_count),
     );
+    hits.push_copyable(Rect::new(0, lay.title_y, header_width, title_row_count));
     if let Some((cursor_row, cursor_col)) = title_cursor {
         // Every title row shares the four-cell gutter (two leading blanks plus
         // glyph and space), so the wrapped field starts at column 4 on all of them.
@@ -1668,6 +1689,7 @@ fn paint_task_page(
                 QueueHitTarget::FormNotes(absolute),
                 Rect::new(0, y, content_width, 1),
             );
+            hits.push_copyable(Rect::new(0, y, content_width, 1));
         } else if !step_views.is_empty() && absolute == content.steps_start {
             put_line(
                 frame,
@@ -1708,6 +1730,7 @@ fn paint_task_page(
                     QueueHitTarget::Step(index),
                     Rect::new(0, y, content_width, 1),
                 );
+                hits.push_copyable(Rect::new(0, y, content_width, 1));
             }
         }
     }
@@ -1847,6 +1870,7 @@ fn paint_page_scope_dropdown(
             QueueHitTarget::FormScopeOption(j),
             Rect::new(0, y, width, 1),
         );
+        hits.push_copyable(Rect::new(0, y, width, 1));
     }
 }
 
@@ -1913,6 +1937,7 @@ fn paint_scope_dropdown(
         // `j` remains the source index after windowing, so a click selects the same option
         // Up/Down plus Enter would confirm rather than its position within this paint slice.
         hits.push(option_target(j), area);
+        hits.push_copyable(area);
     }
 }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -104,6 +104,16 @@ pub struct TaskRowPaint<'a> {
     pub title_bold: bool,
 }
 
+/// One painted task-row line plus the title-content cells a text selection may copy.
+///
+/// `content_x` / `content_width` skip the leading indent, status glyph, and (on the
+/// first line) the right-aligned meta column — chrome the clipboard must not see.
+pub struct TaskRowLine {
+    pub line: Line<'static>,
+    pub content_x: u16,
+    pub content_width: u16,
+}
+
 /// Paint one task as ONE OR MORE list lines: the first is the classic glyph + title +
 /// right-aligned meta row; a title too wide for its budget wraps at word boundaries onto
 /// continuation lines indented into its own column, with no meta. Nothing is cut.
@@ -111,7 +121,7 @@ pub fn paint_task_row_lines(
     row: &TaskRowPaint<'_>,
     geo: &TierGeometry,
     leading_indent: usize,
-) -> Vec<Line<'static>> {
+) -> Vec<TaskRowLine> {
     // The title room `paint_task_row_with_indent` derives must match here, so both
     // share one computation of the prefix cells.
     let row_w = geo.row_width as usize;
@@ -124,6 +134,8 @@ pub fn paint_task_row_lines(
     let glyph_cells = display_width(&super::terminal_text(row.glyph));
     let prefix_cells = leading_indent + 2 + glyph_cells + 1;
     let room = title_budget.saturating_sub(prefix_cells).max(1);
+    let content_x = u16::try_from(prefix_cells).unwrap_or(u16::MAX);
+    let content_width = u16::try_from(room).unwrap_or(1).max(1);
     let segments: Vec<String> = crate::ui::edit::wrap_text(row.title, room)
         .into_iter()
         .map(|wrapped| wrapped.text)
@@ -135,7 +147,11 @@ pub fn paint_task_row_lines(
         title: &segments[0],
         ..*row
     };
-    lines.push(paint_task_row_with_indent(&head, geo, leading_indent));
+    lines.push(TaskRowLine {
+        line: paint_task_row_with_indent(&head, geo, leading_indent),
+        content_x,
+        content_width,
+    });
     // Continuations indent into the title column (past glyph and space).
     let indent = " ".repeat(prefix_cells);
     let continuation_style = if row.selected {
@@ -144,13 +160,17 @@ pub fn paint_task_row_lines(
         style_plain()
     };
     for segment in segments.iter().skip(1) {
-        lines.push(bound_line(
-            Line::from(Span::styled(
-                format!("{indent}{segment}"),
-                continuation_style,
-            )),
-            row_w,
-        ));
+        lines.push(TaskRowLine {
+            line: bound_line(
+                Line::from(Span::styled(
+                    format!("{indent}{segment}"),
+                    continuation_style,
+                )),
+                row_w,
+            ),
+            content_x,
+            content_width,
+        });
     }
     lines
 }
@@ -713,17 +733,27 @@ pub fn draw_queue_frame(
                 ListRow::Hint(line) | ListRow::ThreadHeader(line) => {
                     put_line(frame, y, width, line)
                 }
-                ListRow::Task { id, line } => {
+                ListRow::Task {
+                    id,
+                    line,
+                    content_x,
+                    content_width,
+                } => {
                     put_line(frame, y, width, line);
                     if base_list_interactive {
                         hits.push(QueueHitTarget::Task(id), Rect::new(0, y, width, 1));
                     }
-                    // Task title text is a hit target, but exactly what a text selection is for.
-                    hits.push_copyable(Rect::new(0, y, width, 1));
+                    // Title text only: indent, glyph, and right-side meta stay out of the copy.
+                    hits.push_copyable(Rect::new(content_x, y, content_width, 1));
                 }
-                ListRow::Detail(line) => {
+                ListRow::Detail {
+                    line,
+                    content_x,
+                    content_width,
+                } => {
                     put_line(frame, y, width, line);
-                    hits.push_copyable(Rect::new(0, y, width, 1));
+                    // Peek body past the `│` gutter — the pipe is chrome, not notes.
+                    hits.push_copyable(Rect::new(content_x, y, content_width, 1));
                 }
             }
         }
@@ -1843,7 +1873,14 @@ fn paint_task_page(
         QueueHitTarget::FormTitle,
         Rect::new(0, lay.title_y, width, title_row_count),
     );
-    hits.push_copyable(Rect::new(0, lay.title_y, header_width, title_row_count));
+    // Title words only: two-cell gutter on the left; status word on the first row is
+    // outside this rect because it sits past the title columns in the paint.
+    hits.push_copyable(Rect::new(
+        2,
+        lay.title_y,
+        header_width.saturating_sub(2),
+        title_row_count,
+    ));
     if let Some((cursor_row, cursor_col)) = title_cursor {
         // Every title row shares the four-cell gutter (two leading blanks plus
         // glyph and space), so the wrapped field starts at column 4 on all of them.
@@ -1926,7 +1963,8 @@ fn paint_task_page(
                 QueueHitTarget::FormNotes(absolute),
                 Rect::new(0, y, content_width, 1),
             );
-            hits.push_copyable(Rect::new(0, y, content_width, 1));
+            // Notes body past the two-cell gutter (and the trailing pad space).
+            hits.push_copyable(Rect::new(2, y, content_width.saturating_sub(3), 1));
         } else if !step_views.is_empty() && absolute == content.steps_start {
             put_line(
                 frame,
@@ -1967,7 +2005,14 @@ fn paint_task_page(
                     QueueHitTarget::Step(index),
                     Rect::new(0, y, content_width, 1),
                 );
-                hits.push_copyable(Rect::new(0, y, content_width, 1));
+                // Step text past `▸ `/`  ` + glyph + space; trailing pad stays out.
+                let step_prefix = 2u16 + display_width(glyph) as u16 + 1;
+                hits.push_copyable(Rect::new(
+                    step_prefix,
+                    y,
+                    content_width.saturating_sub(step_prefix).saturating_sub(1),
+                    1,
+                ));
             }
         }
     }
@@ -2209,9 +2254,18 @@ enum ListRow {
     Task {
         id: Uuid,
         line: Line<'static>,
+        /// First column of the title text (past indent + glyph).
+        content_x: u16,
+        /// Title-zone width (excludes right-aligned meta).
+        content_width: u16,
     },
     /// Read-only accordion content under a task, full-width and un-hit-tested.
-    Detail(Line<'static>),
+    Detail {
+        line: Line<'static>,
+        /// First column past the peek `│` gutter.
+        content_x: u16,
+        content_width: u16,
+    },
 }
 
 /// Read-only accordion body under an expanded task: notes preview,
@@ -2222,16 +2276,27 @@ enum ListRow {
 /// on the task page.
 const PEEK_NOTES_LINE_LIMIT: usize = 5;
 
-fn detail_lines_for_task(task: &Task, now: SystemTime, width: u16) -> Vec<Line<'static>> {
-    let indent = "    │ ";
-    let mut lines: Vec<Line<'static>> = Vec::new();
+/// Peek accordion gutter (`    │ `). Copyable content starts after these cells.
+const PEEK_DETAIL_INDENT: &str = "    │ ";
+
+fn detail_lines_for_task(
+    task: &Task,
+    now: SystemTime,
+    width: u16,
+) -> Vec<(Line<'static>, u16, u16)> {
+    let indent = PEEK_DETAIL_INDENT;
+    let content_x = u16::try_from(display_width(indent)).unwrap_or(0);
+    let content_width = width.saturating_sub(content_x);
+    let mut lines: Vec<(Line<'static>, u16, u16)> = Vec::new();
+    let push = |lines: &mut Vec<(Line<'static>, u16, u16)>, line: Line<'static>| {
+        lines.push((line, content_x, content_width));
+    };
     let notes_text = task.notes.as_deref().map(str::trim).unwrap_or_default();
     if notes_text.is_empty() {
-        lines.push(paint_bounded_line(
-            &format!("{indent}no notes yet"),
-            width,
-            style_dim(),
-        ));
+        push(
+            &mut lines,
+            paint_bounded_line(&format!("{indent}no notes yet"), width, style_dim()),
+        );
     } else {
         // Preview rows wrap at word boundaries like every other note surface, so
         // a long line continues under itself instead of being cut at the edge.
@@ -2240,30 +2305,31 @@ fn detail_lines_for_task(task: &Task, now: SystemTime, width: u16) -> Vec<Line<'
         let mut remaining = 0usize;
         for note_row in crate::ui::edit::wrap_text(notes_text, room) {
             if shown < PEEK_NOTES_LINE_LIMIT {
-                lines.push(paint_bounded_line(
-                    &format!("{indent}{}", note_row.text),
-                    width,
-                    style_dim(),
-                ));
+                push(
+                    &mut lines,
+                    paint_bounded_line(&format!("{indent}{}", note_row.text), width, style_dim()),
+                );
                 shown += 1;
             } else {
                 remaining += 1;
             }
         }
         if remaining > 0 {
-            lines.push(paint_bounded_line(
-                &format!("{indent}… {remaining} more lines"),
-                width,
-                style_dim(),
-            ));
+            push(
+                &mut lines,
+                paint_bounded_line(
+                    &format!("{indent}… {remaining} more lines"),
+                    width,
+                    style_dim(),
+                ),
+            );
         }
     }
     if let Some(thread) = task.thread.as_deref() {
-        lines.push(paint_bounded_line(
-            &format!("{indent}thread #{thread}"),
-            width,
-            style_dim(),
-        ));
+        push(
+            &mut lines,
+            paint_bounded_line(&format!("{indent}thread #{thread}"), width, style_dim()),
+        );
     }
     let scope_text = match &task.scope {
         TaskScope::Project { path } => short_project(path).to_string(),
@@ -2274,16 +2340,14 @@ fn detail_lines_for_task(task: &Task, now: SystemTime, width: u16) -> Vec<Line<'
         format_age(now, task.created_at),
         format_age(now, task.updated_at)
     );
-    lines.push(paint_bounded_line(
-        &format!("{indent}scope {scope_text}"),
-        width,
-        style_dim(),
-    ));
-    lines.push(paint_bounded_line(
-        &format!("{indent}{age_text}"),
-        width,
-        style_dim(),
-    ));
+    push(
+        &mut lines,
+        paint_bounded_line(&format!("{indent}scope {scope_text}"), width, style_dim()),
+    );
+    push(
+        &mut lines,
+        paint_bounded_line(&format!("{indent}{age_text}"), width, style_dim()),
+    );
     lines
 }
 
@@ -2337,8 +2401,13 @@ fn build_list_rows(
         if selected {
             *selected_idx = Some(out.len());
         }
-        for line in lines {
-            out.push(ListRow::Task { id: task.id, line });
+        for painted in lines {
+            out.push(ListRow::Task {
+                id: task.id,
+                line: painted.line,
+                content_x: painted.content_x,
+                content_width: painted.content_width,
+            });
         }
         if selected {
             // Selection follow anchors the whole block, so a two-line selection
@@ -2346,8 +2415,14 @@ fn build_list_rows(
             *selected_idx = Some(out.len() - 1);
         }
         if detail_target == Some(task.id) {
-            for line in detail_lines_for_task(task, model.now, geo.row_width) {
-                out.push(ListRow::Detail(line));
+            for (line, content_x, content_width) in
+                detail_lines_for_task(task, model.now, geo.row_width)
+            {
+                out.push(ListRow::Detail {
+                    line,
+                    content_x,
+                    content_width,
+                });
             }
             *anchor_last_idx = Some(out.len() - 1);
         }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1336,8 +1336,12 @@ fn paint_modal_card(
             modal_plain_border_row('└', '─', '┘', card_w),
         );
     }
-    if !legend.is_empty() {
-        let rule_offset = bottom_offset.saturating_sub(2);
+    let rule_offset = if !legend.is_empty() {
+        Some(bottom_offset.saturating_sub(2))
+    } else {
+        None
+    };
+    if let Some(rule_offset) = rule_offset {
         let legend_offset = bottom_offset.saturating_sub(1);
         paint_row_in(
             frame,
@@ -1353,12 +1357,37 @@ fn paint_modal_card(
         );
     }
 
+    // Side borders for every middle row that is not already a full `├─┤` / top / bottom
+    // rule. Content, padding, and the legend line only had corners before — the box
+    // looked open on the left and right.
+    for row_offset in 1..bottom_offset {
+        if rule_offset == Some(row_offset) {
+            continue;
+        }
+        paint_modal_side_borders(frame, area, row_offset);
+    }
+
     Rect::new(
         x0.saturating_add(1 + pad),
         y0.saturating_add(1 + pad),
         card_w.saturating_sub(2 + 2 * pad),
         shown_content,
     )
+}
+
+/// Dim `│` on the left and right edges of one card row (content / padding / legend).
+fn paint_modal_side_borders(frame: &mut Frame<'_>, area: Rect, row_offset: u16) {
+    if row_offset >= area.height || area.width == 0 {
+        return;
+    }
+    let y = area.y.saturating_add(row_offset);
+    let style = style_dim();
+    let buffer = frame.buffer_mut();
+    buffer[(area.x, y)].set_symbol("│").set_style(style);
+    if area.width > 1 {
+        let right = area.x.saturating_add(area.width.saturating_sub(1));
+        buffer[(right, y)].set_symbol("│").set_style(style);
+    }
 }
 
 /// One row of a modal card's border/legend, painted at `area`'s `row_offset`-th row
@@ -1863,9 +1892,30 @@ fn paint_task_page(
                 line.spans
                     .push(Span::styled(status_word.to_string(), style_dim()));
             }
+            // `  {glyph} {title}` — title words start at column 4; the glyph and the
+            // right-aligned status word are chrome and stay out of the copy.
+            let title_cells = used.saturating_sub(4);
+            if title_cells > 0 {
+                hits.push_copyable(Rect::new(
+                    4,
+                    y,
+                    u16::try_from(title_cells).unwrap_or(u16::MAX),
+                    1,
+                ));
+            }
             line
         } else {
-            Line::from(Span::styled(format!("    {row_text}"), style_bold()))
+            let painted = format!("    {row_text}");
+            let title_cells = display_width(&painted).saturating_sub(4);
+            if title_cells > 0 {
+                hits.push_copyable(Rect::new(
+                    4,
+                    y,
+                    u16::try_from(title_cells).unwrap_or(u16::MAX),
+                    1,
+                ));
+            }
+            Line::from(Span::styled(painted, style_bold()))
         };
         put_line(frame, y, header_width, line);
     }
@@ -1873,14 +1923,6 @@ fn paint_task_page(
         QueueHitTarget::FormTitle,
         Rect::new(0, lay.title_y, width, title_row_count),
     );
-    // Title words only: two-cell gutter on the left; status word on the first row is
-    // outside this rect because it sits past the title columns in the paint.
-    hits.push_copyable(Rect::new(
-        2,
-        lay.title_y,
-        header_width.saturating_sub(2),
-        title_row_count,
-    ));
     if let Some((cursor_row, cursor_col)) = title_cursor {
         // Every title row shares the four-cell gutter (two leading blanks plus
         // glyph and space), so the wrapped field starts at column 4 on all of them.

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -25,6 +25,83 @@ use ratatui::style::Modifier;
 use ratatui::Frame;
 use unicode_width::UnicodeWidthChar;
 
+/// Left-button press → drag → release for board text selection.
+///
+/// Clicks are deferred until release so a real drag can copy without also firing
+/// the Down-time peek/select path. Extracted from `run_board` so the transition
+/// table is unit-testable without a live event loop.
+#[derive(Debug, Default, Clone)]
+pub struct DragSelectGesture {
+    /// Down cell while a deferred click is still armed (`None` once a drag has area).
+    pending_down: Option<Position>,
+}
+
+/// One phase of [`DragSelectGesture::handle`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DragSelectPhase {
+    Press,
+    Move,
+    Release,
+}
+
+/// What `run_board` should do after feeding a left-button phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DragSelectOutcome {
+    /// Event consumed; do not dispatch a board click.
+    Continue,
+    /// Selection has area — copy from the painted frame snapshot.
+    Copy,
+    /// Bare click — dispatch at the original Down cell.
+    Click(Position),
+}
+
+impl DragSelectGesture {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Abandon a deferred click (e.g. a key pressed while the button is held).
+    pub fn clear(&mut self) {
+        self.pending_down = None;
+    }
+
+    /// Feed one left-button phase.
+    ///
+    /// For `Press` / `Move`, `selection` is the model selection *after* the caller
+    /// applied `begin_mouse_press` / `drag_text_selection`. For `Release`, it is the
+    /// selection after synthesizing a final drag from the release cell when the host
+    /// omitted intermediate Drag events.
+    pub fn handle(
+        &mut self,
+        phase: DragSelectPhase,
+        position: Position,
+        selection: Option<TextSelection>,
+    ) -> DragSelectOutcome {
+        match phase {
+            DragSelectPhase::Press => {
+                self.pending_down = Some(position);
+                DragSelectOutcome::Continue
+            }
+            DragSelectPhase::Move => {
+                if selection.is_some_and(|sel| sel.has_area()) {
+                    self.pending_down = None;
+                }
+                DragSelectOutcome::Continue
+            }
+            DragSelectPhase::Release => {
+                if selection.is_some_and(|sel| sel.has_area()) {
+                    self.pending_down = None;
+                    DragSelectOutcome::Copy
+                } else if let Some(down) = self.pending_down.take() {
+                    DragSelectOutcome::Click(down)
+                } else {
+                    DragSelectOutcome::Continue
+                }
+            }
+        }
+    }
+}
+
 /// A drag-selected screen region: where the press landed and where the drag sits.
 ///
 /// `anchor` is the press cell, `head` the latest drag cell; either may end up
@@ -51,9 +128,15 @@ impl TextSelection {
         }
     }
 
-    /// Whether the drag has actually covered cells (a bare click is no selection).
+    /// Whether the drag has covered enough cells to count as a selection.
+    ///
+    /// A single-cell wobble (`anchor` adjacent to `head`) stays a click: hosts often
+    /// deliver one pixel of motion between Down and Up. Chebyshev distance ≥ 2
+    /// (two steps in any direction, including diagonal) is the copy threshold.
     pub fn has_area(&self) -> bool {
-        self.anchor != self.head
+        let dx = self.anchor.x.abs_diff(self.head.x);
+        let dy = self.anchor.y.abs_diff(self.head.y);
+        dx.max(dy) >= 2
     }
 }
 
@@ -403,6 +486,63 @@ mod tests {
     }
 
     #[test]
+    fn one_cell_wobble_is_not_a_selection() {
+        assert!(!TextSelection::new(pos(5, 5), pos(5, 5)).has_area());
+        assert!(!TextSelection::new(pos(5, 5), pos(6, 5)).has_area());
+        assert!(!TextSelection::new(pos(5, 5), pos(5, 6)).has_area());
+        assert!(!TextSelection::new(pos(5, 5), pos(6, 6)).has_area());
+        assert!(TextSelection::new(pos(5, 5), pos(7, 5)).has_area());
+        assert!(TextSelection::new(pos(5, 5), pos(5, 7)).has_area());
+    }
+
+    #[test]
+    fn drag_select_gesture_defers_click_until_real_drag_or_release() {
+        let mut g = DragSelectGesture::new();
+        let down = pos(3, 4);
+        assert_eq!(
+            g.handle(DragSelectPhase::Press, down, None),
+            DragSelectOutcome::Continue
+        );
+        // One-cell wobble: still a click.
+        let wobble = TextSelection::new(down, pos(4, 4));
+        assert_eq!(
+            g.handle(DragSelectPhase::Move, pos(4, 4), Some(wobble)),
+            DragSelectOutcome::Continue
+        );
+        assert_eq!(
+            g.handle(DragSelectPhase::Release, pos(4, 4), Some(wobble)),
+            DragSelectOutcome::Click(down)
+        );
+
+        let mut g = DragSelectGesture::new();
+        assert_eq!(
+            g.handle(DragSelectPhase::Press, down, None),
+            DragSelectOutcome::Continue
+        );
+        let drag = TextSelection::new(down, pos(8, 4));
+        assert_eq!(
+            g.handle(DragSelectPhase::Move, pos(8, 4), Some(drag)),
+            DragSelectOutcome::Continue
+        );
+        assert_eq!(
+            g.handle(DragSelectPhase::Release, pos(8, 4), Some(drag)),
+            DragSelectOutcome::Copy
+        );
+
+        let mut g = DragSelectGesture::new();
+        let _ = g.handle(DragSelectPhase::Press, down, None);
+        g.clear();
+        assert_eq!(
+            g.handle(
+                DragSelectPhase::Release,
+                down,
+                Some(TextSelection::new(down, down))
+            ),
+            DragSelectOutcome::Continue
+        );
+    }
+
+    #[test]
     fn paint_selection_stays_inside_copyable_not_gutter() {
         use ratatui::backend::TestBackend;
         use ratatui::style::Modifier;
@@ -477,11 +617,11 @@ mod tests {
             selection_text(&rows, &copyable, &sel).as_deref(),
             Some("abcd")
         );
-        // Partial inclusive end.
-        let sel = TextSelection::new(pos(1, 0), pos(2, 0));
+        // Partial inclusive end (two cells apart so it clears the wobble threshold).
+        let sel = TextSelection::new(pos(0, 0), pos(2, 0));
         assert_eq!(
             selection_text(&rows, &copyable, &sel).as_deref(),
-            Some("bc")
+            Some("abc")
         );
     }
 }

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -177,8 +177,13 @@ fn slice_cells(row: &str, start: u16, end: u16) -> String {
     out
 }
 
-/// Reverse-highlight every cell the selection covers (line-oriented, matching copy).
-pub fn paint_selection(frame: &mut Frame<'_>, selection: &TextSelection) {
+/// Reverse-highlight the cells a selection covers, clipped to `copyable`.
+///
+/// Geometry matches [`selection_text`]: first/last rows use the drag edges, interior
+/// rows span their copyable columns. Chrome outside those rects (peek `│` gutter,
+/// glyphs, meta) stays unhighlighted — the same content bounds grok-build-style
+/// app selection uses, rather than painting full terminal rows.
+pub fn paint_selection(frame: &mut Frame<'_>, selection: &TextSelection, copyable: &[Rect]) {
     if !selection.has_area() {
         return;
     }
@@ -190,18 +195,18 @@ pub fn paint_selection(frame: &mut Frame<'_>, selection: &TextSelection) {
             break;
         }
         let start = if y == y0 { x0 } else { 0 };
-        let end = if y == y1 {
-            x1
-        } else {
-            area.width.saturating_sub(1)
-        };
-        for x in start..=end {
-            if x >= area.width {
-                break;
+        let end = if y == y1 { x1 } else { u16::MAX };
+        for (span_start, span_end) in copyable_spans(copyable, y) {
+            let from = span_start.max(start);
+            let to = span_end.min(end).min(area.width.saturating_sub(1));
+            if from > to {
+                continue;
             }
-            let cell = &mut buffer[(x, y)];
-            let style = cell.style().add_modifier(Modifier::REVERSED);
-            cell.set_style(style);
+            for x in from..=to {
+                let cell = &mut buffer[(x, y)];
+                let style = cell.style().add_modifier(Modifier::REVERSED);
+                cell.set_style(style);
+            }
         }
     }
 }
@@ -395,6 +400,45 @@ mod tests {
         // A drag that only covers the blank middle yields nothing.
         let sel = TextSelection::new(pos(0, 1), pos(5, 1));
         assert_eq!(selection_text(&rows, &copyable, &sel).as_deref(), None);
+    }
+
+    #[test]
+    fn paint_selection_stays_inside_copyable_not_gutter() {
+        use ratatui::backend::TestBackend;
+        use ratatui::style::Modifier;
+        use ratatui::Terminal;
+
+        // Peek-shaped layout: columns 0..5 are `    │ ` chrome; content starts at 6.
+        let copyable = [Rect::new(6, 0, 14, 3)];
+        let sel = TextSelection::new(pos(8, 0), pos(12, 2));
+        let mut terminal = Terminal::new(TestBackend::new(20, 4)).expect("terminal");
+        terminal
+            .draw(|frame| {
+                paint_selection(frame, &sel, &copyable);
+            })
+            .expect("draw");
+        let buffer = terminal.backend().buffer();
+        for y in 0..=2 {
+            for x in 0..6 {
+                assert!(
+                    !buffer[(x, y)].modifier.contains(Modifier::REVERSED),
+                    "gutter cell ({x},{y}) must not reverse-highlight"
+                );
+            }
+        }
+        // Interior row: full copyable span is highlighted (line-oriented within content).
+        for x in 6..=19 {
+            assert!(
+                buffer[(x, 1)].modifier.contains(Modifier::REVERSED),
+                "content cell ({x},1) should reverse-highlight"
+            );
+        }
+        // First row: only from drag start (8) through copyable end.
+        assert!(!buffer[(6, 0)].modifier.contains(Modifier::REVERSED));
+        assert!(buffer[(8, 0)].modifier.contains(Modifier::REVERSED));
+        // Last row: only through drag end (12).
+        assert!(buffer[(12, 2)].modifier.contains(Modifier::REVERSED));
+        assert!(!buffer[(13, 2)].modifier.contains(Modifier::REVERSED));
     }
 
     #[test]

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -1,0 +1,443 @@
+//! Mouse text selection over the painted frame, and its clipboard bridge.
+//!
+//! The board captures the mouse (clicks peek rows, drags were dead weight), so
+//! native terminal selection is unavailable while tsk runs. This module gives that
+//! dead weight a job: a left-button drag marks a screen region, the frame's painted
+//! cells inside that region are the copied text ("copy what you see"), and release
+//! hands the text to the system clipboard through the OSC 52 escape sequence. No
+//! clipboard crate: the terminal (or the host multiplexer) performs the copy,
+//! exactly as it would for a native selection.
+//!
+//! What counts as copyable is declared by the painters, not inferred: every
+//! surface pushes its content rects into `QueueHitMap::copyable` beside the paint
+//! (task rows, page title, notes, steps, drawer body, options). Selection text is
+//! the intersection of the drag region with those rects, so chrome (scrollbars,
+//! borders, verb bars, dividers) is excluded by construction instead of by
+//! pattern-matching glyphs after the fact. The selection is still purely
+//! geometric: screen cells, not document ranges, re-read from the last painted
+//! frame at copy time.
+
+use std::io::{self, Write};
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Position, Rect};
+use ratatui::style::Modifier;
+use ratatui::Frame;
+use unicode_width::UnicodeWidthChar;
+
+/// A drag-selected screen region: where the press landed and where the drag sits.
+///
+/// `anchor` is the press cell, `head` the latest drag cell; either may end up
+/// visually first. Both are frame cells (column, row), not document offsets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextSelection {
+    pub anchor: Position,
+    pub head: Position,
+}
+
+impl TextSelection {
+    pub fn new(anchor: Position, head: Position) -> Self {
+        Self { anchor, head }
+    }
+
+    /// The region ordered so it can be walked top-left to bottom-right.
+    pub fn normalized(&self) -> (u16, u16, u16, u16) {
+        let (ax, ay) = (self.anchor.x, self.anchor.y);
+        let (hx, hy) = (self.head.x, self.head.y);
+        if (ay, ax) <= (hy, hx) {
+            (ax, ay, hx, hy)
+        } else {
+            (hx, hy, ax, ay)
+        }
+    }
+
+    /// Whether the drag has actually covered cells (a bare click is no selection).
+    pub fn has_area(&self) -> bool {
+        self.anchor != self.head
+    }
+}
+
+/// The painted frame's text, one `String` per row, cells concatenated in order.
+///
+/// Empty cells read as spaces, so padded chrome rows reconstruct exactly as
+/// painted; this snapshot is what [`selection_text`] slices at copy time.
+pub fn frame_text_rows(buffer: &Buffer) -> Vec<String> {
+    let width = buffer.area.width as usize;
+    let height = buffer.area.height as usize;
+    let mut rows = Vec::with_capacity(height);
+    for y in 0..height {
+        let mut row = String::with_capacity(width);
+        for x in 0..width {
+            // Default cells are already `" "`; wide-glyph continuations leave an
+            // empty symbol and must not invent a column or unicode-width walks
+            // drift from the buffer.
+            row.push_str(buffer[(x as u16, y as u16)].symbol());
+        }
+        rows.push(row);
+    }
+    rows
+}
+
+/// The text a selection covers, taken from the frame snapshot.
+///
+/// Each covered row contributes its cells between the selection edges (the first
+/// row from its start column onward, the last from the line start to its end
+/// column, interior rows whole); rows join with newlines. Only cells inside the
+/// painters' declared `copyable` rects are taken, so chrome never reaches the
+/// clipboard. Every line is trimmed on both ends: tsk paints rows with a chrome
+/// gutter, and painted padding is never part of what a drag meant to copy. Empty
+/// rows drop entirely. `None` when the region covers no copyable text at all.
+pub fn selection_text(
+    rows: &[String],
+    copyable: &[Rect],
+    selection: &TextSelection,
+) -> Option<String> {
+    if !selection.has_area() {
+        return None;
+    }
+    let (x0, y0, x1, y1) = selection.normalized();
+    let mut lines = Vec::new();
+    for y in y0..=y1 {
+        let Some(row) = rows.get(y as usize) else {
+            continue;
+        };
+        let start = if y == y0 { x0 } else { 0 };
+        let end = if y == y1 { x1 } else { u16::MAX };
+        let mut pieces: Vec<String> = Vec::new();
+        for (span_start, span_end) in copyable_spans(copyable, y) {
+            let from = span_start.max(start);
+            let to = span_end.min(end);
+            if from > to {
+                continue;
+            }
+            let piece = slice_cells(row, from, to);
+            let piece = piece.trim();
+            if !piece.is_empty() {
+                pieces.push(piece.to_string());
+            }
+        }
+        if !pieces.is_empty() {
+            lines.push(pieces.join(" "));
+        }
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+/// The copyable column spans covering one row, merged and in paint order.
+///
+/// Overlapping or adjacent spans coalesce; truly disjoint spans stay
+/// separate and join with a space at copy time, so two side-by-side content
+/// regions on one painted row do not invent the chrome between them.
+fn copyable_spans(copyable: &[Rect], y: u16) -> Vec<(u16, u16)> {
+    let mut spans: Vec<(u16, u16)> = copyable
+        .iter()
+        .filter(|area| {
+            area.width > 0
+                && area.height > 0
+                && y >= area.y
+                && y < area.y.saturating_add(area.height)
+        })
+        .map(|area| (area.x, area.x.saturating_add(area.width.saturating_sub(1))))
+        .collect();
+    spans.sort_by_key(|(start, _)| *start);
+    let mut merged: Vec<(u16, u16)> = Vec::new();
+    for (start, end) in spans {
+        match merged.last_mut() {
+            Some((_, last_end)) if start <= last_end.saturating_add(1) => {
+                *last_end = (*last_end).max(end);
+            }
+            _ => merged.push((start, end)),
+        }
+    }
+    merged
+}
+
+/// Slice `row` by display-cell columns `[start, end]` inclusive.
+fn slice_cells(row: &str, start: u16, end: u16) -> String {
+    let mut out = String::new();
+    let mut col: u16 = 0;
+    for ch in row.chars() {
+        let width = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
+        if width == 0 {
+            continue;
+        }
+        let ch_end = col.saturating_add(width.saturating_sub(1));
+        if ch_end >= start && col <= end {
+            out.push(ch);
+        }
+        col = col.saturating_add(width);
+        if col > end {
+            break;
+        }
+    }
+    out
+}
+
+/// Reverse-highlight every cell the selection covers (line-oriented, matching copy).
+pub fn paint_selection(frame: &mut Frame<'_>, selection: &TextSelection) {
+    if !selection.has_area() {
+        return;
+    }
+    let (x0, y0, x1, y1) = selection.normalized();
+    let area = frame.area();
+    let buffer = frame.buffer_mut();
+    for y in y0..=y1 {
+        if y >= area.height {
+            break;
+        }
+        let start = if y == y0 { x0 } else { 0 };
+        let end = if y == y1 {
+            x1
+        } else {
+            area.width.saturating_sub(1)
+        };
+        for x in start..=end {
+            if x >= area.width {
+                break;
+            }
+            let cell = &mut buffer[(x, y)];
+            let style = cell.style().add_modifier(Modifier::REVERSED);
+            cell.set_style(style);
+        }
+    }
+}
+
+/// The OSC 52 sequence that sets the system clipboard to `text`.
+///
+/// The terminal (or host multiplexer that understands OSC 52) performs the
+/// actual copy; terminals without OSC 52 support ignore it silently.
+pub fn osc52_clipboard(text: &str) -> String {
+    format!("\u{1b}]52;c;{}\u{7}", base64_encode(text.as_bytes()))
+}
+
+/// Generous ceiling so a pathological drag cannot flood the terminal with a
+/// multi-megabyte OSC payload.
+pub const COPY_MAX_CHARS: usize = 100_000;
+
+/// Hand `text` to the system clipboard via OSC 52.
+///
+/// Returns `false` when the payload exceeds [`COPY_MAX_CHARS`] or stdout write
+/// fails.
+pub fn copy_to_clipboard(text: &str) -> bool {
+    if text.chars().count() > COPY_MAX_CHARS {
+        return false;
+    }
+    let mut out = io::stdout();
+    write!(out, "{}", osc52_clipboard(text)).is_ok() && out.flush().is_ok()
+}
+
+/// Standard Base64 (with padding) for OSC 52 payloads.
+pub fn base64_encode(data: &[u8]) -> String {
+    const TABLE: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = u32::from(chunk[0]);
+        let b1 = chunk.get(1).copied().map(u32::from);
+        let b2 = chunk.get(2).copied().map(u32::from);
+        let n = (b0 << 16) | (b1.unwrap_or(0) << 8) | b2.unwrap_or(0);
+        out.push(TABLE[((n >> 18) & 0x3f) as usize] as char);
+        out.push(TABLE[((n >> 12) & 0x3f) as usize] as char);
+        if b1.is_some() {
+            out.push(TABLE[((n >> 6) & 0x3f) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        if b2.is_some() {
+            out.push(TABLE[(n & 0x3f) as usize] as char);
+        } else {
+            out.push('=');
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pos(x: u16, y: u16) -> Position {
+        Position::new(x, y)
+    }
+
+    #[test]
+    fn osc52_wraps_base64_payload() {
+        let text = "hello";
+        let seq = osc52_clipboard(text);
+        assert!(seq.starts_with("\u{1b}]52;c;"));
+        assert!(seq.ends_with('\u{7}'));
+        assert!(seq.contains(&base64_encode(text.as_bytes())));
+        let seq = osc52_clipboard("foo");
+        assert_eq!(seq, format!("\u{1b}]52;c;{}\u{7}", base64_encode(b"foo")));
+    }
+
+    #[test]
+    fn reverse_drag_reads_the_same_text() {
+        let rows = vec!["hello world something".to_string()];
+        let copyable = [Rect::new(0, 0, 21, 1)];
+        let sel = TextSelection::new(pos(0, 0), pos(10, 0));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("hello world")
+        );
+        // Reversed drag direction reads the same.
+        let rev = TextSelection::new(pos(10, 0), pos(0, 0));
+        assert_eq!(
+            selection_text(&rows, &copyable, &rev).as_deref(),
+            Some("hello world")
+        );
+    }
+
+    #[test]
+    fn multi_line_selection_joins_with_newlines() {
+        let rows = vec![
+            "alpha     ".to_string(),
+            "bravo     ".to_string(),
+            "charlie   ".to_string(),
+        ];
+        let copyable = [Rect::new(0, 0, 10, 3)];
+        let sel = TextSelection::new(pos(0, 0), pos(5, 2));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("alpha\nbravo\ncharli")
+        );
+    }
+
+    #[test]
+    fn interior_rows_are_taken_whole_within_copyable() {
+        let rows = vec![
+            "abcdefghij".to_string(),
+            "0123456789".to_string(),
+            "ABCDEFGHIJ".to_string(),
+        ];
+        let copyable = [Rect::new(0, 0, 10, 3)];
+        let sel = TextSelection::new(pos(3, 0), pos(2, 2));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("defghij\n0123456789\nABC")
+        );
+    }
+
+    #[test]
+    fn undeclared_chrome_columns_never_reach_the_copy() {
+        // Glyph / meta sit outside the declared content rect; painters push
+        // only the content columns, so a drag to the frame edge leaves it behind.
+        let rows = vec!["▸ title here          meta".to_string()];
+        let copyable = [
+            // title content starts after the glyph column
+            Rect::new(2, 0, 14, 1),
+        ];
+        let sel = TextSelection::new(pos(0, 0), pos(25, 0));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("title here")
+        );
+    }
+
+    #[test]
+    fn leading_and_trailing_padding_trim_off() {
+        // Gutter spaces inside the selection but outside the trimmed content
+        // is outside the declared content rect, whichever edge the drag entered.
+        let rows = vec![
+            "  notes line one                                   ".to_string(),
+            "  notes line two                                   ".to_string(),
+        ];
+        let copyable = [Rect::new(2, 0, 44, 2)];
+        let sel = TextSelection::new(pos(0, 0), pos(50, 1));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("notes line one\nnotes line two")
+        );
+    }
+
+    #[test]
+    fn disjoint_copyable_spans_on_one_row_join_with_a_space() {
+        let rows = vec!["left        right".to_string()];
+        let copyable = [Rect::new(0, 0, 4, 1), Rect::new(12, 0, 5, 1)];
+        let sel = TextSelection::new(pos(0, 0), pos(20, 0));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("left right")
+        );
+    }
+
+    #[test]
+    fn rows_outside_any_copyable_rect_copy_nothing() {
+        let rows = vec![
+            "chrome".to_string(),
+            "content!".to_string(),
+            "more".to_string(),
+        ];
+        let copyable = [Rect::new(0, 1, 8, 1)];
+        let sel = TextSelection::new(pos(0, 0), pos(5, 2));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("content!")
+        );
+    }
+
+    #[test]
+    fn empty_rows_inside_the_drag_drop_out() {
+        let rows = vec![
+            "first line".to_string(),
+            "          ".to_string(),
+            "third line".to_string(),
+        ];
+        let copyable = [Rect::new(0, 0, 19, 3)];
+        let sel = TextSelection::new(pos(0, 0), pos(9, 2));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("first line\nthird line")
+        );
+        // A drag that only covers the blank middle yields nothing.
+        let sel = TextSelection::new(pos(0, 1), pos(5, 1));
+        assert_eq!(selection_text(&rows, &copyable, &sel).as_deref(), None);
+    }
+
+    #[test]
+    fn bare_click_and_blank_cells_copy_nothing() {
+        let rows = vec!["hello".to_string()];
+        let copyable = [Rect::new(0, 0, 5, 1)];
+        assert_eq!(
+            selection_text(&rows, &copyable, &TextSelection::new(pos(2, 0), pos(2, 0))),
+            None
+        );
+        let blank = vec!["     ".to_string()];
+        assert_eq!(
+            selection_text(&blank, &copyable, &TextSelection::new(pos(1, 0), pos(3, 0))),
+            None
+        );
+    }
+
+    #[test]
+    fn selection_with_no_overlap_of_copyable_is_none() {
+        let rows = vec!["hello".to_string()];
+        let copyable = [Rect::new(0, 0, 5, 1)];
+        // Drag entirely past the copyable rect.
+        let sel = TextSelection::new(pos(10, 0), pos(12, 0));
+        assert_eq!(selection_text(&rows, &copyable, &sel), None);
+    }
+
+    #[test]
+    fn base64_encode_pads_short_inputs() {
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        let rows = vec!["abcd".to_string()];
+        let copyable = [Rect::new(0, 0, 4, 1)];
+        let sel = TextSelection::new(pos(0, 0), pos(3, 0));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("abcd")
+        );
+        // Partial inclusive end.
+        let sel = TextSelection::new(pos(1, 0), pos(2, 0));
+        assert_eq!(
+            selection_text(&rows, &copyable, &sel).as_deref(),
+            Some("bc")
+        );
+    }
+}

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -1187,7 +1187,12 @@ fn save_recovery_unbinds_retired_lens_keys() {
 
 /// Painted board text at the standard size, exactly as the board loop draws it.
 fn board_painted(model: &BoardModel) -> String {
-    painted(|frame| draw_board(frame, model), (80, 24))
+    painted(
+        |frame| {
+            let _ = draw_board(frame, model);
+        },
+        (80, 24),
+    )
 }
 
 /// A task page opened on a task carrying one step, with the step line editor open

--- a/tests/fixtures/queue_board/help.txt
+++ b/tests/fixtures/queue_board/help.txt
@@ -4,19 +4,19 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │         ┌─ help ──────────────────────────────────────────────── [x]─┐         │
-│  ▸ Smoke                                                              tsk · 3m │
-│  ▸ Edit    alt+q quit | Esc close                                     dr · 12m │
-│            j/k · ↑/↓ move | alt+space primary                                  │
-│ desk ───   alt+d done | alt+o reopen                                  ───────1 │
-│            alt+b block | enter open                                            │
-│  ○ Globa   →/← peek | + capture                                             2d │
-│            alt+e title | alt+x/Delete delete                                   │
-│            alt+u undo | z drawer                                               │
-│            : palette | ? help                                                  │
-│            P project                                                           │
-│                                                                                │
+│  ▸ Smoke│                                                            │tsk · 3m │
+│  ▸ Edit │  alt+q quit | Esc close                                    │dr · 12m │
+│         │  j/k · ↑/↓ move | alt+space primary                        │         │
+│ desk ───│  alt+d done | alt+o reopen                                 │───────1 │
+│         │  alt+b block | enter open                                  │         │
+│  ○ Globa│  →/← peek | + capture                                      │      2d │
+│         │  alt+e title | alt+x/Delete delete                         │         │
+│         │  alt+u undo | z drawer                                     │         │
+│         │  : palette | ? help                                        │         │
+│         │  P project                                                 │         │
+│         │                                                            │         │
 │         ├────────────────────────────────────────────────────────────┤         │
-│           any key close                                                        │
+│         │ any key close                                              │         │
 │         └────────────────────────────────────────────────────────────┘         │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/help.txt
+++ b/tests/fixtures/queue_board/help.txt
@@ -1,26 +1,26 @@
 ┌────────────────────────────────────────────────────────────────────────────────┐
 │                                                                                │
+│ desk  ·  projects  ·  threads                                                  │
+│                                                                                │
+│ IN MOTION ───────────────────────────────────────────────────────────────────2 │
+│         ┌─ help ──────────────────────────────────────────────── [x]─┐         │
+│  ▸ Smoke                                                              tsk · 3m │
+│  ▸ Edit    alt+q quit | Esc close                                     dr · 12m │
+│            j/k · ↑/↓ move | alt+space primary                                  │
+│ desk ───   alt+d done | alt+o reopen                                  ───────1 │
+│            alt+b block | enter open                                            │
+│  ○ Globa   →/← peek | + capture                                             2d │
+│            alt+e title | alt+x/Delete delete                                   │
+│            alt+u undo | z drawer                                               │
+│            : palette | ? help                                                  │
+│            P project                                                           │
+│                                                                                │
+│         ├────────────────────────────────────────────────────────────┤         │
+│           any key close                                                        │
+│         └────────────────────────────────────────────────────────────┘         │
 │                                                                                │
 │                                                                                │
-│                                                                                │
-│                                                                                │
-│         keys                                                                   │
-│                                                                                │
-│          alt+q quit | Esc close                                                │
-│          j/k · ↑/↓ move | alt+space primary                                    │
-│          alt+d done | alt+o reopen                                             │
-│          alt+b block | enter open                                              │
-│          →/← peek | + capture                                                  │
-│          alt+e title | alt+x/Delete delete                                     │
-│          alt+u undo | z drawer                                                 │
-│          : palette | ? help                                                    │
-│          P project                                                             │
-│                                                                                │
-│          any key to close                                                      │
-│                                                                                │
-│                                                                                │
-│                                                                                │
-│                                                                                │
-│                                                                                │
+│────────────────────────────────────────────────────────────────────────────────│
+│ 2 done                                                                         │
 │                                                                                │
 └────────────────────────────────────────────────────────────────────────────────┘

--- a/tests/fixtures/queue_board/palette.txt
+++ b/tests/fixtures/queue_board/palette.txt
@@ -5,14 +5,14 @@
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
 │  ▸ Smoke┌─ command ───────────────────────────────────────────── [x]─┐tsk · 3m │
-│  ▸ Edit                                                               dr · 12m │
-│             set status: ready                                                  │
-│ desk ───    set status: started                                       ───────1 │
-│           ▸ set status: blocked                                                │
-│  ○ Globa    set status: review                                              2d │
-│                                                                                │
+│  ▸ Edit │                                                            │dr · 12m │
+│         │   set status: ready                                        │         │
+│ desk ───│   set status: started                                      │───────1 │
+│         │ ▸ set status: blocked                                      │         │
+│  ○ Globa│   set status: review                                       │      2d │
+│         │                                                            │         │
 │         ├────────────────────────────────────────────────────────────┤         │
-│           ↑/↓ move · enter run · esc close                                     │
+│         │ ↑/↓ move · enter run · esc close                           │         │
 │         └────────────────────────────────────────────────────────────┘         │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/palette.txt
+++ b/tests/fixtures/queue_board/palette.txt
@@ -4,23 +4,23 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                                       tsk · 3m │
-│  ▸ Edit target binding pin                                         herdr · 12m │
+│  ▸ Smoke┌─ command ───────────────────────────────────────────── [x]─┐tsk · 3m │
+│  ▸ Edit                                                               dr · 12m │
+│             set status: ready                                                  │
+│ desk ───    set status: started                                       ───────1 │
+│           ▸ set status: blocked                                                │
+│  ○ Globa    set status: review                                              2d │
 │                                                                                │
-│ desk ────────────────────────────────────────────────────────────────────────1 │
-│                                                                                │
-│  ○ Global backlog note                                                      2d │
-│                                                                                │
-│                                                                                │
+│         ├────────────────────────────────────────────────────────────┤         │
+│           ↑/↓ move · enter run · esc close                                     │
+│         └────────────────────────────────────────────────────────────┘         │
 │                                                                                │
 │                                                                                │
 │                                                                                │
-│ command                                                                        │
-│   set status: ready                                                            │
-│   set status: started                                                          │
-│ ▸ set status: blocked                                                          │
-│   set status: review                                                           │
+│                                                                                │
+│                                                                                │
+│                                                                                │
 │────────────────────────────────────────────────────────────────────────────────│
 │ :stat                                                                          │
-│ enter run · esc close · type to filter                                         │
+│                                                                                │
 └────────────────────────────────────────────────────────────────────────────────┘

--- a/tests/queue_board_bench.rs
+++ b/tests/queue_board_bench.rs
@@ -143,7 +143,9 @@ fn cold_start_to_first_frame_under_200ms_at_80x24_with_100_tasks() {
         let mut terminal =
             Terminal::new(TestBackend::new(WIDTH, HEIGHT)).expect("scratch terminal");
         let completed = terminal
-            .draw(|frame| draw_board(frame, &model))
+            .draw(|frame| {
+                let _ = draw_board(frame, &model);
+            })
             .expect("first frame draw");
         std::hint::black_box(&completed);
         elapsed_by_trial.push(start.elapsed());
@@ -208,7 +210,9 @@ fn keypress_to_repaint_p99_under_16ms_during_navigation_at_80x24_with_100_tasks(
     let mut step = |domain: &mut DomainState, model: &mut BoardModel| {
         apply_intent(domain, model, BoardIntent::SelectNext, None).expect("navigation intent");
         let completed = terminal
-            .draw(|frame| draw_board(frame, model))
+            .draw(|frame| {
+                let _ = draw_board(frame, model);
+            })
             .expect("navigation frame draw");
         std::hint::black_box(&completed);
     };

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -219,7 +219,9 @@ fn title_edit_cursor_and_window_track_the_actual_paint_width_not_a_hardcoded_one
         let backend = TestBackend::new(100, 30);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal
-            .draw(|frame| draw_board(frame, &model))
+            .draw(|frame| {
+                let _ = draw_board(frame, &model);
+            })
             .expect("draw 100x30");
         let (title_y, _row) = (0..30)
             .map(|y| (y, row_text(&terminal, 100, y)))
@@ -241,7 +243,9 @@ fn title_edit_cursor_and_window_track_the_actual_paint_width_not_a_hardcoded_one
         let backend = TestBackend::new(40, 10);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal
-            .draw(|frame| draw_board(frame, &model))
+            .draw(|frame| {
+                let _ = draw_board(frame, &model);
+            })
             .expect("draw 40x10");
         // 62 whitespace-free characters at a 30-cell field wrap as 30 / 30 / 2.
         let head_row = row_text(&terminal, 40, 1);
@@ -540,7 +544,9 @@ fn task_page_scope_dropdown_sits_above_the_footer_with_short_names() {
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw");
 
     let rows: Vec<String> = (0..height).map(|y| row_text(&terminal, width, y)).collect();
@@ -595,7 +601,9 @@ fn page_view_shows_thread_beside_scope() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw");
     let painted: String = terminal
         .backend()
@@ -827,7 +835,9 @@ fn editing_an_unthreaded_task_paints_a_labeled_thread_footer_slot() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw thread field");
     let painted: String = terminal
         .backend()
@@ -911,7 +921,9 @@ fn thread_refusal_paints_inline_and_clears_without_status_leak() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw refusal");
     let painted: String = terminal
         .backend()
@@ -1004,7 +1016,9 @@ fn long_invalid_thread_refusal_remains_visible_at_40x10() {
     let backend = TestBackend::new(40, 10);
     let mut terminal = Terminal::new(backend).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw compact refusal");
     let painted: String = terminal
         .backend()
@@ -1047,7 +1061,9 @@ fn page_footer_thread_edit_operable_at_40x10() {
     let backend = TestBackend::new(40, 10);
     let mut terminal = Terminal::new(backend).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw compact");
     let painted: String = terminal
         .backend()

--- a/tests/queue_board_loop.rs
+++ b/tests/queue_board_loop.rs
@@ -117,7 +117,9 @@ fn instrumented_loop_idle_wait_never_sustained_below_25ms_without_animation() {
                 // `TestBackend`'s draw error is `Infallible`; `expect` collapses it to the
                 // `io::Result<()>` `board_frame` requires without inventing a fake error path.
                 terminal
-                    .draw(|frame| draw_board(frame, model))
+                    .draw(|frame| {
+                        let _ = draw_board(frame, model);
+                    })
                     .expect("test backend draw");
                 Ok(())
             },
@@ -168,6 +170,8 @@ fn load_board_and_draw_path_smoke_at_80x24() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("test terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw the loaded board without panicking");
 }

--- a/tests/queue_board_model.rs
+++ b/tests/queue_board_model.rs
@@ -717,7 +717,9 @@ fn selection_stays_on_task_id_across_thread_block_reorder() {
 fn board_rows(model: &BoardModel, width: u16, height: u16) -> Vec<String> {
     let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("test terminal");
     terminal
-        .draw(|frame| draw_board(frame, model))
+        .draw(|frame| {
+            let _ = draw_board(frame, model);
+        })
         .expect("draw board");
     let buffer = terminal.backend().buffer();
     (0..height)

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1077,6 +1077,124 @@ fn a_click_on_the_palettes_own_chrome_does_not_dismiss_it() {
     );
 }
 
+/// The shared modal card's own `[x]` closes/cancels whichever surface painted it, its
+/// border+footer chrome is inert (not a second, redundant dismiss route on top of the
+/// palette's `CommandChrome`/project picker's outside-click fallthrough already proved
+/// above), and a click on the board behind the card still dismisses -- for all three
+/// surfaces the card now shares (Palette, `?` help, `P` project picker).
+#[test]
+fn the_modal_cards_close_control_and_chrome_behave_the_same_on_palette_help_and_project_picker() {
+    // Palette: `[x]` closes the command surface; the card's own border is inert.
+    let (mut domain, mut model, _id) = board_with_task("modal card palette", HumanStatus::Ready);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenCommandPalette,
+        None,
+        None,
+    )
+    .expect("open palette");
+    let hits = board_hit_map(STANDARD, &model);
+    let close_hit = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ModalClose))
+        .expect("the palette card must paint an `[x]` close control");
+    assert_eq!(
+        click(close_hit, &model, &hits),
+        Some(BoardIntent::CloseCommandSurface)
+    );
+    let chrome_hit = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ModalChrome))
+        .expect("the palette card must paint its own border/footer chrome");
+    assert_eq!(
+        click(chrome_hit, &model, &hits),
+        None,
+        "a click on the card's border/footer must be inert"
+    );
+
+    // Project picker: `[x]` cancels the picker; the card's own border is inert.
+    let (mut domain, mut model, _id) = board_with_task("modal card scope", HumanStatus::Ready);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenProjectSelector,
+        None,
+        None,
+    )
+    .expect("open project selector");
+    let hits = board_hit_map(STANDARD, &model);
+    let close_hit = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ModalClose))
+        .expect("the project picker card must paint an `[x]` close control");
+    assert_eq!(
+        click(close_hit, &model, &hits),
+        Some(BoardIntent::CancelProjectPicker)
+    );
+    let chrome_hit = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ModalChrome))
+        .expect("the project picker card must paint its own border/footer chrome");
+    assert_eq!(
+        click(chrome_hit, &model, &hits),
+        None,
+        "a click on the card's border/footer must be inert"
+    );
+
+    // Help: `[x]` closes the layer the same as any other key; the card's border is inert,
+    // but (unlike the other two) its own body text still closes -- there is nothing to
+    // select inside it, so it keeps mouse parity with the keyboard's "any key closes".
+    let (mut domain, mut model, _id) = board_with_task("modal card help", HumanStatus::Ready);
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenHelp, None, None).expect("open help");
+    let hits = board_hit_map(STANDARD, &model);
+    let close_hit = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ModalClose))
+        .expect("the help card must paint an `[x]` close control");
+    assert_eq!(
+        click(close_hit, &model, &hits),
+        Some(BoardIntent::CloseLayer)
+    );
+    let chrome_hit = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ModalChrome))
+        .expect("the help card must paint its own border/footer chrome");
+    assert_eq!(
+        click(chrome_hit, &model, &hits),
+        None,
+        "a click on the card's border/footer must be inert"
+    );
+    // The card repaints `HelpDismiss` over its own content rect *after* the full-frame
+    // one `paint_modal_card` pushes first, so the later (content-sized) region is the
+    // last `HelpDismiss` hit in the map.
+    let body_hit = hits
+        .regions
+        .iter()
+        .rev()
+        .find(|hit| matches!(hit.target, QueueHitTarget::HelpDismiss))
+        .expect("the help card's body must repaint HelpDismiss over its own content rect");
+    assert_eq!(
+        click(body_hit, &model, &hits),
+        Some(BoardIntent::CloseLayer)
+    );
+
+    // A click on the board behind the help card still dismisses it -- the far corner of
+    // the frame paints no card chrome at all. (Palette's own far-corner dismissal is
+    // already proved by `a_click_on_the_palettes_own_chrome_does_not_dismiss_it` above.)
+    let outside = left_click(STANDARD.width - 1, STANDARD.height - 1);
+    assert_eq!(
+        map_board_mouse(&model, &hits, outside),
+        Some(BoardIntent::CloseLayer)
+    );
+}
+
 /// R-2: the standard-tier command surface windows to 6
 /// rows at 80x24 while 13 commands exist, and the painted `▲▼` marker is inert
 /// `CommandChrome`, so a mouse-only user could not reach the 7 commands outside the
@@ -1653,4 +1771,87 @@ fn drag_selection_copies_painted_task_title_not_undeclared_chrome() {
         Position::new(area.x + 2, area.y),
     );
     assert_eq!(selection_text(&rows, &hits.copyable, &bare), None);
+}
+
+/// The shared modal card only declares its own body rows copyable -- never the
+/// border, title, or footer rows around them -- so a selection dragged across the
+/// card's border/footer paints no clipboard text, only its actual binding lines do.
+#[test]
+fn the_modal_cards_copyable_rects_exclude_its_own_border_and_footer() {
+    use ratatui::layout::Position;
+    use tsk_tui::ui::text_select::{selection_text, TextSelection};
+
+    let (mut domain, mut model, _id) = board_with_task("modal card copyable", HumanStatus::Ready);
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenHelp, None, None).expect("open help");
+    let hits = board_hit_map(STANDARD, &model);
+
+    let mut terminal =
+        Terminal::new(TestBackend::new(STANDARD.width, STANDARD.height)).expect("test terminal");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer();
+    let rows: Vec<String> = (0..STANDARD.height)
+        .map(|y| {
+            (0..STANDARD.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect();
+
+    // The top border row (painted with the card's title) declares no copyable rect.
+    let top_border_y = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ModalClose))
+        .expect("the help card paints an `[x]` close control")
+        .area
+        .y;
+    assert!(
+        !hits
+            .copyable
+            .iter()
+            .any(|rect| rect.y == top_border_y && rect.height == 1),
+        "the card's own title/border row must not be copyable: {:?}",
+        rows[top_border_y as usize]
+    );
+    let border = TextSelection::new(
+        Position::new(0, top_border_y),
+        Position::new(STANDARD.width - 1, top_border_y),
+    );
+    assert_eq!(
+        selection_text(&rows, &hits.copyable, &border),
+        None,
+        "a drag across the card's border must yield no copyable text"
+    );
+
+    // A real body row -- one of Help's own binding lines -- is copyable and yields text.
+    let body_hit = hits
+        .regions
+        .iter()
+        .rev()
+        .find(|hit| matches!(hit.target, QueueHitTarget::HelpDismiss))
+        .expect("the help card's body repaints HelpDismiss over its content rect")
+        .area;
+    let body_y = body_hit.y;
+    assert!(
+        hits.copyable
+            .iter()
+            .any(|rect| rect.y == body_y && rect.height == 1),
+        "the card's first body row must be copyable"
+    );
+    let body = TextSelection::new(
+        Position::new(body_hit.x, body_y),
+        Position::new(
+            body_hit.x.saturating_add(body_hit.width.saturating_sub(1)),
+            body_y,
+        ),
+    );
+    let text = selection_text(&rows, &hits.copyable, &body).expect("copyable body text");
+    assert!(
+        !text.trim().is_empty(),
+        "the card's first body row should yield its painted binding text, got {text:?}"
+    );
 }

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -16,7 +16,7 @@ use ratatui::Terminal;
 use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
 use tsk_tui::ui::board::{
     apply_intent, board_hit_map, board_verb_items, draw_board, resolve_board_command,
-    BoardInputMode, BoardModel,
+    BoardInputMode, BoardModel, ProjectScopeOption,
 };
 use tsk_tui::ui::capture::CaptureField;
 use tsk_tui::ui::input::{
@@ -1761,6 +1761,10 @@ fn drag_selection_copies_painted_task_title_not_undeclared_chrome() {
         text.contains("copyable title text"),
         "selection should include the task title, got {text:?}"
     );
+    assert!(
+        !text.contains('○') && !text.contains('▸'),
+        "status glyph is chrome and must stay out of the copy, got {text:?}"
+    );
 
     // A bare click (no drag) leaves no copyable text.
     model.begin_mouse_press(Position::new(area.x + 2, area.y));
@@ -1771,6 +1775,117 @@ fn drag_selection_copies_painted_task_title_not_undeclared_chrome() {
         Position::new(area.x + 2, area.y),
     );
     assert_eq!(selection_text(&rows, &hits.copyable, &bare), None);
+}
+
+/// Peek accordion body paints a `│` gutter; that pipe is chrome. A drag across the
+/// open peek on a project-scoped board must copy the notes text without it — the
+/// same surface that felt broken when copyable rects spanned the full row.
+#[test]
+fn peek_on_project_board_copy_excludes_pipe_gutter() {
+    use ratatui::layout::Position;
+    use tsk_tui::ui::text_select::{selection_text, TextSelection};
+
+    let mut domain = DomainState::new();
+    let notes = "Fixed. It wasn't a bug in the terminal-selection sense.";
+    let id = domain
+        .create(
+            "hi",
+            Some(notes.to_string()),
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    domain.set_status(id, HumanStatus::Started).expect("start");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    // Focus the project board (the "project page" surface), then open peek.
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenProjectSelector,
+        None,
+        None,
+    )
+    .expect("open project picker");
+    let project_idx = model
+        .project_options()
+        .iter()
+        .position(|opt| matches!(opt, ProjectScopeOption::Project(p) if p == Path::new(THIS_REPO)))
+        .expect("this repo is offered");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectProjectOption(project_idx),
+        None,
+        None,
+    )
+    .expect("select project");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmProjectChoice,
+        None,
+        None,
+    )
+    .expect("confirm project focus");
+    assert_eq!(
+        model.selected_project(),
+        Some(Path::new(THIS_REPO)),
+        "board must be project-focused"
+    );
+    apply_intent(&mut domain, &mut model, BoardIntent::PeekDetail, None, None).expect("peek");
+    assert_eq!(model.detail_open(), Some(id));
+
+    let hits = board_hit_map(STANDARD, &model);
+    let mut terminal =
+        Terminal::new(TestBackend::new(STANDARD.width, STANDARD.height)).expect("test terminal");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer();
+    let rows: Vec<String> = (0..STANDARD.height)
+        .map(|y| {
+            (0..STANDARD.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect();
+
+    let note_y = rows
+        .iter()
+        .position(|row| row.contains("Fixed. It wasn't"))
+        .expect("peek paints the notes preview") as u16;
+    assert!(
+        rows[note_y as usize].contains('│'),
+        "sanity: the peek gutter is on the painted row"
+    );
+    let note_copyable = hits
+        .copyable
+        .iter()
+        .find(|rect| rect.y == note_y)
+        .expect("peek notes row must declare a copyable rect");
+    assert!(
+        note_copyable.x >= 6,
+        "copyable must start past `    │ ` (6 cells), got x={}",
+        note_copyable.x
+    );
+
+    let selection = TextSelection::new(
+        Position::new(0, note_y),
+        Position::new(STANDARD.width - 1, note_y),
+    );
+    let text = selection_text(&rows, &hits.copyable, &selection).expect("peek notes copy");
+    assert!(
+        text.contains("Fixed. It wasn't a bug"),
+        "notes text must copy, got {text:?}"
+    );
+    assert!(
+        !text.contains('│'),
+        "peek pipe gutter must stay out of the clipboard, got {text:?}"
+    );
 }
 
 /// The shared modal card only declares its own body rows copyable -- never the

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1091,7 +1091,6 @@ fn the_modal_cards_close_control_and_chrome_behave_the_same_on_palette_help_and_
         &mut model,
         BoardIntent::OpenCommandPalette,
         None,
-        None,
     )
     .expect("open palette");
     let hits = board_hit_map(STANDARD, &model);
@@ -1122,7 +1121,6 @@ fn the_modal_cards_close_control_and_chrome_behave_the_same_on_palette_help_and_
         &mut model,
         BoardIntent::OpenProjectSelector,
         None,
-        None,
     )
     .expect("open project selector");
     let hits = board_hit_map(STANDARD, &model);
@@ -1150,7 +1148,7 @@ fn the_modal_cards_close_control_and_chrome_behave_the_same_on_palette_help_and_
     // but (unlike the other two) its own body text still closes -- there is nothing to
     // select inside it, so it keeps mouse parity with the keyboard's "any key closes".
     let (mut domain, mut model, _id) = board_with_task("modal card help", HumanStatus::Ready);
-    apply_intent(&mut domain, &mut model, BoardIntent::OpenHelp, None, None).expect("open help");
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenHelp, None).expect("open help");
     let hits = board_hit_map(STANDARD, &model);
     let close_hit = hits
         .regions
@@ -1805,7 +1803,6 @@ fn peek_on_project_board_copy_excludes_pipe_gutter() {
         &mut model,
         BoardIntent::OpenProjectSelector,
         None,
-        None,
     )
     .expect("open project picker");
     let project_idx = model
@@ -1818,14 +1815,12 @@ fn peek_on_project_board_copy_excludes_pipe_gutter() {
         &mut model,
         BoardIntent::SelectProjectOption(project_idx),
         None,
-        None,
     )
     .expect("select project");
     apply_intent(
         &mut domain,
         &mut model,
         BoardIntent::ConfirmProjectChoice,
-        None,
         None,
     )
     .expect("confirm project focus");
@@ -1834,7 +1829,7 @@ fn peek_on_project_board_copy_excludes_pipe_gutter() {
         Some(Path::new(THIS_REPO)),
         "board must be project-focused"
     );
-    apply_intent(&mut domain, &mut model, BoardIntent::PeekDetail, None, None).expect("peek");
+    apply_intent(&mut domain, &mut model, BoardIntent::PeekDetail, None).expect("peek");
     assert_eq!(model.detail_open(), Some(id));
 
     let hits = board_hit_map(STANDARD, &model);
@@ -1896,14 +1891,7 @@ fn task_page_title_copy_excludes_glyph_and_status_word() {
     use tsk_tui::ui::text_select::{selection_text, TextSelection};
 
     let (mut domain, mut model, _id) = board_with_task("title only please", HumanStatus::Started);
-    apply_intent(
-        &mut domain,
-        &mut model,
-        BoardIntent::OpenTaskPage,
-        None,
-        None,
-    )
-    .expect("open page");
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
 
     let hits = board_hit_map(STANDARD, &model);
     let mut terminal =
@@ -1955,7 +1943,7 @@ fn the_modal_cards_copyable_rects_exclude_its_own_border_and_footer() {
     use tsk_tui::ui::text_select::{selection_text, TextSelection};
 
     let (mut domain, mut model, _id) = board_with_task("modal card copyable", HumanStatus::Ready);
-    apply_intent(&mut domain, &mut model, BoardIntent::OpenHelp, None, None).expect("open help");
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenHelp, None).expect("open help");
     let hits = board_hit_map(STANDARD, &model);
 
     let mut terminal =

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1513,7 +1513,9 @@ fn page_rows(model: &BoardModel) -> Vec<String> {
     let mut terminal =
         Terminal::new(TestBackend::new(STANDARD.width, STANDARD.height)).expect("test terminal");
     terminal
-        .draw(|frame| draw_board(frame, model))
+        .draw(|frame| {
+            let _ = draw_board(frame, model);
+        })
         .expect("draw page");
     let buffer = terminal.backend().buffer();
     (0..STANDARD.height)
@@ -1594,4 +1596,61 @@ fn clicking_a_step_row_selects_it() {
         "the cursor stays on the clicked step after a notes-half click:\n{}",
         after.join("\n")
     );
+}
+
+/// Painters declare copyable content rects beside the paint; a drag selection
+/// over those cells yields the painted text (chrome columns outside `copyable`
+/// stay out of the clipboard string).
+#[test]
+fn drag_selection_copies_painted_task_title_not_undeclared_chrome() {
+    use ratatui::layout::Position;
+    use tsk_tui::ui::text_select::{selection_text, TextSelection};
+
+    let (_domain, mut model, _id) = board_with_task("copyable title text", HumanStatus::Ready);
+    let hits = board_hit_map(STANDARD, &model);
+    assert!(
+        !hits.copyable.is_empty(),
+        "task rows must push copyable content rects"
+    );
+
+    let mut terminal =
+        Terminal::new(TestBackend::new(STANDARD.width, STANDARD.height)).expect("test terminal");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer();
+    let rows: Vec<String> = (0..STANDARD.height)
+        .map(|y| {
+            (0..STANDARD.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect();
+
+    // Anchor on the title content, drag across it.
+    let area = hits.copyable[0];
+    model.begin_mouse_press(Position::new(area.x, area.y));
+    model.drag_text_selection(Position::new(
+        area.x.saturating_add(area.width.saturating_sub(1)),
+        area.y,
+    ));
+    model.end_mouse_press();
+    let selection = model.text_selection().expect("drag left a selection");
+    let text = selection_text(&rows, &hits.copyable, &selection).expect("copyable text");
+    assert!(
+        text.contains("copyable title text"),
+        "selection should include the task title, got {text:?}"
+    );
+
+    // A bare click (no drag) leaves no copyable text.
+    model.begin_mouse_press(Position::new(area.x + 2, area.y));
+    model.end_mouse_press();
+    assert!(model.text_selection().is_none());
+    let bare = TextSelection::new(
+        Position::new(area.x + 2, area.y),
+        Position::new(area.x + 2, area.y),
+    );
+    assert_eq!(selection_text(&rows, &hits.copyable, &bare), None);
 }

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1888,6 +1888,64 @@ fn peek_on_project_board_copy_excludes_pipe_gutter() {
     );
 }
 
+/// Task-page header copyable rects cover title words only — not the status glyph or
+/// the right-aligned status word.
+#[test]
+fn task_page_title_copy_excludes_glyph_and_status_word() {
+    use ratatui::layout::Position;
+    use tsk_tui::ui::text_select::{selection_text, TextSelection};
+
+    let (mut domain, mut model, _id) = board_with_task("title only please", HumanStatus::Started);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenTaskPage,
+        None,
+        None,
+    )
+    .expect("open page");
+
+    let hits = board_hit_map(STANDARD, &model);
+    let mut terminal =
+        Terminal::new(TestBackend::new(STANDARD.width, STANDARD.height)).expect("test terminal");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer();
+    let rows: Vec<String> = (0..STANDARD.height)
+        .map(|y| {
+            (0..STANDARD.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect();
+
+    let title_y = rows
+        .iter()
+        .position(|row| row.contains("title only please"))
+        .expect("page paints the title") as u16;
+    assert!(
+        rows[title_y as usize].contains('▸'),
+        "sanity: status glyph is on the title row"
+    );
+    assert!(
+        rows[title_y as usize].contains("started"),
+        "sanity: status word is on the title row"
+    );
+
+    let selection = TextSelection::new(
+        Position::new(0, title_y),
+        Position::new(STANDARD.width - 1, title_y),
+    );
+    let text = selection_text(&rows, &hits.copyable, &selection).expect("title copy");
+    assert_eq!(
+        text, "title only please",
+        "copy must be the title alone, got {text:?}"
+    );
+}
+
 /// The shared modal card only declares its own body rows copyable -- never the
 /// border, title, or footer rows around them -- so a selection dragged across the
 /// card's border/footer paints no clipboard text, only its actual binding lines do.

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -785,7 +785,7 @@ fn overlay_rows_are_padded_exact_no_base_bleed() {
         }
     }
 
-    // --- Scope dropdown column must be padded to its col width; no meta bleed in cells ---
+    // --- Scope dropdown is a centered modal card; its rows must be padded full width ---
     {
         let mut model = fixture_model(&tasks, &view);
         model.status_message = Some(status);
@@ -794,32 +794,29 @@ fn overlay_rows_are_padded_exact_no_base_bleed() {
             options: &scope_opts,
             selected: 0,
         };
-        let (rows, geo) = paint(80, 24, &model);
-        // Dropdown sits under selector chip; first option row is selector_row+1.
-        if let Some(sel) = geo.selector_row {
-            let y = sel + 1;
-            if (y as usize) < rows.len() {
-                let row = &rows[y as usize];
-                // The dropdown only writes its col_w cells at x0; those cells must be padded.
-                // We assert the painted option text area does not contain base fragments.
-                // Distinctive status won't be here, but task meta or rule chars could.
-                // Check the right-hand side of the row for our marker/text.
-                assert!(
-                    row.contains("▸ desk") || row.contains("  desk"),
-                    "scope dropdown must paint option text: {row:?}"
-                );
-                // The desk option must be painted as its own dropdown row, not merely
-                // satisfied by task titles or meta elsewhere on the frame.
-                assert!(
-                    rows.get(y as usize + 1)
-                        .is_some_and(|option_row| option_row.contains("tsk")),
-                    "scope dropdown must paint each option on its own row"
-                );
-                // Ensure no stray count/meta tail attached inside the option cells.
-                // Since we pad to col_w in paint, the rendered cells are clean.
-                // Spot-check: after the label there should be trailing space within the column.
-            }
-        }
+        let (rows, _geo) = paint(80, 24, &model);
+        let desk_row = rows
+            .iter()
+            .position(|row| row.contains("▸ desk") || row.contains("  desk"))
+            .expect("scope dropdown must paint the desk option");
+        assert_eq!(
+            rows[desk_row].chars().count(),
+            80,
+            "scope dropdown option row must fill width: {:?}",
+            rows[desk_row]
+        );
+        // The `tsk` option must be painted as its own row, not merely satisfied by task
+        // titles or meta elsewhere on the frame.
+        assert!(
+            rows.get(desk_row + 1)
+                .is_some_and(|option_row| option_row.contains("tsk")),
+            "scope dropdown must paint each option on its own row"
+        );
+        assert!(
+            !rows[desk_row].contains("motion") && !rows[desk_row].contains("done"),
+            "base status/meta must not bleed into scope dropdown: {:?}",
+            rows[desk_row]
+        );
     }
 }
 

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -377,7 +377,9 @@ fn board_rows(model: &BoardModel, width: u16, height: u16) -> Vec<String> {
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).expect("test terminal");
     terminal
-        .draw(|frame: &mut Frame| draw_board(frame, model))
+        .draw(|frame| {
+            let _ = draw_board(frame, model);
+        })
         .expect("draw board");
     let buffer = terminal.backend().buffer();
     assert_buffer_mono(buffer);
@@ -1175,7 +1177,9 @@ fn notes_edit_caret_accounts_for_shared_stream_scroll() {
 
     let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("test terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw edit page");
     let cursor = terminal.backend().cursor_position();
     assert_eq!(
@@ -1223,7 +1227,9 @@ fn notes_edit_after_deep_stream_scroll_keeps_draft_and_caret_aligned() {
     apply_intent(&mut domain, &mut model, BoardIntent::BeginEditNotes, None).expect("edit notes");
     let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw");
     let text = board_rows(&model, 80, 24).join("\n");
     assert!(
@@ -1298,7 +1304,9 @@ fn shift_tab_from_scope_resets_notes_stream_origin_and_aligns_caret() {
 
     let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw");
     let text = board_rows(&model, 80, 24).join("\n");
     assert!(
@@ -1336,7 +1344,9 @@ fn notes_edit_wraps_a_long_line_instead_of_scrolling_horizontally() {
 
     let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw edit page");
     let rows = board_rows(&model, 80, 24);
     assert!(
@@ -2618,7 +2628,9 @@ fn quick_add_wraps_a_long_title_into_the_reserved_rows() {
 
     let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw quick add");
     let rows = board_rows(&model, 80, 24);
     let prompt_rows: Vec<&String> = rows.iter().filter(|row| row.contains("▎")).collect();
@@ -2673,7 +2685,9 @@ fn notes_edit_arrows_move_across_logical_and_wrapped_rows() {
     let caret_at = |model: &BoardModel, width: u16, height: u16| {
         let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
         terminal
-            .draw(|frame| draw_board(frame, model))
+            .draw(|frame| {
+                let _ = draw_board(frame, model);
+            })
             .expect("draw");
         terminal.backend().cursor_position().y
     };
@@ -2824,7 +2838,9 @@ fn edit_title_caret_parks_at_the_capped_headers_end() {
 
     let mut terminal = Terminal::new(TestBackend::new(40, 10)).expect("terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("draw edit page");
     let rows = board_rows(&model, 40, 10);
     // The capped header's last row carries the marker; the caret must sit at

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -698,18 +698,24 @@ fn help_card_lists_every_active_tier_binding_and_closes_on_any_key() {
         );
     }
 
-    // Compact is a takeover, not a truncated card: every binding fits at the minimum.
+    // At the 40x10 operability floor the shared modal card's own border+footer chrome
+    // leaves too few rows for every binding to fit at once (unlike the full-screen takeover
+    // this used to be): the card shows as many as it can starting from the top and marks
+    // the title `▼` so the cut-off is visible rather than silently dropped.
     let compact = rendered_board(&model, 40, 10);
-    for (chord, label) in normal_help_bindings() {
-        assert!(
-            compact.contains(chord),
-            "compact help missing {chord:?}\n{compact}"
-        );
-        assert!(
-            compact.contains(label),
-            "compact help missing {label:?}\n{compact}"
-        );
-    }
+    assert!(
+        compact.contains("help ▼"),
+        "compact help card must mark its title truncated: {compact:?}"
+    );
+    assert!(
+        compact.contains("any key close"),
+        "compact help card must keep its close legend: {compact:?}"
+    );
+    let (first_chord, first_label) = normal_help_bindings()[0];
+    assert!(
+        compact.contains(first_chord) && compact.contains(first_label),
+        "compact help card must show its first binding {first_chord:?}/{first_label:?}: {compact:?}"
+    );
 
     // Any key closes (including a letter that would quit in normal mode).
     let close = map_key(BoardInputMode::Help, press(KeyCode::Char('q'))).expect("any key");

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -394,7 +394,9 @@ fn esc_closes_transient_then_detail_then_quit_and_q_quits_only_in_normal() {
 fn rendered_board(model: &BoardModel, width: u16, height: u16) -> String {
     let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("test terminal");
     terminal
-        .draw(|frame| draw_board(frame, model))
+        .draw(|frame| {
+            let _ = draw_board(frame, model);
+        })
         .expect("draw");
     let buffer = terminal.backend().buffer();
     (0..height)
@@ -415,7 +417,9 @@ fn board_chrome_row(model: &BoardModel, mode: (u16, u16)) -> String {
         .expect("status row present at supported sizes");
     let mut terminal = Terminal::new(TestBackend::new(mode.0, mode.1)).expect("test terminal");
     terminal
-        .draw(|frame| draw_board(frame, model))
+        .draw(|frame| {
+            let _ = draw_board(frame, model);
+        })
         .expect("draw board");
     let buffer = terminal.backend().buffer().clone();
     (0..mode.0)
@@ -1352,7 +1356,9 @@ fn page_scroll_reaches_the_bottom_of_a_wrapping_note() {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).expect("test terminal");
         terminal
-            .draw(|frame| draw_board(frame, model))
+            .draw(|frame| {
+                let _ = draw_board(frame, model);
+            })
             .expect("draw");
         let buffer = terminal.backend().buffer().clone();
         (0..24)

--- a/tests/quick_add_capture.rs
+++ b/tests/quick_add_capture.rs
@@ -952,7 +952,9 @@ fn failed_save_keeps_the_draft_for_retry_or_cancel() {
 fn render_rows(model: &BoardModel, width: u16, height: u16) -> Vec<String> {
     let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("test terminal");
     terminal
-        .draw(|frame| draw_board(frame, model))
+        .draw(|frame| {
+            let _ = draw_board(frame, model);
+        })
         .expect("draw board");
     let buffer = terminal.backend().buffer();
     tsk_tui::ui::render::assert_buffer_mono(buffer);
@@ -1037,7 +1039,9 @@ fn capture_bar_renders_spaced_three_row_block_and_stays_bounded_without_color_sg
     )
     .expect("ANSI terminal");
     terminal
-        .draw(|frame| draw_board(frame, &model))
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
         .expect("ANSI draw");
     drop(terminal);
     let output = String::from_utf8(bytes.borrow().clone()).expect("ANSI output");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Builds on mouse text selection with shared centered modal cards for Help (`?`), Palette (`:`), and project scope (`P`).

### Copy polish

- **Board drag-copy**: left Down is deferred until Up, so dragging over a task row copies without also peeking/selecting. Bare click still peeks as before.
- **Project board / peek**: copyable rects start past the `│` gutter and task glyph/meta, so a drag on an open peek pastes notes without chrome. Page notes/steps use the same content-only rects.
- **Task-page title**: copyable starts past the status glyph and excludes the right-aligned status word (F-1).
- **Selection highlight**: reverse paint is clipped to those same copyable rects — multi-line drags no longer light up the peek gutter / chrome.
- **Click slop**: Chebyshev distance ≥ 2 before a press counts as a selection; one-cell wobble stays a click (F-4).
- **Hosts without Drag events**: a Down→Up move still counts as a selection.
- **Copy toast**: brief `copied` / `copy failed` clears itself after ~2s and restores any sticky status it covered (e.g. save-recovery) (F-3).
- **Gesture**: `DragSelectGesture` owns the deferral table and is unit-tested (F-5).

### Modal card

- Left/right `│` borders painted on content, padding, and legend rows (F-2). Goldens regenerated.

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
- [x] `peek_on_project_board_copy_excludes_pipe_gutter`
- [x] `task_page_title_copy_excludes_glyph_and_status_word`
- [x] `paint_selection_stays_inside_copyable_not_gutter`
- [x] `drag_select_gesture_defers_click_until_real_drag_or_release`
- [x] `one_cell_wobble_is_not_a_selection`
- [x] `ephemeral_toast_restores_sticky_save_recovery_banner`
- [ ] Live herdr smoke (not run — `HERDR_ENV` unset)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c02137c7-0c5d-487a-b0f8-4410c62815f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c02137c7-0c5d-487a-b0f8-4410c62815f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

