### PR TITLE
feat: board list scrollbar for overflowing decks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+Board list scrollbar: when the deck is taller than the viewport, a dim track (`│`)
+and solid thumb (`█`) paint on the right edge with a one-column gap so titles stay
+clear of the thumb. Selection-follow still keeps the selected row (and an open
+peek) on screen; a click on the track jumps selection to that fraction of the
+deck without peeking or opening the task page. The task page body scrollbar uses
+the same paint helper.
+
 Removed dark engines from the live tree: attention / NEEDS YOU poll, park/resume,
 dispatch/worktree recovery UI, and agent-link board plumbing. Store fields that
 old documents may still carry (`capsule`, `agent_meta`, `last_observed`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Unreleased
 
-Board list scrollbar: when the deck is taller than the viewport, a dim track (`│`)
-and solid thumb (`█`) paint on the right edge with a one-column gap so titles stay
-clear of the thumb. Selection-follow still keeps the selected row (and an open
-peek) on screen; a click on the track jumps selection to that fraction of the
-deck without peeking or opening the task page. The task page body scrollbar uses
-the same paint helper.
+Board list scrollbar: when the deck is taller than the viewport, a thinner thumb (`▌`)
+paints on the right edge with a one-column gap so titles stay clear of it. The gutter
+is blank and clickable (no `│` track). Titles and age wrap/fit instead of clipping to
+`…`. Clicking the gutter or dragging the thumb moves the viewport without changing
+selection or peeking. The current section header (desk, project, thread, DONE) pins
+under the tabs with a one-row gap once it would scroll off, and the next header
+replaces it. The task page body scrollbar uses the same paint helper, including
+gutter click and thumb drag.
 
 Removed dark engines from the live tree: attention / NEEDS YOU poll, park/resume,
 dispatch/worktree recovery UI, and agent-link board plumbing. Store fields that

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ letters do nothing, so typing in a focused board cannot complete or delete work.
 
 | Key | Does |
 | --- | --- |
-| `j` `k` or `↑` `↓` | move (the wheel does too) |
+| `j` `k` or `↑` `↓` | move selection |
+| wheel | scroll the list |
 | `alt+space` | start the selected task, or reopen it if it is done |
 | `alt+d` | done |
 | `alt+o` | reopen |

--- a/src/app.rs
+++ b/src/app.rs
@@ -708,6 +708,7 @@ pub fn apply_board_intent_with_save_recovery(
             BoardIntent::SelectNext
             | BoardIntent::SelectPrev
             | BoardIntent::SelectIndex(_)
+            | BoardIntent::SelectListIndex(_)
             | BoardIntent::OpenCommandPalette
             | BoardIntent::CommandNext
             | BoardIntent::CommandPrev

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,7 +29,7 @@ use crate::ui::input::{
 };
 use crate::ui::mouse::{
     capture_layout_for_model, enable_terminal_input, keyboard_enhancement_supported,
-    map_capture_mouse,
+    map_capture_mouse, scrollbar_hit_at, scrollbar_intent_at,
 };
 use crate::ui::queue::BoardTab;
 use crate::ui::scheduler;
@@ -299,10 +299,12 @@ fn run_board() -> Result<(), Box<dyn Error>> {
         // as content).
         let mut frame_rows: Vec<String> = Vec::new();
         let mut frame_copyable: Vec<Rect> = Vec::new();
+        let mut frame_hits = crate::ui::render::QueueHitMap::default();
         // Left Down is deferred until Up (or abandoned when a text drag grows): firing
         // the click on Down made every board-row drag also peek/toggle, so copy only
         // felt reliable on the task page where Down is inert over notes.
         let mut drag_gesture = crate::ui::text_select::DragSelectGesture::new();
+        let mut scrollbar_drag = false;
         loop {
             // Settle, paint, then wait. The board frame path does no host polling, so the
             // wait is only the Frame Scheduler's idle floor. All three are one call because
@@ -317,7 +319,8 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                         .draw(|frame| {
                             let hits = draw_board(frame, model);
                             frame_rows = frame_text_rows(frame.buffer_mut());
-                            frame_copyable = hits.copyable;
+                            frame_copyable = hits.copyable.clone();
+                            frame_hits = hits;
                         })
                         .map(|_| ())
                 },
@@ -335,6 +338,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                     // A key while the mouse button is held abandons the deferred click so
                     // Up does not fire a stale peek/select after the keyboard moved on.
                     drag_gesture.clear();
+                    scrollbar_drag = false;
                     let area = terminal_area(terminal)?;
                     // The painted mode owns the keyboard: `resolve_board_surface` resolves the
                     // same input mode at every terminal size (`board_input_mode_for_area` no
@@ -368,6 +372,47 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                     // so a drag does not also fire the Down-time peek/select path.
                     use crate::ui::text_select::{DragSelectOutcome, DragSelectPhase};
                     use crossterm::event::{MouseButton, MouseEventKind};
+                    let page = model.input_mode() == BoardInputMode::TaskPage;
+                    match mouse.kind {
+                        MouseEventKind::Down(MouseButton::Left) => {
+                            let pos = Position::new(mouse.column, mouse.row);
+                            if let Some(intent) = scrollbar_hit_at(&frame_hits, pos) {
+                                scrollbar_drag = true;
+                                drag_gesture.clear();
+                                if handle_board_intent(
+                                    &store,
+                                    &mut domain,
+                                    &mut model,
+                                    intent,
+                                    &mut save_recovery,
+                                )? {
+                                    break;
+                                }
+                                continue;
+                            }
+                            scrollbar_drag = false;
+                        }
+                        MouseEventKind::Drag(MouseButton::Left) if scrollbar_drag => {
+                            if let Some(intent) = scrollbar_intent_at(&frame_hits, mouse.row, page)
+                            {
+                                if handle_board_intent(
+                                    &store,
+                                    &mut domain,
+                                    &mut model,
+                                    intent,
+                                    &mut save_recovery,
+                                )? {
+                                    break;
+                                }
+                            }
+                            continue;
+                        }
+                        MouseEventKind::Up(MouseButton::Left) if scrollbar_drag => {
+                            scrollbar_drag = false;
+                            continue;
+                        }
+                        _ => {}
+                    }
                     let mut click = mouse;
                     match mouse.kind {
                         MouseEventKind::Drag(MouseButton::Left) => {
@@ -708,7 +753,8 @@ pub fn apply_board_intent_with_save_recovery(
             BoardIntent::SelectNext
             | BoardIntent::SelectPrev
             | BoardIntent::SelectIndex(_)
-            | BoardIntent::SelectListIndex(_)
+            | BoardIntent::ListScrollTo(_)
+            | BoardIntent::PageScrollTo(_)
             | BoardIntent::OpenCommandPalette
             | BoardIntent::CommandNext
             | BoardIntent::CommandPrev

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,7 +29,7 @@ use crate::ui::input::{
 };
 use crate::ui::mouse::{
     capture_layout_for_model, enable_terminal_input, keyboard_enhancement_supported,
-    map_capture_mouse, scrollbar_hit_at, scrollbar_intent_at,
+    map_capture_mouse, map_scrollbar_mouse, ScrollbarMouse,
 };
 use crate::ui::queue::BoardTab;
 use crate::ui::scheduler;
@@ -372,46 +372,30 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                     // so a drag does not also fire the Down-time peek/select path.
                     use crate::ui::text_select::{DragSelectOutcome, DragSelectPhase};
                     use crossterm::event::{MouseButton, MouseEventKind};
-                    let page = model.input_mode() == BoardInputMode::TaskPage;
-                    match mouse.kind {
-                        MouseEventKind::Down(MouseButton::Left) => {
-                            let pos = Position::new(mouse.column, mouse.row);
-                            if let Some(intent) = scrollbar_hit_at(&frame_hits, pos) {
-                                scrollbar_drag = true;
-                                drag_gesture.clear();
-                                if handle_board_intent(
-                                    &store,
-                                    &mut domain,
-                                    &mut model,
-                                    intent,
-                                    &mut save_recovery,
-                                )? {
-                                    break;
-                                }
-                                continue;
-                            }
-                            scrollbar_drag = false;
-                        }
-                        MouseEventKind::Drag(MouseButton::Left) if scrollbar_drag => {
-                            if let Some(intent) = scrollbar_intent_at(&frame_hits, mouse.row, page)
-                            {
-                                if handle_board_intent(
-                                    &store,
-                                    &mut domain,
-                                    &mut model,
-                                    intent,
-                                    &mut save_recovery,
-                                )? {
-                                    break;
-                                }
+                    match map_scrollbar_mouse(
+                        model.input_mode(),
+                        &frame_hits,
+                        mouse,
+                        &mut scrollbar_drag,
+                    ) {
+                        ScrollbarMouse::Miss => {}
+                        ScrollbarMouse::Intent(intent) => {
+                            drag_gesture.clear();
+                            if handle_board_intent(
+                                &store,
+                                &mut domain,
+                                &mut model,
+                                intent,
+                                &mut save_recovery,
+                            )? {
+                                break;
                             }
                             continue;
                         }
-                        MouseEventKind::Up(MouseButton::Left) if scrollbar_drag => {
-                            scrollbar_drag = false;
+                        ScrollbarMouse::Consumed => {
+                            drag_gesture.clear();
                             continue;
                         }
-                        _ => {}
                     }
                     let mut click = mouse;
                     match mouse.kind {

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -504,6 +504,10 @@ fn apply_board_intent(
             }
             return Ok(IntentOutcome::None);
         }
+        BoardIntent::SelectListIndex(idx) => {
+            model.select_index(idx);
+            return Ok(IntentOutcome::None);
+        }
         BoardIntent::BeginAddStep => {
             model.close_popup();
             // The step input lives on the task page's footer row; from any other

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -504,8 +504,8 @@ fn apply_board_intent(
             }
             return Ok(IntentOutcome::None);
         }
-        BoardIntent::SelectListIndex(idx) => {
-            model.select_index(idx);
+        BoardIntent::ListScrollTo(offset) => {
+            model.set_list_scroll(offset);
             return Ok(IntentOutcome::None);
         }
         BoardIntent::BeginAddStep => {
@@ -1034,6 +1034,15 @@ fn apply_board_intent(
                         form.steps.cursor = Some(index);
                         steps_scroll_to_cursor(form, index);
                     }
+                }
+            }
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::PageScrollTo(offset) => {
+            if let Some(form) = model.form.as_mut().filter(|form| form.is_task()) {
+                if model.input_mode == BoardInputMode::TaskPage {
+                    let horizon = form.notes_max_scroll.get();
+                    form.notes_scroll = offset.min(horizon);
                 }
             }
             return Ok(IntentOutcome::None);

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -636,8 +636,13 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
         now: SystemTime::now(),
         overlay,
         detail_open: model.detail_open,
+        list_scroll: model.list_scroll.get(),
+        follow_list: model.follow_list.get(),
     };
-    let hits = render::draw_queue_frame(frame, &frame_model, &geo);
+    let (hits, painted_list_scroll) = render::draw_queue_frame(frame, &frame_model, &geo);
+    if let Some(scroll) = painted_list_scroll {
+        model.list_scroll.set(scroll);
+    }
 
     // Board-form edits use the task page's status and verb rows rather than an inline rule row.
     if model.open_field_edit().is_some() && model.form.is_none() {

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -857,6 +857,7 @@ impl BoardModel {
             self.reveal_task_on_home(id);
             if self.visible_ids().contains(&id) {
                 self.selection_id = Some(id);
+                self.follow_list.set(true);
             } else {
                 // Anchor on the saved id's old position when it had one (an edit that
                 // left this lens); otherwise fall back to the pre-sync selection so an

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -1,5 +1,6 @@
 //! Session-only board state, forms, selection, and recovery presentation.
 
+use std::cell::Cell;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -572,6 +573,11 @@ pub struct BoardModel {
     /// The last left-button press cell, held until release so a drag can grow a text
     /// selection out of it. Presentation-only; a plain click never reads it.
     pub(super) mouse_press: Option<Position>,
+    /// List viewport offset. Scrollbar click/drag writes it; row click leaves it.
+    pub(super) list_scroll: Cell<usize>,
+    /// When true, the next paint nudges `list_scroll` so the selection is on screen
+    /// (keyboard / reanchor). Row click and scrollbar leave it false.
+    pub(super) follow_list: Cell<bool>,
     /// The live drag-selected screen region, cleared on the next press.
     pub(super) text_selection: Option<TextSelection>,
     /// When set, [`Self::message`] clears itself on the next idle tick after this instant.
@@ -635,6 +641,8 @@ impl BoardModel {
             command_query: String::new(),
             command_selected: 0,
             mouse_press: None,
+            list_scroll: Cell::new(0),
+            follow_list: Cell::new(true),
             text_selection: None,
             message_expires_at: None,
             message_restore: None,
@@ -1086,6 +1094,11 @@ impl BoardModel {
     /// Selected task id, if any.
     pub fn selected_id(&self) -> Option<Uuid> {
         self.selection_id
+    }
+
+    /// Current list viewport offset.
+    pub fn list_scroll(&self) -> usize {
+        self.list_scroll.get()
     }
 }
 
@@ -1566,10 +1579,12 @@ impl BoardModel {
                 .find(|id| visible.contains(id))
             {
                 self.selection_id = Some(id);
+                self.follow_list.set(true);
                 return;
             }
         }
         self.selection_id = None;
+        self.follow_list.set(true);
     }
 
     /// Re-pin selection after the visible set changes (edit bind wins while still visible).
@@ -1587,6 +1602,7 @@ impl BoardModel {
                 return;
             }
         }
+        self.follow_list.set(true);
         self.selection_id = selection::reanchor(previous, previous_visible, &new_visible);
         // `reanchor` defers when `previous` was `None`; if rows exist again (e.g. CancelSave
         // restored a completed task into the deck), seed rather than leave the pin empty.
@@ -1625,6 +1641,7 @@ impl BoardModel {
             None => ids[0],
         };
         self.selection_id = Some(next);
+        self.follow_list.set(true);
     }
 
     pub(super) fn select_prev(&mut self) {
@@ -1642,6 +1659,7 @@ impl BoardModel {
             Some(i) => ids[i - 1],
         };
         self.selection_id = Some(prev);
+        self.follow_list.set(true);
     }
 
     pub(super) fn select_index(&mut self, idx: usize) {
@@ -1653,7 +1671,14 @@ impl BoardModel {
         }
         if let Some(&id) = ids.get(idx) {
             self.selection_id = Some(id);
+            // Nudge only if this row is off-screen; a click on a visible row stays put.
+            self.follow_list.set(true);
         }
+    }
+
+    pub(super) fn set_list_scroll(&mut self, offset: usize) {
+        self.list_scroll.set(offset);
+        self.follow_list.set(false);
     }
 
     /// Set the session-only project focus. `None` returns home on the Desk tab.

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -118,9 +118,11 @@ pub enum BoardIntent {
     SelectPrev,
     /// Select visible list row by index (mouse row click).
     SelectIndex(usize),
-    /// Jump selection to a visible list row without peek or double-click side effects
-    /// (list scrollbar track click).
-    SelectListIndex(usize),
+    /// Jump the list viewport to a content offset without changing selection or peek
+    /// (list scrollbar track click / thumb drag).
+    ListScrollTo(usize),
+    /// Jump the task-page body to a content offset (page scrollbar track click / drag).
+    PageScrollTo(usize),
     SetStatus(HumanStatus),
     Complete,
     Reopen,
@@ -766,10 +768,9 @@ pub fn map_edit_paste(mode: BoardInputMode, text: &str) -> Option<BoardIntent> {
 /// Which primary board action an intent advances, if any.
 pub fn intent_primary_action(intent: &BoardIntent) -> Option<PrimaryBoardAction> {
     match intent {
-        BoardIntent::SelectNext
-        | BoardIntent::SelectPrev
-        | BoardIntent::SelectIndex(_)
-        | BoardIntent::SelectListIndex(_) => Some(PrimaryBoardAction::SelectTask),
+        BoardIntent::SelectNext | BoardIntent::SelectPrev | BoardIntent::SelectIndex(_) => {
+            Some(PrimaryBoardAction::SelectTask)
+        }
         BoardIntent::Complete => Some(PrimaryBoardAction::Complete),
         BoardIntent::Reopen => Some(PrimaryBoardAction::Reopen),
         BoardIntent::SoftDelete => Some(PrimaryBoardAction::SoftDelete),
@@ -854,6 +855,8 @@ pub fn intent_primary_action(intent: &BoardIntent) -> Option<PrimaryBoardAction>
         | BoardIntent::PageScrollDown
         | BoardIntent::PageWheelScrollUp
         | BoardIntent::PageWheelScrollDown
+        | BoardIntent::PageScrollTo(_)
+        | BoardIntent::ListScrollTo(_)
         | BoardIntent::ToggleDoneDrawer
         | BoardIntent::OpenHelp
         | BoardIntent::CloseLayer

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -118,6 +118,9 @@ pub enum BoardIntent {
     SelectPrev,
     /// Select visible list row by index (mouse row click).
     SelectIndex(usize),
+    /// Jump selection to a visible list row without peek or double-click side effects
+    /// (list scrollbar track click).
+    SelectListIndex(usize),
     SetStatus(HumanStatus),
     Complete,
     Reopen,
@@ -763,9 +766,10 @@ pub fn map_edit_paste(mode: BoardInputMode, text: &str) -> Option<BoardIntent> {
 /// Which primary board action an intent advances, if any.
 pub fn intent_primary_action(intent: &BoardIntent) -> Option<PrimaryBoardAction> {
     match intent {
-        BoardIntent::SelectNext | BoardIntent::SelectPrev | BoardIntent::SelectIndex(_) => {
-            Some(PrimaryBoardAction::SelectTask)
-        }
+        BoardIntent::SelectNext
+        | BoardIntent::SelectPrev
+        | BoardIntent::SelectIndex(_)
+        | BoardIntent::SelectListIndex(_) => Some(PrimaryBoardAction::SelectTask),
         BoardIntent::Complete => Some(PrimaryBoardAction::Complete),
         BoardIntent::Reopen => Some(PrimaryBoardAction::Reopen),
         BoardIntent::SoftDelete => Some(PrimaryBoardAction::SoftDelete),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod mouse;
 pub mod queue;
 pub mod render;
 pub mod scheduler;
+pub mod scrollbar;
 pub mod selection;
 pub mod text_select;
 pub mod tier;

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -415,6 +415,54 @@ pub fn scrollbar_intent_at(hits: &QueueHitMap, row: u16, page: bool) -> Option<B
     scrollbar_target_intent(chosen.target)
 }
 
+/// Result of routing a pointer event through the scrollbar grab zone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScrollbarMouse {
+    /// Not a scrollbar event; the rest of the mouse path should run.
+    Miss,
+    /// Dispatch this intent and skip the rest of the mouse path.
+    Intent(BoardIntent),
+    /// Drag ended; swallow the Up so it does not become a click.
+    Consumed,
+}
+
+/// List/page scrollbar pointer state machine. Overlays (palette, picker, help)
+/// miss so a gutter click still dismisses them.
+pub fn map_scrollbar_mouse(
+    mode: BoardInputMode,
+    hits: &QueueHitMap,
+    mouse: MouseEvent,
+    dragging: &mut bool,
+) -> ScrollbarMouse {
+    if !matches!(mode, BoardInputMode::Normal | BoardInputMode::TaskPage) {
+        *dragging = false;
+        return ScrollbarMouse::Miss;
+    }
+    let page = mode == BoardInputMode::TaskPage;
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            let pos = Position::new(mouse.column, mouse.row);
+            if let Some(intent) = scrollbar_hit_at(hits, pos) {
+                *dragging = true;
+                ScrollbarMouse::Intent(intent)
+            } else {
+                *dragging = false;
+                ScrollbarMouse::Miss
+            }
+        }
+        MouseEventKind::Drag(MouseButton::Left) if *dragging => {
+            scrollbar_intent_at(hits, mouse.row, page)
+                .map(ScrollbarMouse::Intent)
+                .unwrap_or(ScrollbarMouse::Consumed)
+        }
+        MouseEventKind::Up(MouseButton::Left) if *dragging => {
+            *dragging = false;
+            ScrollbarMouse::Consumed
+        }
+        _ => ScrollbarMouse::Miss,
+    }
+}
+
 fn wheel_board_intent(model: &BoardModel, kind: MouseEventKind) -> Option<BoardIntent> {
     match model.input_mode() {
         BoardInputMode::TaskPage => match kind {

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -368,6 +368,53 @@ fn hit_at(hits: &QueueHitMap, pos: Position) -> Option<QueueHitTarget> {
         .map(|hit| hit.target)
 }
 
+fn scrollbar_target_intent(target: QueueHitTarget) -> Option<BoardIntent> {
+    match target {
+        QueueHitTarget::ListScroll(offset) => Some(BoardIntent::ListScrollTo(offset)),
+        QueueHitTarget::PageScroll(offset) => Some(BoardIntent::PageScrollTo(offset)),
+        _ => None,
+    }
+}
+
+/// Scrollbar intent for a press that actually lands on the grab zone.
+pub fn scrollbar_hit_at(hits: &QueueHitMap, pos: Position) -> Option<BoardIntent> {
+    hit_at(hits, pos).and_then(scrollbar_target_intent)
+}
+
+/// Scrollbar intent for a drag: clamp `row` to the track even if the pointer left it.
+pub fn scrollbar_intent_at(hits: &QueueHitMap, row: u16, page: bool) -> Option<BoardIntent> {
+    let mut cells: Vec<&crate::ui::render::QueueHit> = hits
+        .regions
+        .iter()
+        .filter(|hit| match hit.target {
+            QueueHitTarget::PageScroll(_) if page => true,
+            QueueHitTarget::ListScroll(_) if !page => true,
+            _ => false,
+        })
+        .collect();
+    if cells.is_empty() {
+        return None;
+    }
+    cells.sort_by_key(|hit| hit.area.y);
+    let first = cells[0];
+    let last = cells[cells.len() - 1];
+    let chosen = if row <= first.area.y {
+        first
+    } else if row >= last.area.y {
+        last
+    } else {
+        cells
+            .iter()
+            .copied()
+            .find(|hit| {
+                let end = hit.area.y.saturating_add(hit.area.height.max(1));
+                (hit.area.y..end).contains(&row)
+            })
+            .unwrap_or(first)
+    };
+    scrollbar_target_intent(chosen.target)
+}
+
 fn wheel_board_intent(model: &BoardModel, kind: MouseEventKind) -> Option<BoardIntent> {
     match model.input_mode() {
         BoardInputMode::TaskPage => match kind {
@@ -375,17 +422,15 @@ fn wheel_board_intent(model: &BoardModel, kind: MouseEventKind) -> Option<BoardI
             MouseEventKind::ScrollDown => Some(BoardIntent::PageWheelScrollDown),
             _ => None,
         },
-        BoardInputMode::Normal => {
-            let visible = model.visible_ids().len();
-            let selected = model.selected_index()?;
-            match kind {
-                MouseEventKind::ScrollUp if selected > 0 => Some(BoardIntent::SelectPrev),
-                MouseEventKind::ScrollDown if selected + 1 < visible => {
-                    Some(BoardIntent::SelectNext)
-                }
-                _ => None,
-            }
-        }
+        BoardInputMode::Normal => match kind {
+            MouseEventKind::ScrollUp => Some(BoardIntent::ListScrollTo(
+                model.list_scroll().saturating_sub(1),
+            )),
+            MouseEventKind::ScrollDown => Some(BoardIntent::ListScrollTo(
+                model.list_scroll().saturating_add(1),
+            )),
+            _ => None,
+        },
         BoardInputMode::Palette => {
             let len = model.visible_commands().len();
             let selected = model.command_selected()?;
@@ -478,6 +523,7 @@ pub fn map_board_mouse(
             // A click on an step row selects it (AC-21) — the board's click
             // convention: a click selects, never mutates.
             Some(QueueHitTarget::Step(index)) => Some(BoardIntent::SelectStep(index)),
+            Some(QueueHitTarget::PageScroll(offset)) => Some(BoardIntent::PageScrollTo(offset)),
             Some(QueueHitTarget::Verb(index)) => verb_intent(model, index),
             _ => None,
         },
@@ -514,11 +560,7 @@ pub fn map_board_mouse(
                 .iter()
                 .position(|&visible| visible == id)
                 .map(BoardIntent::SelectIndex),
-            Some(QueueHitTarget::ListScrollSelect(id)) => model
-                .visible_ids()
-                .iter()
-                .position(|&visible| visible == id)
-                .map(BoardIntent::SelectListIndex),
+            Some(QueueHitTarget::ListScroll(offset)) => Some(BoardIntent::ListScrollTo(offset)),
             Some(QueueHitTarget::Verb(index)) => verb_intent(model, index),
             Some(QueueHitTarget::DeleteNoticeUndo) => Some(BoardIntent::Undo),
             _ => None,

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -514,6 +514,11 @@ pub fn map_board_mouse(
                 .iter()
                 .position(|&visible| visible == id)
                 .map(BoardIntent::SelectIndex),
+            Some(QueueHitTarget::ListScrollSelect(id)) => model
+                .visible_ids()
+                .iter()
+                .position(|&visible| visible == id)
+                .map(BoardIntent::SelectListIndex),
             Some(QueueHitTarget::Verb(index)) => verb_intent(model, index),
             Some(QueueHitTarget::DeleteNoticeUndo) => Some(BoardIntent::Undo),
             _ => None,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -770,7 +770,7 @@ pub fn draw_queue_frame(
             if base_list_interactive {
                 let zone = scrollbar::grab_zone(track);
                 for row in 0..track.height {
-                    let jump = scrollbar::click_to_offset(row, track.height, total, viewport_h);
+                    let jump = scrollbar::click_to_offset(row, track.height, total, min_content);
                     hits.push(
                         QueueHitTarget::ListScroll(jump),
                         Rect::new(zone.x, track.y.saturating_add(row), zone.width, 1),

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -22,6 +22,7 @@ use super::present_line;
 use super::queue::{
     BoardTab, QueueSection, QueueView, SectionKind, StatusCounts, ThreadProjectCollapseKey,
 };
+use super::scrollbar;
 use super::tier::{Tier, TierGeometry};
 use crate::domain::{HumanStatus, Task, TaskScope};
 
@@ -560,6 +561,10 @@ pub enum QueueHitTarget {
     /// One painted option in a shared form's scope dropdown, indexed into that form's own
     /// `TaskScope` choices. It cannot name the board selector's all-projects choice.
     FormScopeOption(usize),
+    /// One cell of the board list's overflow scrollbar track. Selecting it jumps the
+    /// viewport (and the pinned selection) to keep that task on screen — the mouse
+    /// counterpart of walking ↑/↓ until the thumb reaches that fraction of the deck.
+    ListScrollSelect(Uuid),
     /// The `u Undo` control inside the delete-recovery notice on the status line (I2,
     /// round 2), positioned wherever [`paint_status_line`] actually put it -- which shifts
     /// with the deleted title's length and with whether a later message is composed after
@@ -670,9 +675,28 @@ pub fn draw_queue_frame(
     let base_list_interactive = true;
 
     if geo.viewport_height > 0 && !page_active {
-        let (list_rows, anchor_last_idx, selected_idx) = build_list_rows(model, geo);
+        // First pass measures overflow at the full row width; when a scrollbar is
+        // needed, rebuild at the narrowed content width so wrapped titles and the
+        // thumb share one consistent row count.
+        let (mut list_rows, mut anchor_last_idx, mut selected_idx) = build_list_rows(model, geo);
         let top = geo.viewport_top;
         let viewport_h = geo.viewport_height as usize;
+        let (_, provisional_track) =
+            scrollbar::split_for_scrollbar(0, top, width, geo.viewport_height, list_rows.len());
+        let list_geo = if provisional_track.is_some() {
+            let mut narrowed = *geo;
+            narrowed.row_width = width.saturating_sub(scrollbar::SCROLLBAR_RESERVE_COLS);
+            let rebuilt = build_list_rows(model, &narrowed);
+            list_rows = rebuilt.0;
+            anchor_last_idx = rebuilt.1;
+            selected_idx = rebuilt.2;
+            narrowed
+        } else {
+            *geo
+        };
+        let content_width = list_geo.row_width;
+        let (_, track) =
+            scrollbar::split_for_scrollbar(0, top, width, geo.viewport_height, list_rows.len());
         // An expanded accordion can land past the viewport on a long deck. Keep its complete
         // block visible, and otherwise follow the plain selection so mutating verbs never act
         // on an invisible row.
@@ -681,6 +705,15 @@ pub fn draw_queue_frame(
             Some(idx) if idx >= viewport_h => idx + 1 - viewport_h,
             _ => 0,
         };
+        // Per absolute list-row index: the task id that row belongs to (headers/blanks
+        // are None). Scrollbar clicks pick the nearest task at their jump offset.
+        let row_tasks: Vec<Option<Uuid>> = list_rows
+            .iter()
+            .map(|row| match row {
+                ListRow::Task { id, .. } => Some(*id),
+                _ => None,
+            })
+            .collect();
         for (offset, list_row) in list_rows
             .into_iter()
             .skip(scroll)
@@ -689,28 +722,28 @@ pub fn draw_queue_frame(
         {
             let y = top + offset as u16;
             match list_row {
-                ListRow::Blank => put_line(frame, y, width, Line::from("")),
+                ListRow::Blank => put_line(frame, y, content_width, Line::from("")),
                 ListRow::Header(kind, _section_idx, line) => {
-                    put_line(frame, y, width, line);
+                    put_line(frame, y, content_width, line);
                     if kind == SectionKind::Done && base_list_interactive {
-                        hits.push(QueueHitTarget::Drawer, Rect::new(0, y, width, 1));
+                        hits.push(QueueHitTarget::Drawer, Rect::new(0, y, content_width, 1));
                     }
                 }
                 ListRow::ProjectGroupHeader { section_idx, line } => {
-                    put_line(frame, y, width, line);
+                    put_line(frame, y, content_width, line);
                     if base_list_interactive {
                         hits.push(
                             QueueHitTarget::SectionProject(section_idx),
-                            Rect::new(0, y, width, 1),
+                            Rect::new(0, y, content_width, 1),
                         );
                     }
                 }
                 ListRow::ThreadGroupHeader { section_idx, line } => {
-                    put_line(frame, y, width, line);
+                    put_line(frame, y, content_width, line);
                     if base_list_interactive {
                         hits.push(
                             QueueHitTarget::SectionThread(section_idx),
-                            Rect::new(0, y, width, 1),
+                            Rect::new(0, y, content_width, 1),
                         );
                     }
                 }
@@ -719,41 +752,56 @@ pub fn draw_queue_frame(
                     subgroup_idx,
                     line,
                 } => {
-                    put_line(frame, y, width, line);
+                    put_line(frame, y, content_width, line);
                     if base_list_interactive {
                         hits.push(
                             QueueHitTarget::SectionThreadProject {
                                 section_idx,
                                 subgroup_idx,
                             },
-                            Rect::new(0, y, width, 1),
+                            Rect::new(0, y, content_width, 1),
                         );
                     }
                 }
                 ListRow::Hint(line) | ListRow::ThreadHeader(line) => {
-                    put_line(frame, y, width, line)
+                    put_line(frame, y, content_width, line)
                 }
                 ListRow::Task {
                     id,
                     line,
                     content_x,
-                    content_width,
+                    content_width: copy_w,
                 } => {
-                    put_line(frame, y, width, line);
+                    put_line(frame, y, content_width, line);
                     if base_list_interactive {
-                        hits.push(QueueHitTarget::Task(id), Rect::new(0, y, width, 1));
+                        hits.push(QueueHitTarget::Task(id), Rect::new(0, y, content_width, 1));
                     }
                     // Title text only: indent, glyph, and right-side meta stay out of the copy.
-                    hits.push_copyable(Rect::new(content_x, y, content_width, 1));
+                    hits.push_copyable(Rect::new(content_x, y, copy_w, 1));
                 }
                 ListRow::Detail {
                     line,
                     content_x,
-                    content_width,
+                    content_width: copy_w,
                 } => {
-                    put_line(frame, y, width, line);
+                    put_line(frame, y, content_width, line);
                     // Peek body past the `│` gutter — the pipe is chrome, not notes.
-                    hits.push_copyable(Rect::new(content_x, y, content_width, 1));
+                    hits.push_copyable(Rect::new(content_x, y, copy_w, 1));
+                }
+            }
+        }
+        if let Some(track) = track {
+            let total = row_tasks.len();
+            scrollbar::paint(frame, track, scroll, total);
+            if base_list_interactive {
+                for row in 0..track.height {
+                    let jump = scrollbar::click_to_offset(row, track.height, total, viewport_h);
+                    if let Some(id) = nearest_task_id(&row_tasks, jump) {
+                        hits.push(
+                            QueueHitTarget::ListScrollSelect(id),
+                            Rect::new(track.x, track.y.saturating_add(row), 1, 1),
+                        );
+                    }
                 }
             }
         }
@@ -2111,28 +2159,24 @@ fn paint_page_scrollbar(
     scroll: usize,
     total_rows: usize,
 ) {
-    let viewport = lay.notes_rows as usize;
-    if width == 0 || viewport == 0 || total_rows <= viewport {
+    let viewport = lay.notes_rows;
+    if width == 0 || viewport == 0 || !scrollbar::needs_scrollbar(total_rows, viewport as usize) {
         return;
     }
-    let thumb_rows = (viewport * viewport).div_ceil(total_rows).max(1);
-    let travel = viewport.saturating_sub(thumb_rows);
-    let max_scroll = total_rows.saturating_sub(viewport);
-    let thumb_start = scroll
-        .saturating_mul(travel)
-        .checked_div(max_scroll)
-        .unwrap_or(0);
-    for row in 0..viewport {
-        let glyph = if (thumb_start..thumb_start + thumb_rows).contains(&row) {
-            "█"
-        } else {
-            "│"
-        };
-        frame.render_widget(
-            Paragraph::new(Span::styled(glyph, style_dim())),
-            Rect::new(width - 1, lay.notes_y.saturating_add(row as u16), 1, 1),
-        );
+    let track = Rect::new(width - 1, lay.notes_y, 1, viewport);
+    scrollbar::paint(frame, track, scroll, total_rows);
+}
+
+/// Nearest task id at or after `row`, falling back to the nearest earlier task.
+fn nearest_task_id(row_tasks: &[Option<Uuid>], row: usize) -> Option<Uuid> {
+    if row_tasks.is_empty() {
+        return None;
     }
+    let start = row.min(row_tasks.len().saturating_sub(1));
+    if let Some(id) = row_tasks[start..].iter().flatten().next() {
+        return Some(*id);
+    }
+    row_tasks[..=start].iter().rev().flatten().next().copied()
 }
 
 /// The page's scope chooser stacks its options directly above the scope footer (left,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -503,6 +503,10 @@ pub struct QueueFrameModel<'a> {
     /// Standard: expands inline under the selected row. Compact: full-viewport takeover.
     /// Only painted while `overlay` is `QueueOverlay::None`.
     pub detail_open: Option<Uuid>,
+    /// List viewport offset. Scrollbar and the last paint persist this; row click leaves it.
+    pub list_scroll: usize,
+    /// Nudge `list_scroll` so the selection (or its peek) stays on screen.
+    pub follow_list: bool,
 }
 
 /// Logical control under a painted rectangle (rebuilt every frame).
@@ -561,10 +565,11 @@ pub enum QueueHitTarget {
     /// One painted option in a shared form's scope dropdown, indexed into that form's own
     /// `TaskScope` choices. It cannot name the board selector's all-projects choice.
     FormScopeOption(usize),
-    /// One cell of the board list's overflow scrollbar track. Selecting it jumps the
-    /// viewport (and the pinned selection) to keep that task on screen — the mouse
-    /// counterpart of walking ↑/↓ until the thumb reaches that fraction of the deck.
-    ListScrollSelect(Uuid),
+    /// One cell of the board list's overflow scrollbar (track or thumb). The usize is the
+    /// content offset that cell jumps the viewport to. Does not change selection or peek.
+    ListScroll(usize),
+    /// One cell of the task-page body scrollbar. The usize is the notes/steps offset.
+    PageScroll(usize),
     /// The `u Undo` control inside the delete-recovery notice on the status line (I2,
     /// round 2), positioned wherever [`paint_status_line`] actually put it -- which shifts
     /// with the deleted title's length and with whether a later message is composed after
@@ -637,20 +642,21 @@ pub fn status_glyph(status: HumanStatus) -> &'static str {
 
 /// Paint the the queue frame: selector, list, rule, status, verb bar.
 ///
-/// Returns the hit-map recorded beside the paint. Never panics on tiny
-/// geometries; every painted line is width-bounded to `geo.row_width`.
+/// Returns the hit-map recorded beside the paint, plus the list viewport offset
+/// used this frame (`None` when the list was not painted).
 pub fn draw_queue_frame(
     frame: &mut Frame<'_>,
     model: &QueueFrameModel<'_>,
     geo: &TierGeometry,
-) -> QueueHitMap {
+) -> (QueueHitMap, Option<usize>) {
     let input_slot_geo = bottom_input_slot_geometry(*geo, &model.overlay);
     let geo = &input_slot_geo;
     let mut hits = QueueHitMap::default();
+    let mut painted_list_scroll = None;
     let width = geo.row_width;
     let height = geo.height;
     if width == 0 || height == 0 {
-        return hits;
+        return (hits, None);
     }
 
     // Clear the frame so leftover cells never leak chrome between sizes.
@@ -684,8 +690,8 @@ pub fn draw_queue_frame(
         let (_, provisional_track) =
             scrollbar::split_for_scrollbar(0, top, width, geo.viewport_height, list_rows.len());
         let list_geo = if provisional_track.is_some() {
-            let mut narrowed = *geo;
-            narrowed.row_width = width.saturating_sub(scrollbar::SCROLLBAR_RESERVE_COLS);
+            let narrowed =
+                geo.with_row_width(width.saturating_sub(scrollbar::SCROLLBAR_RESERVE_COLS));
             let rebuilt = build_list_rows(model, &narrowed);
             list_rows = rebuilt.0;
             anchor_last_idx = rebuilt.1;
@@ -697,114 +703,82 @@ pub fn draw_queue_frame(
         let content_width = list_geo.row_width;
         let (_, track) =
             scrollbar::split_for_scrollbar(0, top, width, geo.viewport_height, list_rows.len());
-        // An expanded accordion can land past the viewport on a long deck. Keep its complete
-        // block visible, and otherwise follow the plain selection so mutating verbs never act
-        // on an invisible row.
+        // Row click and scrollbar drag persist list_scroll and leave the viewport
+        // where it is. Keyboard selection sets follow_list so a row that walked
+        // off-screen is nudged back, without parking the peek at the bottom.
         let follow_idx = anchor_last_idx.or(selected_idx);
-        let scroll = match follow_idx {
-            Some(idx) if idx >= viewport_h => idx + 1 - viewport_h,
-            _ => 0,
+        let has_headers = list_rows.iter().any(ListRow::is_sticky_header);
+        let min_content = if has_headers {
+            viewport_h.saturating_sub(2).max(1)
+        } else {
+            viewport_h
         };
-        // Per absolute list-row index: the task id that row belongs to (headers/blanks
-        // are None). Scrollbar clicks pick the nearest task at their jump offset.
-        let row_tasks: Vec<Option<Uuid>> = list_rows
-            .iter()
-            .map(|row| match row {
-                ListRow::Task { id, .. } => Some(*id),
-                _ => None,
-            })
-            .collect();
-        for (offset, list_row) in list_rows
-            .into_iter()
-            .skip(scroll)
-            .take(viewport_h)
-            .enumerate()
-        {
-            let y = top + offset as u16;
-            match list_row {
-                ListRow::Blank => put_line(frame, y, content_width, Line::from("")),
-                ListRow::Header(kind, _section_idx, line) => {
-                    put_line(frame, y, content_width, line);
-                    if kind == SectionKind::Done && base_list_interactive {
-                        hits.push(QueueHitTarget::Drawer, Rect::new(0, y, content_width, 1));
-                    }
-                }
-                ListRow::ProjectGroupHeader { section_idx, line } => {
-                    put_line(frame, y, content_width, line);
-                    if base_list_interactive {
-                        hits.push(
-                            QueueHitTarget::SectionProject(section_idx),
-                            Rect::new(0, y, content_width, 1),
-                        );
-                    }
-                }
-                ListRow::ThreadGroupHeader { section_idx, line } => {
-                    put_line(frame, y, content_width, line);
-                    if base_list_interactive {
-                        hits.push(
-                            QueueHitTarget::SectionThread(section_idx),
-                            Rect::new(0, y, content_width, 1),
-                        );
-                    }
-                }
-                ListRow::ThreadProjectHeader {
-                    section_idx,
-                    subgroup_idx,
-                    line,
-                } => {
-                    put_line(frame, y, content_width, line);
-                    if base_list_interactive {
-                        hits.push(
-                            QueueHitTarget::SectionThreadProject {
-                                section_idx,
-                                subgroup_idx,
-                            },
-                            Rect::new(0, y, content_width, 1),
-                        );
-                    }
-                }
-                ListRow::Hint(line) | ListRow::ThreadHeader(line) => {
-                    put_line(frame, y, content_width, line)
-                }
-                ListRow::Task {
-                    id,
-                    line,
-                    content_x,
-                    content_width: copy_w,
-                } => {
-                    put_line(frame, y, content_width, line);
-                    if base_list_interactive {
-                        hits.push(QueueHitTarget::Task(id), Rect::new(0, y, content_width, 1));
-                    }
-                    // Title text only: indent, glyph, and right-side meta stay out of the copy.
-                    hits.push_copyable(Rect::new(content_x, y, copy_w, 1));
-                }
-                ListRow::Detail {
-                    line,
-                    content_x,
-                    content_width: copy_w,
-                } => {
-                    put_line(frame, y, content_width, line);
-                    // Peek body past the `│` gutter — the pipe is chrome, not notes.
-                    hits.push_copyable(Rect::new(content_x, y, copy_w, 1));
+        let max_scroll = list_rows.len().saturating_sub(min_content);
+        let mut scroll = model.list_scroll.min(max_scroll);
+        if model.follow_list {
+            let pin = if model.detail_open.is_some() && model.detail_open == model.selection_id {
+                selected_idx
+            } else {
+                follow_idx
+            };
+            if let Some(idx) = pin {
+                let visible_h = viewport_h
+                    .saturating_sub(header_chrome_rows(&list_rows, scroll))
+                    .max(1);
+                if idx < scroll {
+                    scroll = idx;
+                } else if idx >= scroll.saturating_add(visible_h) {
+                    scroll = idx
+                        .saturating_add(1)
+                        .saturating_sub(min_content)
+                        .min(max_scroll);
                 }
             }
+        }
+        let sticky = sticky_header_at(&list_rows, scroll);
+        let first_is_header = list_rows.get(scroll).is_some_and(ListRow::is_sticky_header);
+        let mut y = top;
+        if sticky.is_some() || first_is_header {
+            put_line(frame, y, content_width, Line::from(""));
+            y = y.saturating_add(1);
+        }
+        if let Some(header_idx) = sticky {
+            paint_list_row(
+                frame,
+                &mut hits,
+                &list_rows[header_idx],
+                y,
+                content_width,
+                base_list_interactive,
+            );
+            y = y.saturating_add(1);
+        }
+        let content_h = viewport_h.saturating_sub((y - top) as usize);
+        for (offset, list_row) in list_rows.iter().skip(scroll).take(content_h).enumerate() {
+            paint_list_row(
+                frame,
+                &mut hits,
+                list_row,
+                y.saturating_add(offset as u16),
+                content_width,
+                base_list_interactive,
+            );
         }
         if let Some(track) = track {
-            let total = row_tasks.len();
+            let total = list_rows.len();
             scrollbar::paint(frame, track, scroll, total);
             if base_list_interactive {
+                let zone = scrollbar::grab_zone(track);
                 for row in 0..track.height {
                     let jump = scrollbar::click_to_offset(row, track.height, total, viewport_h);
-                    if let Some(id) = nearest_task_id(&row_tasks, jump) {
-                        hits.push(
-                            QueueHitTarget::ListScrollSelect(id),
-                            Rect::new(track.x, track.y.saturating_add(row), 1, 1),
-                        );
-                    }
+                    hits.push(
+                        QueueHitTarget::ListScroll(jump),
+                        Rect::new(zone.x, track.y.saturating_add(row), zone.width, 1),
+                    );
                 }
             }
         }
+        painted_list_scroll = Some(scroll);
     }
 
     if let Some(row) = geo.rule_row {
@@ -896,7 +870,7 @@ pub fn draw_queue_frame(
 
     paint_overlay(frame, model, geo, &mut hits);
 
-    hits
+    (hits, painted_list_scroll)
 }
 
 /// Reserve breathing room around a shared bottom input by taking two rows from the list.
@@ -2121,7 +2095,7 @@ fn paint_task_page(
         );
     }
     if content.max_scroll > 0 {
-        paint_page_scrollbar(frame, &lay, width, scroll, content.total_rows);
+        paint_page_scrollbar(frame, hits, &lay, width, scroll, content.total_rows);
     }
 
     // Meta footer: scope · thread · created · updated. It remains available while a step
@@ -2154,6 +2128,7 @@ fn paint_task_page(
 /// render notes and steps.
 fn paint_page_scrollbar(
     frame: &mut Frame<'_>,
+    hits: &mut QueueHitMap,
     lay: &TaskPageLayout,
     width: u16,
     scroll: usize,
@@ -2165,18 +2140,14 @@ fn paint_page_scrollbar(
     }
     let track = Rect::new(width - 1, lay.notes_y, 1, viewport);
     scrollbar::paint(frame, track, scroll, total_rows);
-}
-
-/// Nearest task id at or after `row`, falling back to the nearest earlier task.
-fn nearest_task_id(row_tasks: &[Option<Uuid>], row: usize) -> Option<Uuid> {
-    if row_tasks.is_empty() {
-        return None;
+    let zone = scrollbar::grab_zone(track);
+    for row in 0..track.height {
+        let jump = scrollbar::click_to_offset(row, track.height, total_rows, viewport as usize);
+        hits.push(
+            QueueHitTarget::PageScroll(jump),
+            Rect::new(zone.x, track.y.saturating_add(row), zone.width, 1),
+        );
     }
-    let start = row.min(row_tasks.len().saturating_sub(1));
-    if let Some(id) = row_tasks[start..].iter().flatten().next() {
-        return Some(*id);
-    }
-    row_tasks[..=start].iter().rev().flatten().next().copied()
 }
 
 /// The page's scope chooser stacks its options directly above the scope footer (left,
@@ -2352,6 +2323,121 @@ enum ListRow {
         content_x: u16,
         content_width: u16,
     },
+}
+
+impl ListRow {
+    fn is_sticky_header(&self) -> bool {
+        matches!(
+            self,
+            ListRow::Header(..)
+                | ListRow::ProjectGroupHeader { .. }
+                | ListRow::ThreadGroupHeader { .. }
+                | ListRow::ThreadProjectHeader { .. }
+                | ListRow::ThreadHeader(_)
+        )
+    }
+}
+
+/// Last section header strictly above `scroll`. None when `scroll` is already on a header
+/// (that header is naturally at the top) or nothing has been scrolled past.
+fn sticky_header_at(rows: &[ListRow], scroll: usize) -> Option<usize> {
+    if scroll == 0 || rows.is_empty() {
+        return None;
+    }
+    let scroll = scroll.min(rows.len());
+    if scroll < rows.len() && rows[scroll].is_sticky_header() {
+        return None;
+    }
+    rows[..scroll]
+        .iter()
+        .rposition(|row| row.is_sticky_header())
+}
+
+/// Rows the viewport spends on a blank-under-tabs gap and a pinned header.
+fn header_chrome_rows(rows: &[ListRow], scroll: usize) -> usize {
+    if sticky_header_at(rows, scroll).is_some() {
+        2
+    } else if rows.get(scroll).is_some_and(ListRow::is_sticky_header) {
+        1
+    } else {
+        0
+    }
+}
+
+fn paint_list_row(
+    frame: &mut Frame<'_>,
+    hits: &mut QueueHitMap,
+    list_row: &ListRow,
+    y: u16,
+    content_width: u16,
+    base_list_interactive: bool,
+) {
+    match list_row {
+        ListRow::Blank => put_line(frame, y, content_width, Line::from("")),
+        ListRow::Header(kind, _section_idx, line) => {
+            put_line(frame, y, content_width, line.clone());
+            if *kind == SectionKind::Done && base_list_interactive {
+                hits.push(QueueHitTarget::Drawer, Rect::new(0, y, content_width, 1));
+            }
+        }
+        ListRow::ProjectGroupHeader { section_idx, line } => {
+            put_line(frame, y, content_width, line.clone());
+            if base_list_interactive {
+                hits.push(
+                    QueueHitTarget::SectionProject(*section_idx),
+                    Rect::new(0, y, content_width, 1),
+                );
+            }
+        }
+        ListRow::ThreadGroupHeader { section_idx, line } => {
+            put_line(frame, y, content_width, line.clone());
+            if base_list_interactive {
+                hits.push(
+                    QueueHitTarget::SectionThread(*section_idx),
+                    Rect::new(0, y, content_width, 1),
+                );
+            }
+        }
+        ListRow::ThreadProjectHeader {
+            section_idx,
+            subgroup_idx,
+            line,
+        } => {
+            put_line(frame, y, content_width, line.clone());
+            if base_list_interactive {
+                hits.push(
+                    QueueHitTarget::SectionThreadProject {
+                        section_idx: *section_idx,
+                        subgroup_idx: *subgroup_idx,
+                    },
+                    Rect::new(0, y, content_width, 1),
+                );
+            }
+        }
+        ListRow::Hint(line) | ListRow::ThreadHeader(line) => {
+            put_line(frame, y, content_width, line.clone())
+        }
+        ListRow::Task {
+            id,
+            line,
+            content_x,
+            content_width: copy_w,
+        } => {
+            put_line(frame, y, content_width, line.clone());
+            if base_list_interactive {
+                hits.push(QueueHitTarget::Task(*id), Rect::new(0, y, content_width, 1));
+            }
+            hits.push_copyable(Rect::new(*content_x, y, *copy_w, 1));
+        }
+        ListRow::Detail {
+            line,
+            content_x,
+            content_width: copy_w,
+        } => {
+            put_line(frame, y, content_width, line.clone());
+            hits.push_copyable(Rect::new(*content_x, y, *copy_w, 1));
+        }
+    }
 }
 
 /// Read-only accordion body under an expanded task: notes preview,

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -1,0 +1,167 @@
+//! Vertical mono scrollbar: dim track (`│`) and solid thumb (`█`).
+//!
+//! Space is reserved only when content overflows the viewport. Callers paint the
+//! track in the last column and leave a one-column gap beside it.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+fn style_dim() -> Style {
+    Style::default().add_modifier(Modifier::DIM)
+}
+
+/// Columns reserved beside content when a scrollbar is shown: gap + track.
+pub const SCROLLBAR_RESERVE_COLS: u16 = 2;
+
+/// Whether content overflows the viewport enough to need a scrollbar.
+pub fn needs_scrollbar(total_rows: usize, viewport_rows: usize) -> bool {
+    total_rows > viewport_rows && viewport_rows > 0
+}
+
+/// Content width and optional one-column track rect when a scrollbar is shown.
+///
+/// Returns the original width and `None` when the frame is too narrow or content
+/// fits. The track sits on the last column; the column before it is the gap.
+pub fn split_for_scrollbar(
+    area_x: u16,
+    area_y: u16,
+    width: u16,
+    height: u16,
+    total_rows: usize,
+) -> (u16, Option<Rect>) {
+    if !needs_scrollbar(total_rows, height as usize) || width <= SCROLLBAR_RESERVE_COLS {
+        return (width, None);
+    }
+    let content_width = width.saturating_sub(SCROLLBAR_RESERVE_COLS);
+    let track = Rect {
+        x: area_x.saturating_add(width.saturating_sub(1)),
+        y: area_y,
+        width: 1,
+        height,
+    };
+    (content_width, Some(track))
+}
+
+/// Map a click on the track to a content scroll offset.
+///
+/// First / last track rows jump to the extremes; interior rows place the thumb
+/// centered on the click (inverse of [`thumb_range`]).
+pub fn click_to_offset(
+    cell_index: u16,
+    track_cells: u16,
+    total_rows: usize,
+    viewport_rows: usize,
+) -> usize {
+    if track_cells == 0 || !needs_scrollbar(total_rows, viewport_rows) {
+        return 0;
+    }
+    let max_scroll = total_rows.saturating_sub(viewport_rows);
+    if cell_index == 0 {
+        return 0;
+    }
+    if cell_index >= track_cells.saturating_sub(1) {
+        return max_scroll;
+    }
+    let (thumb_start, thumb_rows) = thumb_range(0, total_rows, viewport_rows);
+    let _ = thumb_start;
+    let travel = (track_cells as usize).saturating_sub(thumb_rows);
+    if travel == 0 || max_scroll == 0 {
+        return 0;
+    }
+    // Center the thumb on the clicked cell.
+    let centered = (cell_index as usize).saturating_sub(thumb_rows / 2);
+    centered
+        .saturating_mul(max_scroll)
+        .checked_div(travel)
+        .unwrap_or(0)
+        .min(max_scroll)
+}
+
+/// Inclusive-exclusive thumb span within the track, in track-local rows.
+pub fn thumb_range(scroll: usize, total_rows: usize, viewport_rows: usize) -> (usize, usize) {
+    if !needs_scrollbar(total_rows, viewport_rows) {
+        return (0, viewport_rows);
+    }
+    let thumb_rows = (viewport_rows * viewport_rows)
+        .div_ceil(total_rows)
+        .max(1)
+        .min(viewport_rows);
+    let travel = viewport_rows.saturating_sub(thumb_rows);
+    let max_scroll = total_rows.saturating_sub(viewport_rows);
+    let thumb_start = scroll
+        .saturating_mul(travel)
+        .checked_div(max_scroll)
+        .unwrap_or(0)
+        .min(travel);
+    (thumb_start, thumb_rows)
+}
+
+/// Paint a one-column vertical scrollbar into `track`.
+pub fn paint(frame: &mut Frame<'_>, track: Rect, scroll: usize, total_rows: usize) {
+    let viewport = track.height as usize;
+    if track.width == 0 || viewport == 0 || !needs_scrollbar(total_rows, viewport) {
+        return;
+    }
+    let (thumb_start, thumb_rows) = thumb_range(scroll, total_rows, viewport);
+    for row in 0..viewport {
+        let glyph = if (thumb_start..thumb_start + thumb_rows).contains(&row) {
+            "█"
+        } else {
+            "│"
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(glyph, style_dim()))),
+            Rect::new(track.x, track.y.saturating_add(row as u16), 1, 1),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn needs_scrollbar_only_when_overflowing() {
+        assert!(needs_scrollbar(20, 10));
+        assert!(!needs_scrollbar(10, 10));
+        assert!(!needs_scrollbar(5, 10));
+        assert!(!needs_scrollbar(20, 0));
+    }
+
+    #[test]
+    fn split_reserves_gap_and_track() {
+        let (content, track) = split_for_scrollbar(0, 2, 40, 10, 20);
+        assert_eq!(content, 38);
+        let track = track.expect("track");
+        assert_eq!(track.x, 39);
+        assert_eq!(track.width, 1);
+        assert_eq!(track.y, 2);
+        assert_eq!(track.height, 10);
+    }
+
+    #[test]
+    fn split_keeps_full_width_when_content_fits() {
+        let (content, track) = split_for_scrollbar(0, 0, 40, 10, 5);
+        assert_eq!(content, 40);
+        assert!(track.is_none());
+    }
+
+    #[test]
+    fn click_extremes_and_interior() {
+        assert_eq!(click_to_offset(0, 10, 100, 10), 0);
+        assert_eq!(click_to_offset(9, 10, 100, 10), 90);
+        let mid = click_to_offset(5, 10, 100, 10);
+        assert!(mid > 0 && mid < 90, "mid={mid}");
+    }
+
+    #[test]
+    fn thumb_moves_with_scroll() {
+        let (top, rows) = thumb_range(0, 100, 10);
+        let (bottom, rows2) = thumb_range(90, 100, 10);
+        assert_eq!(rows, rows2);
+        assert!(top < bottom);
+    }
+}

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -1,7 +1,7 @@
-//! Vertical mono scrollbar: dim track (`│`) and solid thumb (`█`).
+//! Vertical mono scrollbar: a thinner thumb (`▌`) in the last column.
 //!
-//! Space is reserved only when content overflows the viewport. Callers paint the
-//! track in the last column and leave a one-column gap beside it.
+//! Space is reserved only when content overflows the viewport. Callers leave a
+//! one-column gap beside the thumb column; the gutter itself is blank (clickable).
 
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
@@ -15,6 +15,9 @@ fn style_dim() -> Style {
 
 /// Columns reserved beside content when a scrollbar is shown: gap + track.
 pub const SCROLLBAR_RESERVE_COLS: u16 = 2;
+
+/// Thumb glyph: left-half block, one cell, thinner than a full `█`.
+pub const THUMB_GLYPH: &str = "▌";
 
 /// Whether content overflows the viewport enough to need a scrollbar.
 pub fn needs_scrollbar(total_rows: usize, viewport_rows: usize) -> bool {
@@ -43,6 +46,21 @@ pub fn split_for_scrollbar(
         height,
     };
     (content_width, Some(track))
+}
+
+/// Mouse grab zone: the track plus the one-column gap to its left.
+///
+/// Grok Build uses gap + track + one slop column past the border so a press on
+/// the adjacent chrome still grabs. Our track is already the frame edge, so the
+/// gap column is the slop.
+pub fn grab_zone(track: Rect) -> Rect {
+    let x = track.x.saturating_sub(1);
+    Rect {
+        x,
+        y: track.y,
+        width: (track.x - x).saturating_add(track.width),
+        height: track.height,
+    }
 }
 
 /// Map a click on the track to a content scroll offset.
@@ -106,14 +124,9 @@ pub fn paint(frame: &mut Frame<'_>, track: Rect, scroll: usize, total_rows: usiz
         return;
     }
     let (thumb_start, thumb_rows) = thumb_range(scroll, total_rows, viewport);
-    for row in 0..viewport {
-        let glyph = if (thumb_start..thumb_start + thumb_rows).contains(&row) {
-            "█"
-        } else {
-            "│"
-        };
+    for row in thumb_start..thumb_start.saturating_add(thumb_rows).min(viewport) {
         frame.render_widget(
-            Paragraph::new(Line::from(Span::styled(glyph, style_dim()))),
+            Paragraph::new(Line::from(Span::styled(THUMB_GLYPH, style_dim()))),
             Rect::new(track.x, track.y.saturating_add(row as u16), 1, 1),
         );
     }
@@ -163,5 +176,15 @@ mod tests {
         let (bottom, rows2) = thumb_range(90, 100, 10);
         assert_eq!(rows, rows2);
         assert!(top < bottom);
+    }
+
+    #[test]
+    fn grab_zone_includes_the_gap_column() {
+        let zone = grab_zone(Rect::new(39, 2, 1, 10));
+        assert_eq!(zone, Rect::new(38, 2, 2, 10));
+        assert!(zone.contains((38, 2).into()), "gap column grabs");
+        assert!(zone.contains((39, 11).into()), "track grabs");
+        assert!(!zone.contains((37, 5).into()), "two columns left is out");
+        assert!(!zone.contains((40, 5).into()), "past the frame is out");
     }
 }

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -65,26 +65,29 @@ pub fn grab_zone(track: Rect) -> Rect {
 
 /// Map a click on the track to a content scroll offset.
 ///
+/// `content_viewport` is the number of list rows shown under sticky chrome, so
+/// the last track cell can reach the renderer's `max_scroll`. Thumb size still
+/// follows the painted track (`track_cells`).
+///
 /// First / last track rows jump to the extremes; interior rows place the thumb
 /// centered on the click (inverse of [`thumb_range`]).
 pub fn click_to_offset(
     cell_index: u16,
     track_cells: u16,
     total_rows: usize,
-    viewport_rows: usize,
+    content_viewport: usize,
 ) -> usize {
-    if track_cells == 0 || !needs_scrollbar(total_rows, viewport_rows) {
+    if track_cells == 0 || !needs_scrollbar(total_rows, content_viewport) {
         return 0;
     }
-    let max_scroll = total_rows.saturating_sub(viewport_rows);
+    let max_scroll = total_rows.saturating_sub(content_viewport);
     if cell_index == 0 {
         return 0;
     }
     if cell_index >= track_cells.saturating_sub(1) {
         return max_scroll;
     }
-    let (thumb_start, thumb_rows) = thumb_range(0, total_rows, viewport_rows);
-    let _ = thumb_start;
+    let thumb_rows = thumb_range(0, total_rows, track_cells as usize).1;
     let travel = (track_cells as usize).saturating_sub(thumb_rows);
     if travel == 0 || max_scroll == 0 {
         return 0;
@@ -168,6 +171,9 @@ mod tests {
         assert_eq!(click_to_offset(9, 10, 100, 10), 90);
         let mid = click_to_offset(5, 10, 100, 10);
         assert!(mid > 0 && mid < 90, "mid={mid}");
+        // Sticky chrome shrinks the content viewport; the last cell must still
+        // reach the renderer's max_scroll, not total - track_cells.
+        assert_eq!(click_to_offset(9, 10, 100, 8), 92);
     }
 
     #[test]

--- a/src/ui/tier.rs
+++ b/src/ui/tier.rs
@@ -41,6 +41,26 @@ pub struct TierGeometry {
     pub verb_bar_entry_budget: u16,
 }
 
+impl TierGeometry {
+    /// Rebuild title/meta budgets for a narrower content width (scrollbar gap + track).
+    ///
+    /// Only shrinking `row_width` left title+meta summing past the row and clipped
+    /// every task into `…`.
+    pub fn with_row_width(self, row_width: u16) -> Self {
+        let meta_column_width = match self.tier {
+            Tier::Standard => STANDARD_META_COLUMN_WIDTH.min(row_width),
+            Tier::Compact => 0,
+        };
+        let title_width = row_width.saturating_sub(meta_column_width);
+        Self {
+            row_width,
+            title_width,
+            meta_column_width,
+            ..self
+        }
+    }
+}
+
 /// Project chip truncation ceiling shared by both tiers.
 pub const SELECTOR_CHIP_MAX_CELLS: u16 = 24;
 
@@ -165,6 +185,15 @@ mod tests {
                 assert_eq!(g.meta_column_width, STANDARD_META_COLUMN_WIDTH);
                 assert_eq!(g.title_width, 50, "78 columns retain 50 title cells");
             }
+            let narrowed = g.with_row_width(w.saturating_sub(2));
+            assert_eq!(narrowed.row_width, w.saturating_sub(2), "{w}x{h}");
+            assert_eq!(
+                narrowed
+                    .title_width
+                    .saturating_add(narrowed.meta_column_width),
+                narrowed.row_width,
+                "{w}x{h} scrollbar shrink must rebalance title+meta"
+            );
             // Width ≥ 120 still reports standard in the (wide deferred).
             if w >= 120 {
                 assert_eq!(g.tier, Tier::Standard, "wide not returned in M1 at {w}x{h}");

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -2016,3 +2016,38 @@ fn the_modal_cards_copyable_rects_exclude_its_own_border_and_footer() {
         "the card's first body row should yield its painted binding text, got {text:?}"
     );
 }
+
+#[test]
+fn list_scrollbar_click_jumps_selection_without_peeking() {
+    let (mut domain, mut model) = deck_of(40);
+    let first = model.visible_ids()[0];
+    assert_eq!(model.selected_id(), Some(first));
+    assert_eq!(model.detail_open(), None);
+
+    let hits = board_hit_map(STANDARD, &model);
+    let track = hits
+        .regions
+        .iter()
+        .rev()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ListScrollSelect(_)))
+        .expect("overflowing deck paints scrollbar hits");
+    // Bottom of the track jumps toward the end of the deck.
+    let bottom = hits
+        .regions
+        .iter()
+        .filter(|hit| matches!(hit.target, QueueHitTarget::ListScrollSelect(_)))
+        .max_by_key(|hit| hit.area.y)
+        .expect("scrollbar track cells");
+    let intent = map_board_mouse(&model, &hits, left_click(bottom.area.x, bottom.area.y))
+        .expect("scrollbar click");
+    assert!(
+        matches!(intent, BoardIntent::SelectListIndex(_)),
+        "scrollbar must quiet-select, got {intent:?}"
+    );
+    apply_intent(&mut domain, &mut model, intent, None).expect("apply jump");
+    let selected = model.selected_id().expect("selection");
+    assert_ne!(selected, first, "jump must leave the top of the deck");
+    assert_eq!(model.detail_open(), None, "scrollbar click must not peek");
+    assert_eq!(model.input_mode(), BoardInputMode::Normal);
+    let _ = track; // silence unused when filter finds cells
+}

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -25,7 +25,7 @@ use tsk_tui::ui::input::{
 };
 use tsk_tui::ui::mouse::{
     capture_layout, capture_mouse_paths_complete, left_click, map_board_mouse, map_capture_mouse,
-    map_scrollbar_mouse, primary_capture_action_sample_mouse, ScrollbarMouse,
+    map_scrollbar_mouse, primary_capture_action_sample_mouse, scrollbar_intent_at, ScrollbarMouse,
 };
 use tsk_tui::ui::render::{QueueHit, QueueHitMap, QueueHitTarget};
 
@@ -2184,6 +2184,48 @@ fn scrollbar_pointer_state_machine_drags_and_ignores_overlays() {
     );
     assert_eq!(miss, ScrollbarMouse::Miss);
     assert!(!overlay_drag);
+}
+
+#[test]
+fn scrollbar_intent_at_clamps_off_track_and_ignores_the_other_surface() {
+    let (_, model) = deck_of(40);
+    let _ = page_rows(&model);
+    let hits = board_hit_map(STANDARD, &model);
+    let mut cells: Vec<_> = hits
+        .regions
+        .iter()
+        .filter(|hit| matches!(hit.target, QueueHitTarget::ListScroll(_)))
+        .collect();
+    cells.sort_by_key(|hit| hit.area.y);
+    let first = cells.first().expect("track");
+    let last = cells.last().expect("track");
+    let QueueHitTarget::ListScroll(first_off) = first.target else {
+        panic!("first cell");
+    };
+    let QueueHitTarget::ListScroll(last_off) = last.target else {
+        panic!("last cell");
+    };
+    assert_eq!(
+        scrollbar_intent_at(&hits, first.area.y.saturating_sub(5), false),
+        Some(BoardIntent::ListScrollTo(first_off))
+    );
+    assert_eq!(
+        scrollbar_intent_at(&hits, last.area.y.saturating_add(20), false),
+        Some(BoardIntent::ListScrollTo(last_off))
+    );
+    let mid = cells[cells.len() / 2];
+    let QueueHitTarget::ListScroll(mid_off) = mid.target else {
+        panic!("mid cell");
+    };
+    assert_eq!(
+        scrollbar_intent_at(&hits, mid.area.y, false),
+        Some(BoardIntent::ListScrollTo(mid_off))
+    );
+    assert_eq!(
+        scrollbar_intent_at(&hits, mid.area.y, true),
+        None,
+        "list hits must not drive the page scrollbar"
+    );
 }
 
 #[test]

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -25,7 +25,7 @@ use tsk_tui::ui::input::{
 };
 use tsk_tui::ui::mouse::{
     capture_layout, capture_mouse_paths_complete, left_click, map_board_mouse, map_capture_mouse,
-    primary_capture_action_sample_mouse,
+    map_scrollbar_mouse, primary_capture_action_sample_mouse, ScrollbarMouse,
 };
 use tsk_tui::ui::render::{QueueHit, QueueHitMap, QueueHitTarget};
 
@@ -73,6 +73,24 @@ fn wheel_up(column: u16, row: u16) -> MouseEvent {
 fn wheel_down(column: u16, row: u16) -> MouseEvent {
     MouseEvent {
         kind: MouseEventKind::ScrollDown,
+        column,
+        row,
+        modifiers: KeyModifiers::NONE,
+    }
+}
+
+fn left_drag(column: u16, row: u16) -> MouseEvent {
+    MouseEvent {
+        kind: MouseEventKind::Drag(MouseButton::Left),
+        column,
+        row,
+        modifiers: KeyModifiers::NONE,
+    }
+}
+
+fn left_up(column: u16, row: u16) -> MouseEvent {
+    MouseEvent {
+        kind: MouseEventKind::Up(MouseButton::Left),
         column,
         row,
         modifiers: KeyModifiers::NONE,
@@ -2001,11 +2019,20 @@ fn list_scrollbar_click_jumps_viewport_without_changing_selection() {
         .expect("scrollbar track cells");
     let intent = map_board_mouse(&model, &hits, left_click(bottom.area.x, bottom.area.y))
         .expect("scrollbar click");
+    let QueueHitTarget::ListScroll(bottom_offset) = bottom.target else {
+        panic!("bottom cell must be ListScroll, got {:?}", bottom.target);
+    };
     assert!(
-        matches!(intent, BoardIntent::ListScrollTo(offset) if offset > 0),
-        "scrollbar must jump the viewport, got {intent:?}"
+        matches!(intent, BoardIntent::ListScrollTo(offset) if offset == bottom_offset && offset > 0),
+        "bottom track cell must jump to its mapped offset {bottom_offset}, got {intent:?}"
     );
     apply_intent(&mut domain, &mut model, intent, None).expect("apply jump");
+    let _ = page_rows(&model);
+    assert_eq!(
+        model.list_scroll(),
+        bottom_offset,
+        "bottom click must land on the mapped offset, not a sticky-clipped one"
+    );
     assert_eq!(
         model.selected_id(),
         Some(first),
@@ -2092,5 +2119,129 @@ fn mouse_wheel_scrolls_the_list_while_peek_is_open() {
         before,
         "wheel must move the list while peek is open:\n{}",
         after.join("\n")
+    );
+}
+
+#[test]
+fn scrollbar_pointer_state_machine_drags_and_ignores_overlays() {
+    let (mut domain, mut model) = deck_of(40);
+    let _ = page_rows(&model);
+    let hits = board_hit_map(STANDARD, &model);
+    let cell = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::ListScroll(_)))
+        .expect("list scrollbar");
+    let mut dragging = false;
+    let down = map_scrollbar_mouse(
+        BoardInputMode::Normal,
+        &hits,
+        left_click(cell.area.x, cell.area.y),
+        &mut dragging,
+    );
+    assert!(matches!(
+        down,
+        ScrollbarMouse::Intent(BoardIntent::ListScrollTo(_))
+    ));
+    assert!(dragging);
+
+    let below = cell.area.y.saturating_add(20);
+    let drag = map_scrollbar_mouse(
+        BoardInputMode::Normal,
+        &hits,
+        left_drag(cell.area.x, below),
+        &mut dragging,
+    );
+    assert!(matches!(
+        drag,
+        ScrollbarMouse::Intent(BoardIntent::ListScrollTo(_))
+    ));
+    assert!(dragging);
+
+    let up = map_scrollbar_mouse(
+        BoardInputMode::Normal,
+        &hits,
+        left_up(cell.area.x, below),
+        &mut dragging,
+    );
+    assert_eq!(up, ScrollbarMouse::Consumed);
+    assert!(!dragging);
+
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenCommandPalette,
+        None,
+    )
+    .expect("open palette");
+    let overlay_hits = board_hit_map(STANDARD, &model);
+    let mut overlay_drag = false;
+    let miss = map_scrollbar_mouse(
+        model.input_mode(),
+        &overlay_hits,
+        left_click(cell.area.x, cell.area.y),
+        &mut overlay_drag,
+    );
+    assert_eq!(miss, ScrollbarMouse::Miss);
+    assert!(!overlay_drag);
+}
+
+#[test]
+fn task_page_scrollbar_click_jumps_notes_without_changing_selection() {
+    let notes = (0..30)
+        .map(|i| format!("page-scroll line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut domain = DomainState::new();
+    let id = domain
+        .create(
+            "Page scrollbar",
+            Some(notes),
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
+    let before = page_rows(&model);
+    let hits = board_hit_map(STANDARD, &model);
+    let bottom = hits
+        .regions
+        .iter()
+        .filter(|hit| matches!(hit.target, QueueHitTarget::PageScroll(_)))
+        .max_by_key(|hit| hit.area.y)
+        .expect("page scrollbar hits");
+    let intent = map_board_mouse(&model, &hits, left_click(bottom.area.x, bottom.area.y))
+        .expect("page scrollbar click");
+    assert!(matches!(intent, BoardIntent::PageScrollTo(offset) if offset > 0));
+    apply_intent(&mut domain, &mut model, intent, None).expect("jump notes");
+    assert_eq!(model.selected_id(), Some(id));
+    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+    let after = page_rows(&model);
+    assert_ne!(
+        after,
+        before,
+        "page scrollbar must move notes:\n{}",
+        after.join("\n")
+    );
+}
+
+#[test]
+fn painting_clamps_an_oversize_list_scroll_back_into_the_model() {
+    let (mut domain, mut model) = deck_of(40);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ListScrollTo(10_000),
+        None,
+    )
+    .expect("oversize scroll");
+    let _ = page_rows(&model);
+    assert!(
+        model.list_scroll() < 10_000,
+        "paint must write the clamped offset back, got {}",
+        model.list_scroll()
     );
 }

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -641,52 +641,20 @@ fn click_and_wheel_match_keyboard_effects_for_each_control() {
         .expect("mouse close drawer");
     assert!(!model_mouse.drawer_open());
 
-    // Wheel: a step is the keyboard's own relative selection step.
-    let mut seed = DomainState::new();
-    seed.create(
-        "first",
-        None,
-        project(THIS_REPO),
-        None,
-        None,
-        ProvenanceOrigin::Manual,
-    )
-    .expect("first");
-    seed.create(
-        "second",
-        None,
-        project(THIS_REPO),
-        None,
-        None,
-        ProvenanceOrigin::Manual,
-    )
-    .expect("second");
-    let mut domain_key = seed.clone();
-    let mut domain_mouse = seed.clone();
-    let mut model_key = BoardModel::from_domain(&domain_key, Some(PathBuf::from(THIS_REPO)));
-    let mut model_mouse = BoardModel::from_domain(&domain_mouse, Some(PathBuf::from(THIS_REPO)));
-    let ids = model_key.visible_ids();
-    assert_eq!(ids.len(), 2, "both tasks must be visible on the deck");
-    assert_eq!(model_key.selected_id(), Some(ids[0]));
-    let keyboard_next = map_key(BoardInputMode::Normal, press(KeyCode::Down)).expect("down key");
-    apply_intent(&mut domain_key, &mut model_key, keyboard_next.clone(), None)
-        .expect("keyboard next");
+    // Wheel scrolls the list viewport; it does not move selection (j/k still do).
+    let (mut domain_mouse, mut model_mouse) = deck_of(40);
+    let selected = model_mouse.selected_id();
+    let _ = page_rows(&model_mouse);
     let hits = board_hit_map(STANDARD, &model_mouse);
-    let mouse_next = map_board_mouse(&model_mouse, &hits, wheel_down(0, 0)).expect("wheel next");
-    assert_eq!(mouse_next, keyboard_next);
-    apply_intent(&mut domain_mouse, &mut model_mouse, mouse_next, None).expect("mouse next");
-    assert_eq!(model_key.selected_id(), Some(ids[1]));
-    assert_eq!(model_mouse.selected_id(), Some(ids[1]));
-    // the last row is a hard stop for the wheel, unlike the
-    // keyboard's own wrap: no further step down, but a step back up still moves the
-    // selection. This is a deliberate, signed-off divergence from's literal wording,
-    // not an inherited accident -- see the comment on `wheel_step_matches_the_keyboard_
-    // selection_step` in `src/ui/mouse.rs` for why a wheel step does not wrap.
+    let mouse_next = map_board_mouse(&model_mouse, &hits, wheel_down(0, 0)).expect("wheel down");
+    assert_eq!(mouse_next, BoardIntent::ListScrollTo(1));
+    apply_intent(&mut domain_mouse, &mut model_mouse, mouse_next, None).expect("wheel scroll");
+    assert_eq!(model_mouse.selected_id(), selected);
+    assert_eq!(model_mouse.list_scroll(), 1);
     let hits = board_hit_map(STANDARD, &model_mouse);
-    assert_eq!(map_board_mouse(&model_mouse, &hits, wheel_down(0, 0)), None);
     assert_eq!(
         map_board_mouse(&model_mouse, &hits, wheel_up(0, 0)),
-        Some(BoardIntent::SelectPrev)
+        Some(BoardIntent::ListScrollTo(0))
     );
 
     // Project selector chip: no the key binds it (mouse-only, like `SelectIndex`), so its
@@ -2018,36 +1986,111 @@ fn the_modal_cards_copyable_rects_exclude_its_own_border_and_footer() {
 }
 
 #[test]
-fn list_scrollbar_click_jumps_selection_without_peeking() {
+fn list_scrollbar_click_jumps_viewport_without_changing_selection() {
     let (mut domain, mut model) = deck_of(40);
     let first = model.visible_ids()[0];
     assert_eq!(model.selected_id(), Some(first));
     assert_eq!(model.detail_open(), None);
 
     let hits = board_hit_map(STANDARD, &model);
-    let track = hits
-        .regions
-        .iter()
-        .rev()
-        .find(|hit| matches!(hit.target, QueueHitTarget::ListScrollSelect(_)))
-        .expect("overflowing deck paints scrollbar hits");
-    // Bottom of the track jumps toward the end of the deck.
     let bottom = hits
         .regions
         .iter()
-        .filter(|hit| matches!(hit.target, QueueHitTarget::ListScrollSelect(_)))
+        .filter(|hit| matches!(hit.target, QueueHitTarget::ListScroll(_)))
         .max_by_key(|hit| hit.area.y)
         .expect("scrollbar track cells");
     let intent = map_board_mouse(&model, &hits, left_click(bottom.area.x, bottom.area.y))
         .expect("scrollbar click");
     assert!(
-        matches!(intent, BoardIntent::SelectListIndex(_)),
-        "scrollbar must quiet-select, got {intent:?}"
+        matches!(intent, BoardIntent::ListScrollTo(offset) if offset > 0),
+        "scrollbar must jump the viewport, got {intent:?}"
     );
     apply_intent(&mut domain, &mut model, intent, None).expect("apply jump");
-    let selected = model.selected_id().expect("selection");
-    assert_ne!(selected, first, "jump must leave the top of the deck");
+    assert_eq!(
+        model.selected_id(),
+        Some(first),
+        "track click must leave selection alone"
+    );
     assert_eq!(model.detail_open(), None, "scrollbar click must not peek");
     assert_eq!(model.input_mode(), BoardInputMode::Normal);
-    let _ = track; // silence unused when filter finds cells
+}
+
+#[test]
+fn row_click_selects_without_jumping_the_viewport() {
+    let (mut domain, mut model) = deck_of(40);
+    let _ = page_rows(&model);
+    let before = page_rows(&model);
+    assert!(
+        before.iter().any(|row| row.contains("task 39")),
+        "top of the deck should be on screen:\n{}",
+        before.join("\n")
+    );
+    let ids = model.visible_ids();
+    let mid = 8;
+    apply_intent(&mut domain, &mut model, BoardIntent::SelectIndex(mid), None)
+        .expect("select middle row");
+    assert_eq!(model.selected_id(), Some(ids[mid]));
+    assert_eq!(model.detail_open(), Some(ids[mid]));
+    let after = page_rows(&model);
+    assert!(
+        after.iter().any(|row| row.contains("task 39")),
+        "clicking a visible row must not park the peek at the bottom:\n{}",
+        after.join("\n")
+    );
+}
+
+#[test]
+fn list_scrollbar_still_moves_the_viewport_while_peek_is_open() {
+    let (mut domain, mut model) = deck_of(40);
+    let _ = page_rows(&model);
+    apply_intent(&mut domain, &mut model, BoardIntent::SelectIndex(0), None)
+        .expect("peek first row");
+    assert!(model.detail_open().is_some());
+    let before = page_rows(&model);
+    let hits = board_hit_map(STANDARD, &model);
+    let bottom = hits
+        .regions
+        .iter()
+        .filter(|hit| matches!(hit.target, QueueHitTarget::ListScroll(_)))
+        .max_by_key(|hit| hit.area.y)
+        .expect("peek must not remove the list scrollbar");
+    let intent = map_board_mouse(&model, &hits, left_click(bottom.area.x, bottom.area.y))
+        .expect("scrollbar click with peek open");
+    apply_intent(&mut domain, &mut model, intent, None).expect("scroll with peek open");
+    let after = page_rows(&model);
+    assert_ne!(
+        after,
+        before,
+        "scrollbar must move the list while peek is open:\n{}",
+        after.join("\n")
+    );
+}
+
+#[test]
+fn mouse_wheel_scrolls_the_list_while_peek_is_open() {
+    let (mut domain, mut model) = deck_of(40);
+    let _ = page_rows(&model);
+    apply_intent(&mut domain, &mut model, BoardIntent::SelectIndex(0), None)
+        .expect("peek first row");
+    let selected = model.selected_id();
+    let before = page_rows(&model);
+    let hits = board_hit_map(STANDARD, &model);
+    for _ in 0..8 {
+        let intent = map_board_mouse(&model, &hits, wheel_down(0, 0)).expect("wheel down");
+        apply_intent(&mut domain, &mut model, intent, None).expect("apply wheel");
+    }
+    assert_eq!(
+        model.selected_id(),
+        selected,
+        "wheel must not move selection"
+    );
+    assert_eq!(model.detail_open(), selected, "wheel must leave peek open");
+    assert!(model.list_scroll() > 0, "wheel must advance list_scroll");
+    let after = page_rows(&model);
+    assert_ne!(
+        after,
+        before,
+        "wheel must move the list while peek is open:\n{}",
+        after.join("\n")
+    );
 }

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -2930,7 +2930,7 @@ fn overflowing_board_list_does_not_clip_task_rows_to_ellipsis() {
         .map(|i| {
             task(
                 7100 + i,
-                &format!("Scrollbar padding task {i}"),
+                &format!("ScrollbarNoBreakTitleThatMustWrapNotEllipsize{i:02}XXXXXXXXXXXXXXXX"),
                 HumanStatus::Ready,
                 project("/repos/tsk"),
                 3600,
@@ -2942,14 +2942,21 @@ fn overflowing_board_list_does_not_clip_task_rows_to_ellipsis() {
     let (rows, geo) = paint(80, 24, &model);
     let top = geo.viewport_top as usize;
     let bottom = (geo.viewport_top + geo.viewport_height) as usize;
+    let mut saw_title = false;
     for row in &rows[top..bottom] {
-        if trimmed(row).contains("Scrollbar padding task") {
+        if trimmed(row).contains("ScrollbarNoBreakTitle") {
+            saw_title = true;
             assert!(
                 !row.contains('…'),
                 "scrollbar must not clip task rows into ellipsis:\n{row}"
             );
         }
     }
+    assert!(
+        saw_title,
+        "fixture title must actually paint:\n{}",
+        rows.join("\n")
+    );
 }
 
 #[test]

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -396,6 +396,48 @@ fn trimmed(row: &str) -> String {
     row.trim_end().to_string()
 }
 
+/// List content without the overflow scrollbar's track/thumb cell on the right edge.
+fn list_body(row: &str) -> String {
+    let mut body = trimmed(row);
+    if body.ends_with('█') || body.ends_with('│') {
+        body.pop();
+        body = body.trim_end().to_string();
+    }
+    body
+}
+
+fn assert_exact_header_spacing(
+    rows: &[String],
+    geo: TierGeometry,
+    header: &str,
+    first_content: &str,
+    dimensions: &str,
+) {
+    let marker = format!("{header} ─");
+    let header_row = rows
+        .iter()
+        .position(|line| list_body(line).contains(&marker))
+        .unwrap_or_else(|| panic!("{dimensions}: missing {header:?}:\n{:#?}", rows));
+    let viewport_top = geo.viewport_top as usize;
+    let viewport_bottom = viewport_top + geo.viewport_height as usize;
+    assert!(
+        header_row > viewport_top && header_row + 2 < viewport_bottom,
+        "{dimensions}: {header:?} and its surrounding rows must be visible after selection scrolling:\n{:#?}",
+        rows
+    );
+    assert!(
+        list_body(&rows[header_row - 1]).is_empty() && list_body(&rows[header_row + 1]).is_empty(),
+        "{dimensions}: {header:?} needs one blank row immediately above and below:\n{:#?}",
+        rows
+    );
+    assert!(
+        !list_body(&rows[header_row - 2]).is_empty()
+            && list_body(&rows[header_row + 2]).contains(first_content),
+        "{dimensions}: {header:?} must have exactly one surrounding blank row before {first_content:?}:\n{:#?}",
+        rows
+    );
+}
+
 #[test]
 fn standard_78x24_fixture_has_selector_list_rule_status_verb_and_no_other_chrome_rows() {
     let tasks = fixture_tasks();
@@ -537,38 +579,6 @@ fn assert_visible_chrome(rows: &[String], geo: TierGeometry, dimensions: &str) {
             "{dimensions}: row exceeds the frame width"
         );
     }
-}
-
-fn assert_exact_header_spacing(
-    rows: &[String],
-    geo: TierGeometry,
-    header: &str,
-    first_content: &str,
-    dimensions: &str,
-) {
-    let marker = format!("{header} ─");
-    let header_row = rows
-        .iter()
-        .position(|line| trimmed(line).contains(&marker))
-        .unwrap_or_else(|| panic!("{dimensions}: missing {header:?}:\n{:#?}", rows));
-    let viewport_top = geo.viewport_top as usize;
-    let viewport_bottom = viewport_top + geo.viewport_height as usize;
-    assert!(
-        header_row > viewport_top && header_row + 2 < viewport_bottom,
-        "{dimensions}: {header:?} and its surrounding rows must be visible after selection scrolling:\n{:#?}",
-        rows
-    );
-    assert!(
-        trimmed(&rows[header_row - 1]).is_empty() && trimmed(&rows[header_row + 1]).is_empty(),
-        "{dimensions}: {header:?} needs one blank row immediately above and below:\n{:#?}",
-        rows
-    );
-    assert!(
-        !trimmed(&rows[header_row - 2]).is_empty()
-            && trimmed(&rows[header_row + 2]).contains(first_content),
-        "{dimensions}: {header:?} must have exactly one surrounding blank row before {first_content:?}:\n{:#?}",
-        rows
-    );
 }
 
 /// every section heading has one, and only one, blank row above and below it in both
@@ -2857,5 +2867,48 @@ fn edit_title_caret_parks_at_the_capped_headers_end() {
         painted.chars().count(),
         "caret must sit immediately after the marker, not at a hidden column:\n{}",
         rows.join("\n")
+    );
+}
+
+/// A deck longer than the viewport paints a dim track+thumb on the right edge and
+/// reserves a gap so wrapped titles never sit under the thumb.
+#[test]
+fn overflowing_board_list_paints_a_scrollbar() {
+    let tasks: Vec<Task> = (0..40u128)
+        .map(|i| {
+            task(
+                7000 + i,
+                &format!("Scrollbar padding task {i}"),
+                HumanStatus::Ready,
+                project("/repos/tsk"),
+                3600,
+            )
+        })
+        .collect();
+    let last_id = Uuid::from_u128(7000 + 39);
+    let view = fixture_view_projects(&tasks, false);
+    let mut model = fixture_model_on_tab(&tasks, &view, BoardTab::Projects);
+    model.selection_id = Some(last_id);
+
+    let (rows, geo) = paint(80, 24, &model);
+    let top = geo.viewport_top as usize;
+    let bottom = (geo.viewport_top + geo.viewport_height) as usize;
+    let viewport = &rows[top..bottom];
+    assert!(
+        viewport.iter().any(|row| row.contains('█')),
+        "overflowing list needs a thumb:\n{}",
+        viewport.join("\n")
+    );
+    assert!(
+        viewport.iter().any(|row| row.contains('│')),
+        "overflowing list needs a track:\n{}",
+        viewport.join("\n")
+    );
+    assert!(
+        viewport
+            .iter()
+            .any(|row| trimmed(row).contains("Scrollbar padding task 39")),
+        "selection-follow still keeps the selected task visible:\n{}",
+        viewport.join("\n")
     );
 }

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -337,6 +337,8 @@ fn fixture_model_on_tab<'a>(
         now: now(),
         overlay: QueueOverlay::None,
         detail_open: None,
+        list_scroll: 0,
+        follow_list: true,
     }
 }
 
@@ -346,7 +348,7 @@ fn paint(width: u16, height: u16, model: &QueueFrameModel<'_>) -> (Vec<String>, 
     let mut terminal = Terminal::new(backend).expect("test terminal");
     terminal
         .draw(|frame: &mut Frame| {
-            let _hits = draw_queue_frame(frame, model, &geo);
+            let _ = draw_queue_frame(frame, model, &geo);
         })
         .expect("draw");
     let backend = terminal.backend();
@@ -399,7 +401,7 @@ fn trimmed(row: &str) -> String {
 /// List content without the overflow scrollbar's track/thumb cell on the right edge.
 fn list_body(row: &str) -> String {
     let mut body = trimmed(row);
-    if body.ends_with('█') || body.ends_with('│') {
+    if body.ends_with('█') || body.ends_with('▌') || body.ends_with('│') {
         body.pop();
         body = body.trim_end().to_string();
     }
@@ -1439,7 +1441,7 @@ fn task_page_scrolls_notes_and_steps_as_one_content_region() {
     );
     assert!(shown[20].contains("created"), "footer must stay fixed");
     assert!(
-        shown.iter().any(|row| row.contains('█')),
+        shown.iter().any(|row| row.contains('▌')),
         "overflow needs a scrollbar"
     );
     assert!(shown.iter().any(|row| row.contains("N16 filler line")));
@@ -1473,7 +1475,7 @@ fn task_page_scrolls_notes_and_steps_as_one_content_region() {
     assert!(
         shown[step_row + 1]
             .chars()
-            .all(|cell| matches!(cell, ' ' | '█' | '│')),
+            .all(|cell| matches!(cell, ' ' | '▌')),
         "the steps section needs its trailing blank row:\n{}",
         shown.join("\n")
     );
@@ -1886,10 +1888,17 @@ fn compact_peek_is_inline_and_editors_stay_full_screen_takeovers() {
             viewport.contains("Smoke-test worktree dispatch"),
             "{w}x{h}: the peeked task's row must stay visible:\n{viewport}"
         );
-        assert!(
-            viewport.contains("scope tsk"),
-            "{w}x{h}: the peek body must weave inline under the row:\n{viewport}"
-        );
+        if h > 10 {
+            assert!(
+                viewport.contains("scope tsk"),
+                "{w}x{h}: the peek body must weave inline under the row:\n{viewport}"
+            );
+        } else {
+            assert!(
+                viewport.contains("no notes yet"),
+                "{w}x{h}: compact floor still shows the peek under the row:\n{viewport}"
+            );
+        }
 
         // A field editor (title) is still a full takeover that erases the base list.
         model.detail_open = None;
@@ -2895,13 +2904,15 @@ fn overflowing_board_list_paints_a_scrollbar() {
     let bottom = (geo.viewport_top + geo.viewport_height) as usize;
     let viewport = &rows[top..bottom];
     assert!(
-        viewport.iter().any(|row| row.contains('█')),
+        viewport.iter().any(|row| row.contains('▌')),
         "overflowing list needs a thumb:\n{}",
         viewport.join("\n")
     );
     assert!(
-        viewport.iter().any(|row| row.contains('│')),
-        "overflowing list needs a track:\n{}",
+        viewport
+            .iter()
+            .all(|row| { !matches!(row.chars().last(), Some('│')) }),
+        "scrollbar gutter is blank, not a │ track:\n{}",
         viewport.join("\n")
     );
     assert!(
@@ -2910,5 +2921,108 @@ fn overflowing_board_list_paints_a_scrollbar() {
             .any(|row| trimmed(row).contains("Scrollbar padding task 39")),
         "selection-follow still keeps the selected task visible:\n{}",
         viewport.join("\n")
+    );
+}
+
+#[test]
+fn overflowing_board_list_does_not_clip_task_rows_to_ellipsis() {
+    let tasks: Vec<Task> = (0..40u128)
+        .map(|i| {
+            task(
+                7100 + i,
+                &format!("Scrollbar padding task {i}"),
+                HumanStatus::Ready,
+                project("/repos/tsk"),
+                3600,
+            )
+        })
+        .collect();
+    let view = fixture_view_projects(&tasks, false);
+    let model = fixture_model_on_tab(&tasks, &view, BoardTab::Projects);
+    let (rows, geo) = paint(80, 24, &model);
+    let top = geo.viewport_top as usize;
+    let bottom = (geo.viewport_top + geo.viewport_height) as usize;
+    for row in &rows[top..bottom] {
+        if trimmed(row).contains("Scrollbar padding task") {
+            assert!(
+                !row.contains('…'),
+                "scrollbar must not clip task rows into ellipsis:\n{row}"
+            );
+        }
+    }
+}
+
+#[test]
+fn scrolled_list_pins_the_section_header_under_the_tabs() {
+    let tasks: Vec<Task> = (0..40u128)
+        .map(|i| {
+            task(
+                7200 + i,
+                &format!("Sticky header task {i}"),
+                HumanStatus::Ready,
+                TaskScope::Global,
+                3600,
+            )
+        })
+        .collect();
+    let view = fixture_view(&tasks, false);
+    let mut model = fixture_model(&tasks, &view);
+    model.selection_id = Some(Uuid::from_u128(7200));
+    model.list_scroll = 6;
+    model.follow_list = false;
+    let (rows, geo) = paint(80, 24, &model);
+    let top = geo.viewport_top as usize;
+    assert!(
+        trimmed(&rows[top]).is_empty(),
+        "pinned header needs a blank row under the tabs:\n{}",
+        rows.join("\n")
+    );
+    let header = trimmed(&rows[top + 1]);
+    assert!(
+        header.contains("desk"),
+        "desk header must pin under the tabs after scrolling past it:\n{header}\n{}",
+        rows.join("\n")
+    );
+}
+
+#[test]
+fn scrolled_done_section_pins_done_under_the_tabs() {
+    let mut tasks: Vec<Task> = (0..8u128)
+        .map(|i| {
+            task(
+                7300 + i,
+                &format!("Open sticky {i}"),
+                HumanStatus::Ready,
+                TaskScope::Global,
+                3600,
+            )
+        })
+        .collect();
+    tasks.extend((0..40u128).map(|i| {
+        task(
+            7400 + i,
+            &format!("Done sticky {i}"),
+            HumanStatus::Done,
+            TaskScope::Global,
+            3600,
+        )
+    }));
+    let view = fixture_view(&tasks, true);
+    let mut model = fixture_model(&tasks, &view);
+    model.selection_id = Some(Uuid::from_u128(7300));
+    model.list_scroll = 20;
+    model.follow_list = false;
+    let (rows, geo) = paint(80, 24, &model);
+    let top = geo.viewport_top as usize;
+    assert!(
+        trimmed(&rows[top]).is_empty(),
+        "pinned header needs a blank row under the tabs:\n{}",
+        rows.join("\n")
+    );
+    let header = trimmed(&rows[top + 1]);
+    assert!(
+        header.contains("DONE"),
+        "DONE header must pin under the tabs once that section reaches the top:\n{header}\n{}",
+        rows.join("\n")
     );
 }

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -1515,7 +1515,7 @@ fn arrow_keys_move_the_cursor_through_shared_steps() {
 
     let frame = rendered_board(&model, 80, 24);
     assert!(
-        frame.contains('█'),
+        frame.contains('▌'),
         "overflow must show the page scrollbar:\n{frame}"
     );
     assert!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the board list is taller than the viewport, paint a dim track (`│`) and solid thumb (`█`) on the right edge with a one-column gap so titles stay clear of the chrome. Selection-follow still keeps the selected row (and an open peek) on screen. A click on the track jumps selection to that fraction of the deck without peeking or opening the task page.

The task page body scrollbar uses the same paint helper (`src/ui/scrollbar.rs`).

## Stack

1. **This PR** — list scrollbar
2. Edge autoscroll during text drag-select (follows)
3. Hover feedback (follows)
4. Resize debounce (follows)
5. Mono markdown notes (follows)

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
- [x] Overflowing deck paints thumb + track; short decks do not
- [x] Scrollbar click jumps selection without peek
- [ ] Live herdr smoke not run (`HERDR_ENV` unset)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c02137c7-0c5d-487a-b0f8-4410c62815f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c02137c7-0c5d-487a-b0f8-4410c62815f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

