### PR TITLE
feat: edge auto-scroll during text drag-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Edge auto-scroll during text drag-select: holding a selection near the top or
+bottom of the board list or task-page notes viewport scrolls that surface while
+the drag stays armed, with a faster idle tick so the motion keeps up with the
+pointer. Leaving the edge zone or releasing the button clears it.
+
 Board list scrollbar: when the deck is taller than the viewport, a thinner thumb (`▌`)
 paints on the right edge with a one-column gap so titles stay clear of it. The gutter
 is blank and clickable (no `│` track). Titles and age wrap/fit instead of clipping to

--- a/src/app.rs
+++ b/src/app.rs
@@ -335,7 +335,16 @@ fn run_board() -> Result<(), Box<dyn Error>> {
             )?;
             if poll == FramePoll::Idle {
                 if let Some(auto) = drag_gesture.autoscroll() {
-                    tick_drag_autoscroll(&mut model, auto);
+                    let area = terminal_area(terminal)?;
+                    let content = drag_content_area(&model, area);
+                    tick_drag_autoscroll(
+                        &mut model,
+                        &mut drag_gesture,
+                        auto,
+                        &frame_rows,
+                        &frame_copyable,
+                        content,
+                    );
                 }
                 continue;
             }
@@ -436,7 +445,13 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                                 model.text_selection(),
                             ) {
                                 DragSelectOutcome::Copy => {
-                                    copy_drag_selection(&mut model, &frame_rows, &frame_copyable);
+                                    copy_drag_selection(
+                                        &mut model,
+                                        &frame_rows,
+                                        &frame_copyable,
+                                        drag_gesture.captured_before(),
+                                        drag_gesture.captured_after(),
+                                    );
                                     continue;
                                 }
                                 DragSelectOutcome::Click(down) => {
@@ -505,11 +520,20 @@ fn run_board() -> Result<(), Box<dyn Error>> {
 /// and other chrome never reach the clipboard. A selection with no text (a bare
 /// click, or a drag over blank cells) copies nothing. Success flashes a short
 /// ephemeral status that clears itself; the highlight drops so it does not stick.
-fn copy_drag_selection(model: &mut BoardModel, frame_rows: &[String], copyable: &[Rect]) {
+fn copy_drag_selection(
+    model: &mut BoardModel,
+    frame_rows: &[String],
+    copyable: &[Rect],
+    captured_before: &[String],
+    captured_after: &[String],
+) {
     let Some(selection) = model.text_selection() else {
         return;
     };
-    let Some(text) = selection_text(frame_rows, copyable, &selection) else {
+    let live = selection_text(frame_rows, copyable, &selection);
+    let Some(text) =
+        crate::ui::text_select::compose_selection_copy(captured_before, live, captured_after)
+    else {
         model.clear_text_selection();
         return;
     };
@@ -538,16 +562,39 @@ fn drag_content_area(model: &BoardModel, area: Rect) -> Rect {
 }
 
 /// One idle tick of edge auto-scroll while a text drag sits near the content edge.
-fn tick_drag_autoscroll(model: &mut BoardModel, auto: crate::ui::text_select::DragAutoScrollState) {
-    match model.input_mode() {
-        BoardInputMode::TaskPage => {
-            model.nudge_notes_scroll(auto.direction, auto.speed);
-        }
-        BoardInputMode::Normal => {
-            model.nudge_list_scroll(auto.direction, auto.speed);
-        }
-        _ => {}
+fn tick_drag_autoscroll(
+    model: &mut BoardModel,
+    gesture: &mut crate::ui::text_select::DragSelectGesture,
+    auto: crate::ui::text_select::DragAutoScrollState,
+    frame_rows: &[String],
+    copyable: &[Rect],
+    content: Rect,
+) {
+    let delta = match model.input_mode() {
+        BoardInputMode::TaskPage => model.nudge_notes_scroll(auto.direction, auto.speed),
+        BoardInputMode::Normal => model.nudge_list_scroll(auto.direction, auto.speed),
+        _ => 0,
+    };
+    if delta == 0 {
+        return;
     }
+    if let Some(selection) = model.text_selection() {
+        gesture.capture_leaving_rows(
+            frame_rows,
+            copyable,
+            selection,
+            content,
+            auto.direction,
+            delta,
+        );
+    }
+    let shift = match auto.direction {
+        crate::ui::text_select::AutoScrollDirection::Down => {
+            -i16::try_from(delta).unwrap_or(i16::MAX)
+        }
+        crate::ui::text_select::AutoScrollDirection::Up => i16::try_from(delta).unwrap_or(i16::MAX),
+    };
+    model.shift_text_selection_anchor_y(shift);
 }
 
 /// Whether save recovery permits the board to apply background state changes.

--- a/src/app.rs
+++ b/src/app.rs
@@ -417,6 +417,11 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                         MouseEventKind::Drag(MouseButton::Left) => {
                             let pos = Position::new(mouse.column, mouse.row);
                             model.drag_text_selection(pos);
+                            if let Some(line) =
+                                model.copyable_press_line(&frame_rows, &frame_copyable)
+                            {
+                                drag_gesture.ensure_copy_origin(line);
+                            }
                             let _ = drag_gesture.handle(
                                 DragSelectPhase::Move,
                                 pos,
@@ -451,6 +456,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                                         &frame_copyable,
                                         drag_gesture.captured_before(),
                                         drag_gesture.captured_after(),
+                                        drag_gesture.copy_origin(),
                                     );
                                     continue;
                                 }
@@ -526,14 +532,18 @@ fn copy_drag_selection(
     copyable: &[Rect],
     captured_before: &[String],
     captured_after: &[String],
+    origin: Option<&str>,
 ) {
     let Some(selection) = model.text_selection() else {
         return;
     };
     let live = selection_text(frame_rows, copyable, &selection);
-    let Some(text) =
-        crate::ui::text_select::compose_selection_copy(captured_before, live, captured_after)
-    else {
+    let Some(text) = crate::ui::text_select::compose_selection_copy(
+        captured_before,
+        live,
+        captured_after,
+        origin,
+    ) else {
         model.clear_text_selection();
         return;
     };

--- a/src/app.rs
+++ b/src/app.rs
@@ -197,10 +197,11 @@ pub fn board_frame(
     write: impl FnOnce() -> Result<(), StoreError>,
     paint: impl FnOnce(&BoardModel) -> io::Result<()>,
     wait: impl FnOnce(Duration) -> io::Result<bool>,
+    active_animations: bool,
 ) -> io::Result<FramePoll> {
     record_walkthrough_dismissal(model, write);
     paint(model)?;
-    if wait(board_poll_duration(false))? {
+    if wait(board_poll_duration(active_animations))? {
         Ok(FramePoll::Event)
     } else {
         Ok(FramePoll::Idle)
@@ -226,9 +227,10 @@ pub fn board_idle_tick(
     domain: &mut DomainState,
     watch: &mut StoreWatch,
     save_recovery: &SaveRecovery<DomainState>,
+    active_animations: bool,
 ) -> io::Result<FramePoll> {
     model.expire_ephemeral_message();
-    let poll = board_frame(model, write, paint, wait)?;
+    let poll = board_frame(model, write, paint, wait, active_animations)?;
     if poll == FramePoll::Idle {
         revalidate_board_from_store(store, domain, model, watch, save_recovery);
     }
@@ -329,8 +331,12 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                 &mut domain,
                 &mut store_watch,
                 &save_recovery,
+                drag_gesture.has_autoscroll(),
             )?;
             if poll == FramePoll::Idle {
+                if let Some(auto) = drag_gesture.autoscroll() {
+                    tick_drag_autoscroll(&mut model, auto);
+                }
                 continue;
             }
             match event::read()? {
@@ -406,6 +412,12 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                                 DragSelectPhase::Move,
                                 pos,
                                 model.text_selection(),
+                            );
+                            let area = terminal_area(terminal)?;
+                            drag_gesture.update_autoscroll(
+                                pos.y,
+                                drag_content_area(&model, area),
+                                model.text_selection().is_some_and(|s| s.has_area()),
                             );
                             continue;
                         }
@@ -507,6 +519,35 @@ fn copy_drag_selection(model: &mut BoardModel, frame_rows: &[String], copyable: 
         model.set_ephemeral_message("copy failed", Duration::from_secs(2));
     }
     model.clear_text_selection();
+}
+
+/// Content rect that edge auto-scroll watches during a text drag.
+fn drag_content_area(model: &BoardModel, area: Rect) -> Rect {
+    let geo = crate::ui::tier::resolve(area.width, area.height);
+    match model.input_mode() {
+        BoardInputMode::TaskPage => {
+            // Approximate the shared notes/steps viewport: below a one-row header,
+            // above the rule. Exact step halving is unnecessary for edge detection.
+            let top = geo.viewport_top.saturating_add(1);
+            let bottom = geo.rule_row.unwrap_or(geo.height.saturating_sub(2));
+            let height = bottom.saturating_sub(top);
+            Rect::new(0, top, area.width, height)
+        }
+        _ => Rect::new(0, geo.viewport_top, area.width, geo.viewport_height),
+    }
+}
+
+/// One idle tick of edge auto-scroll while a text drag sits near the content edge.
+fn tick_drag_autoscroll(model: &mut BoardModel, auto: crate::ui::text_select::DragAutoScrollState) {
+    match model.input_mode() {
+        BoardInputMode::TaskPage => {
+            model.nudge_notes_scroll(auto.direction, auto.speed);
+        }
+        BoardInputMode::Normal => {
+            model.nudge_list_scroll(auto.direction, auto.speed);
+        }
+        _ => {}
+    }
 }
 
 /// Whether save recovery permits the board to apply background state changes.
@@ -1645,6 +1686,7 @@ mod idle_store_revalidation_tests {
             &mut domain,
             &mut watch,
             &save_recovery,
+            false,
         )
         .unwrap();
         assert_eq!(poll, FramePoll::Idle);

--- a/src/app.rs
+++ b/src/app.rs
@@ -417,10 +417,14 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                         MouseEventKind::Drag(MouseButton::Left) => {
                             let pos = Position::new(mouse.column, mouse.row);
                             model.drag_text_selection(pos);
-                            if let Some(line) =
-                                model.copyable_press_line(&frame_rows, &frame_copyable)
-                            {
-                                drag_gesture.ensure_copy_origin(line);
+                            if let Some(sel) = model.text_selection() {
+                                if let Some(text) =
+                                    selection_text(&frame_rows, &frame_copyable, &sel)
+                                {
+                                    if let Some(first) = text.lines().next() {
+                                        drag_gesture.ensure_copy_origin(first.to_string());
+                                    }
+                                }
                             }
                             let _ = drag_gesture.handle(
                                 DragSelectPhase::Move,

--- a/src/app.rs
+++ b/src/app.rs
@@ -588,13 +588,10 @@ fn tick_drag_autoscroll(
             delta,
         );
     }
-    let shift = match auto.direction {
-        crate::ui::text_select::AutoScrollDirection::Down => {
-            -i16::try_from(delta).unwrap_or(i16::MAX)
-        }
-        crate::ui::text_select::AutoScrollDirection::Up => i16::try_from(delta).unwrap_or(i16::MAX),
-    };
-    model.shift_text_selection_anchor_y(shift);
+    if let Some(y) = gesture.last_drag_row() {
+        let x = model.text_selection().map(|s| s.head.x).unwrap_or(0);
+        model.recompute_text_selection_head(ratatui::layout::Position::new(x, y));
+    }
 }
 
 /// Whether save recovery permits the board to apply background state changes.

--- a/src/app.rs
+++ b/src/app.rs
@@ -169,8 +169,8 @@ pub enum FramePoll {
 
 /// The board loop's input-wait duration for one frame.
 ///
-/// the paints no animation yet, so every real call site passes `false` here; the parameter
-/// stays so a future animation source can shorten the wait without moving this call site.
+/// `active_animations` is true while a text-drag autoscroll is armed, so the wait
+/// shortens to the scheduler's animation tick.
 /// Wired straight through [`scheduler::next_wait`] rather than a fixed constant -- the base
 /// tick and the short-tick floor stay the Frame Scheduler's, not a second copy in the loop.
 pub fn board_poll_duration(active_animations: bool) -> Duration {
@@ -549,11 +549,13 @@ fn copy_drag_selection(
         return;
     };
     let live = selection_text(frame_rows, copyable, &selection);
+    let from_origin = selection.anchor.y <= selection.head.y;
     let Some(text) = crate::ui::text_select::compose_selection_copy(
         captured_before,
         live,
         captured_after,
         origin,
+        from_origin,
     ) else {
         model.clear_text_selection();
         return;
@@ -567,7 +569,7 @@ fn copy_drag_selection(
 }
 
 /// Content rect that edge auto-scroll watches during a text drag.
-fn drag_content_area(model: &BoardModel, area: Rect) -> Rect {
+pub fn drag_content_area(model: &BoardModel, area: Rect) -> Rect {
     let geo = crate::ui::tier::resolve(area.width, area.height);
     match model.input_mode() {
         BoardInputMode::TaskPage => {
@@ -583,7 +585,7 @@ fn drag_content_area(model: &BoardModel, area: Rect) -> Rect {
 }
 
 /// One idle tick of edge auto-scroll while a text drag sits near the content edge.
-fn tick_drag_autoscroll(
+pub fn tick_drag_autoscroll(
     model: &mut BoardModel,
     gesture: &mut crate::ui::text_select::DragSelectGesture,
     auto: crate::ui::text_select::DragAutoScrollState,

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,7 +33,9 @@ use crate::ui::mouse::{
 };
 use crate::ui::queue::BoardTab;
 use crate::ui::scheduler;
-use crate::ui::text_select::{copy_to_clipboard, frame_text_rows, selection_text};
+use crate::ui::text_select::{
+    copy_to_clipboard, copyable_line_at, frame_text_rows, selection_text,
+};
 
 /// Env var set by open-capture launcher for Capture UI mode.
 pub const MODE_ENV: &str = "TSK_MODE";
@@ -482,6 +484,11 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                             let pos = Position::new(mouse.column, mouse.row);
                             model.begin_mouse_press(pos);
                             let _ = drag_gesture.handle(DragSelectPhase::Press, pos, None);
+                            if let Some(line) =
+                                copyable_line_at(&frame_rows, &frame_copyable, pos.y)
+                            {
+                                drag_gesture.ensure_copy_origin(line);
+                            }
                             continue;
                         }
                         _ => {}

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -640,8 +640,9 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
         follow_list: model.follow_list.get(),
     };
     let (hits, painted_list_scroll) = render::draw_queue_frame(frame, &frame_model, &geo);
-    if let Some(scroll) = painted_list_scroll {
+    if let Some((scroll, max_scroll)) = painted_list_scroll {
         model.list_scroll.set(scroll);
+        model.list_max_scroll.set(max_scroll);
     }
 
     // Board-form edits use the task page's status and verb rows rather than an inline rule row.

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use ratatui::layout::Position;
+use ratatui::layout::{Position, Rect};
 use uuid::Uuid;
 
 use crate::config::VerbModifier;
@@ -998,6 +998,12 @@ impl BoardModel {
     /// Recompute the live highlight after the viewport scrolled under a held drag.
     pub fn recompute_text_selection_head(&mut self, head: Position) {
         self.drag_text_selection(head);
+    }
+
+    /// Copyable text on the original press row (used once, before autoscroll).
+    pub fn copyable_press_line(&self, rows: &[String], copyable: &[Rect]) -> Option<String> {
+        let press = self.mouse_press?;
+        crate::ui::text_select::copyable_line_at(rows, copyable, press.y)
     }
 
     /// Clear the press on release; the selection itself stays until copy clears it

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -573,6 +573,9 @@ pub struct BoardModel {
     /// The last left-button press cell, held until release so a drag can grow a text
     /// selection out of it. Presentation-only; a plain click never reads it.
     pub(super) mouse_press: Option<Position>,
+    /// `list_scroll` / notes scroll at the press, so the anchor stays on that content
+    /// row while edge auto-scroll moves the viewport.
+    pub(super) mouse_press_scroll: Option<usize>,
     /// List viewport offset. Scrollbar click/drag writes it; row click leaves it.
     pub(super) list_scroll: Cell<usize>,
     /// When true, the next paint nudges `list_scroll` so the selection is on screen
@@ -643,6 +646,7 @@ impl BoardModel {
             command_query: String::new(),
             command_selected: 0,
             mouse_press: None,
+            mouse_press_scroll: None,
             list_scroll: Cell::new(0),
             follow_list: Cell::new(true),
             text_selection: None,
@@ -952,7 +956,32 @@ impl BoardModel {
     /// click never reads it. Called for every left press, whatever the input mode.
     pub fn begin_mouse_press(&mut self, position: Position) {
         self.mouse_press = Some(position);
+        self.mouse_press_scroll = Some(self.content_scroll());
         self.text_selection = None;
+    }
+
+    fn content_scroll(&self) -> usize {
+        match self.input_mode() {
+            BoardInputMode::TaskPage => self
+                .form
+                .as_ref()
+                .map(|form| form.notes_scroll)
+                .unwrap_or(0),
+            _ => self.list_scroll.get(),
+        }
+    }
+
+    fn content_relative_anchor(&self, press: Position) -> Position {
+        let Some(press_scroll) = self.mouse_press_scroll else {
+            return press;
+        };
+        let dy = self.content_scroll() as i32 - press_scroll as i32;
+        let y = if dy >= 0 {
+            press.y.saturating_sub(dy as u16)
+        } else {
+            press.y.saturating_add(dy.unsigned_abs() as u16)
+        };
+        Position::new(press.x, y)
     }
 
     /// Extend the drag selection to `position`, anchored at the press cell.
@@ -960,29 +989,22 @@ impl BoardModel {
     /// Inert without a live press (a drag that starts mid-gesture, e.g. before tsk
     /// saw the press), so it can never invent an anchor.
     pub fn drag_text_selection(&mut self, position: Position) {
-        if let Some(anchor) = self.mouse_press {
+        if let Some(press) = self.mouse_press {
+            let anchor = self.content_relative_anchor(press);
             self.text_selection = Some(TextSelection::new(anchor, position));
         }
     }
 
-    /// Keep the drag anchor on the same content row after the list/notes scrolled.
-    pub fn shift_text_selection_anchor_y(&mut self, delta: i16) {
-        if let Some(press) = self.mouse_press.as_mut() {
-            press.y = if delta >= 0 {
-                press.y.saturating_add(delta as u16)
-            } else {
-                press.y.saturating_sub(delta.unsigned_abs())
-            };
-        }
-        if let Some(selection) = self.text_selection.as_mut() {
-            selection.shift_anchor_y(delta);
-        }
+    /// Recompute the live highlight after the viewport scrolled under a held drag.
+    pub fn recompute_text_selection_head(&mut self, head: Position) {
+        self.drag_text_selection(head);
     }
 
     /// Clear the press on release; the selection itself stays until copy clears it
     /// or the next press replaces it.
     pub fn end_mouse_press(&mut self) {
         self.mouse_press = None;
+        self.mouse_press_scroll = None;
     }
 
     /// Drop a finished text selection highlight (after copy, Esc, or cancel).

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -965,6 +965,20 @@ impl BoardModel {
         }
     }
 
+    /// Keep the drag anchor on the same content row after the list/notes scrolled.
+    pub fn shift_text_selection_anchor_y(&mut self, delta: i16) {
+        if let Some(press) = self.mouse_press.as_mut() {
+            press.y = if delta >= 0 {
+                press.y.saturating_add(delta as u16)
+            } else {
+                press.y.saturating_sub(delta.unsigned_abs())
+            };
+        }
+        if let Some(selection) = self.text_selection.as_mut() {
+            selection.shift_anchor_y(delta);
+        }
+    }
+
     /// Clear the press on release; the selection itself stays until copy clears it
     /// or the next press replaces it.
     pub fn end_mouse_press(&mut self) {
@@ -989,8 +1003,9 @@ impl BoardModel {
         &self,
         direction: crate::ui::text_select::AutoScrollDirection,
         rows: u16,
-    ) {
+    ) -> usize {
         use crate::ui::text_select::AutoScrollDirection;
+        self.follow_list.set(false);
         let max = self.list_max_scroll.get();
         let cur = self.list_scroll.get();
         let next = match direction {
@@ -998,6 +1013,7 @@ impl BoardModel {
             AutoScrollDirection::Down => cur.saturating_add(rows as usize).min(max),
         };
         self.list_scroll.set(next);
+        cur.abs_diff(next)
     }
 
     /// Scroll the open task page's shared notes body by `rows` (view mode only).
@@ -1005,18 +1021,20 @@ impl BoardModel {
         &mut self,
         direction: crate::ui::text_select::AutoScrollDirection,
         rows: u16,
-    ) {
+    ) -> usize {
         use crate::ui::text_select::AutoScrollDirection;
         let Some(form) = self.form.as_mut() else {
-            return;
+            return 0;
         };
         let horizon = form.notes_max_scroll.get();
+        let cur = form.notes_scroll;
         form.notes_scroll = match direction {
             AutoScrollDirection::Up => form.notes_scroll.saturating_sub(rows as usize),
             AutoScrollDirection::Down => {
                 form.notes_scroll.saturating_add(rows as usize).min(horizon)
             }
         };
+        cur.abs_diff(form.notes_scroll)
     }
 
     /// Options the session project selector offers, in presentation order.

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -580,6 +580,8 @@ pub struct BoardModel {
     pub(super) follow_list: Cell<bool>,
     /// The live drag-selected screen region, cleared on the next press.
     pub(super) text_selection: Option<TextSelection>,
+    /// Furthest list scroll the last painted frame could show (renderer-recorded).
+    pub(super) list_max_scroll: Cell<usize>,
     /// When set, [`Self::message`] clears itself on the next idle tick after this instant.
     /// Sticky messages (errors, delete notices) leave this `None`.
     pub(super) message_expires_at: Option<Instant>,
@@ -644,6 +646,7 @@ impl BoardModel {
             list_scroll: Cell::new(0),
             follow_list: Cell::new(true),
             text_selection: None,
+            list_max_scroll: Cell::new(0),
             message_expires_at: None,
             message_restore: None,
             verb_modifier: VerbModifier::Alt,
@@ -976,6 +979,44 @@ impl BoardModel {
     /// The live drag selection, if a drag is (or was) in progress.
     pub fn text_selection(&self) -> Option<TextSelection> {
         self.text_selection
+    }
+
+    /// Scroll the board list by `rows` without moving the pinned selection.
+    ///
+    /// Used by drag edge auto-scroll so a text drag near the viewport edge can
+    /// reveal more of the deck. Clamped to the last painted max scroll.
+    pub fn nudge_list_scroll(
+        &self,
+        direction: crate::ui::text_select::AutoScrollDirection,
+        rows: u16,
+    ) {
+        use crate::ui::text_select::AutoScrollDirection;
+        let max = self.list_max_scroll.get();
+        let cur = self.list_scroll.get();
+        let next = match direction {
+            AutoScrollDirection::Up => cur.saturating_sub(rows as usize),
+            AutoScrollDirection::Down => cur.saturating_add(rows as usize).min(max),
+        };
+        self.list_scroll.set(next);
+    }
+
+    /// Scroll the open task page's shared notes body by `rows` (view mode only).
+    pub fn nudge_notes_scroll(
+        &mut self,
+        direction: crate::ui::text_select::AutoScrollDirection,
+        rows: u16,
+    ) {
+        use crate::ui::text_select::AutoScrollDirection;
+        let Some(form) = self.form.as_mut() else {
+            return;
+        };
+        let horizon = form.notes_max_scroll.get();
+        form.notes_scroll = match direction {
+            AutoScrollDirection::Up => form.notes_scroll.saturating_sub(rows as usize),
+            AutoScrollDirection::Down => {
+                form.notes_scroll.saturating_add(rows as usize).min(horizon)
+            }
+        };
     }
 
     /// Options the session project selector offers, in presentation order.

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use ratatui::layout::{Position, Rect};
+use ratatui::layout::Position;
 use uuid::Uuid;
 
 use crate::config::VerbModifier;
@@ -998,12 +998,6 @@ impl BoardModel {
     /// Recompute the live highlight after the viewport scrolled under a held drag.
     pub fn recompute_text_selection_head(&mut self, head: Position) {
         self.drag_text_selection(head);
-    }
-
-    /// Copyable text on the original press row (used once, before autoscroll).
-    pub fn copyable_press_line(&self, rows: &[String], copyable: &[Rect]) -> Option<String> {
-        let press = self.mouse_press?;
-        crate::ui::text_select::copyable_line_at(rows, copyable, press.y)
     }
 
     /// Clear the press on release; the selection itself stays until copy clears it

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -648,7 +648,7 @@ pub fn draw_queue_frame(
     frame: &mut Frame<'_>,
     model: &QueueFrameModel<'_>,
     geo: &TierGeometry,
-) -> (QueueHitMap, Option<usize>) {
+) -> (QueueHitMap, Option<(usize, usize)>) {
     let input_slot_geo = bottom_input_slot_geometry(*geo, &model.overlay);
     let geo = &input_slot_geo;
     let mut hits = QueueHitMap::default();
@@ -778,7 +778,7 @@ pub fn draw_queue_frame(
                 }
             }
         }
-        painted_list_scroll = Some(scroll);
+        painted_list_scroll = Some((scroll, max_scroll));
     }
 
     if let Some(row) = geo.rule_row {

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -204,10 +204,10 @@ impl DragSelectGesture {
                 (from, to, true)
             }
             AutoScrollDirection::Up => {
-                let bottom = content.y.saturating_add(content.height);
-                let to = bottom.saturating_sub(1);
-                let from = bottom.saturating_sub(delta);
-                (from, to, false)
+                let end = last_copyable_row(copyable, content)
+                    .unwrap_or_else(|| content.y.saturating_add(content.height.saturating_sub(1)));
+                let from = end.saturating_sub(delta.saturating_sub(1));
+                (from, end, false)
             }
         };
         let lines = selection_lines(rows, copyable, &selection, from, to);
@@ -321,20 +321,6 @@ impl TextSelection {
         let dy = self.anchor.y.abs_diff(self.head.y);
         dx.max(dy) >= 2
     }
-
-    /// Keep the anchor on the same content row after the viewport scrolled.
-    /// Head stays on the pointer.
-    pub fn shift_anchor_y(&mut self, delta: i16) {
-        self.anchor.y = add_y(self.anchor.y, delta);
-    }
-}
-
-fn add_y(y: u16, delta: i16) -> u16 {
-    if delta >= 0 {
-        y.saturating_add(delta as u16)
-    } else {
-        y.saturating_sub(delta.unsigned_abs())
-    }
 }
 
 /// The painted frame's text, one `String` per row, cells concatenated in order.
@@ -397,6 +383,19 @@ fn first_copyable_row(copyable: &[Rect], content: Rect) -> Option<u16> {
         .min()
 }
 
+fn last_copyable_row(copyable: &[Rect], content: Rect) -> Option<u16> {
+    copyable
+        .iter()
+        .filter(|area| {
+            area.width > 0
+                && area.height > 0
+                && area.y >= content.y
+                && area.y < content.y.saturating_add(content.height)
+        })
+        .map(|area| area.y.saturating_add(area.height.saturating_sub(1)))
+        .max()
+}
+
 /// Copyable lines of `selection` whose screen row sits in `y_from..=y_to`.
 /// One-row slices are kept; this is how autoscroll records lines that left the window.
 fn selection_lines(
@@ -451,20 +450,22 @@ pub fn copyable_line_at(rows: &[String], copyable: &[Rect], y: u16) -> Option<St
 }
 
 /// Prefix (scrolled off the top) + live frame + suffix (scrolled off the bottom).
-/// `origin` is the press-row title: lines before it are dropped, and a duplicate
-/// of it at the live/prefix join is dropped.
+/// `origin` is the press-row title. `from_origin` is a downward drag: drop lines
+/// before origin. Upward: drop lines after origin. Seam de-dupe is exact equality
+/// only, so `fix` and `fix bug` stay two titles.
 pub fn compose_selection_copy(
     before: &[String],
     live: Option<String>,
     after: &[String],
     origin: Option<&str>,
+    from_origin: bool,
 ) -> Option<String> {
     let mut lines: Vec<String> = Vec::new();
     lines.extend(before.iter().cloned());
     if let Some(live) = live {
         let live_lines: Vec<String> = live.split('\n').map(str::to_string).collect();
         if let (Some(last), Some(first)) = (lines.last(), live_lines.first()) {
-            if same_copy_line(last, first) {
+            if last == first {
                 lines.extend(live_lines.into_iter().skip(1));
             } else {
                 lines.extend(live_lines);
@@ -476,8 +477,12 @@ pub fn compose_selection_copy(
     lines.extend(after.iter().cloned());
     lines.retain(|line| !line.is_empty());
     if let Some(origin) = origin {
-        if let Some(i) = lines.iter().position(|line| same_copy_line(line, origin)) {
-            lines.drain(..i);
+        if let Some(i) = lines.iter().position(|line| line == origin) {
+            if from_origin {
+                lines.drain(..i);
+            } else {
+                lines.truncate(i.saturating_add(1));
+            }
         }
     }
     if lines.is_empty() {
@@ -485,10 +490,6 @@ pub fn compose_selection_copy(
     } else {
         Some(lines.join("\n"))
     }
-}
-
-fn same_copy_line(a: &str, b: &str) -> bool {
-    a == b || a.ends_with(b) || b.ends_with(a)
 }
 
 /// The copyable column spans covering one row, merged and in paint order.
@@ -932,17 +933,6 @@ mod tests {
     }
 
     #[test]
-    fn shift_anchor_keeps_the_head_on_the_pointer() {
-        let mut sel = TextSelection::new(pos(4, 10), pos(8, 20));
-        sel.shift_anchor_y(-3);
-        assert_eq!(sel.anchor, pos(4, 7));
-        assert_eq!(sel.head, pos(8, 20));
-        sel.shift_anchor_y(2);
-        assert_eq!(sel.anchor, pos(4, 9));
-        assert_eq!(sel.head, pos(8, 20));
-    }
-
-    #[test]
     fn autoscroll_keeps_scrolled_out_copyable_lines() {
         let rows = vec![
             "....title-one..........".to_string(),
@@ -970,8 +960,9 @@ mod tests {
             g.captured_before()
         );
         let live = Some("title-two\ntitle-three".to_string());
-        let text = compose_selection_copy(g.captured_before(), live, g.captured_after(), None)
-            .expect("stitched copy");
+        let text =
+            compose_selection_copy(g.captured_before(), live, g.captured_after(), None, true)
+                .expect("stitched copy");
         assert!(
             text.starts_with("title-one"),
             "copy must keep the start title: {text:?}"
@@ -1014,20 +1005,70 @@ mod tests {
             Some("next\nbelow".into()),
             &[],
             Some("start"),
+            true,
         )
         .expect("copy");
         assert_eq!(text, "start\nnext\nbelow");
-        let partial = compose_selection_copy(
-            &["PR18 overflow 41".into(), "overflow 40".into()],
-            Some("PR18 overflow 40\nPR18 overflow 39".into()),
+    }
+
+    #[test]
+    fn compose_keeps_adjacent_titles_that_share_a_prefix() {
+        let text = compose_selection_copy(
+            &["fix".into()],
+            Some("fix bug".into()),
             &[],
-            Some("overflow 40"),
+            Some("fix"),
+            true,
         )
-        .expect("partial origin");
-        assert!(
-            partial.starts_with("overflow 40") || partial.starts_with("PR18 overflow 40"),
-            "{partial:?}"
+        .expect("copy");
+        assert_eq!(text, "fix\nfix bug");
+    }
+
+    #[test]
+    fn compose_upward_keeps_through_origin_and_drops_titles_below() {
+        let text = compose_selection_copy(
+            &[],
+            Some("top\nstart\nbelow".into()),
+            &["below".into(), "further".into()],
+            Some("start"),
+            false,
+        )
+        .expect("copy");
+        assert_eq!(text, "top\nstart");
+    }
+
+    #[test]
+    fn upward_autoscroll_captures_the_last_copyable_row() {
+        let rows = vec![
+            "....top-title...........".to_string(),
+            "....mid-title...........".to_string(),
+            "....end-title...........".to_string(),
+            "....STATUS..............".to_string(),
+        ];
+        let copyable = vec![Rect::new(4, 0, 12, 3)];
+        let sel = TextSelection::new(pos(16, 2), pos(4, 0));
+        let mut g = DragSelectGesture::new();
+        g.capture_leaving_rows(
+            &rows,
+            &copyable,
+            sel,
+            Rect::new(0, 0, 40, 4),
+            AutoScrollDirection::Up,
+            1,
         );
-        assert!(!partial.contains("overflow 41"), "{partial:?}");
+        assert!(
+            g.captured_after()
+                .last()
+                .is_some_and(|line| line.contains("end-title")),
+            "bottom-to-top crawl must keep the press row, got {:?}",
+            g.captured_after()
+        );
+        assert!(
+            !g.captured_after()
+                .iter()
+                .any(|line| line.contains("STATUS")),
+            "status chrome must not be captured, got {:?}",
+            g.captured_after()
+        );
     }
 }

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -176,10 +176,13 @@ impl DragSelectGesture {
             return;
         }
         let delta = u16::try_from(delta).unwrap_or(u16::MAX);
+        // Sticky headers pin at content.y, so titles leave below them. Use the
+        // first copyable row in the viewport as the top of scrolling content.
+        let origin = first_copyable_row(copyable, content).unwrap_or(content.y);
         let (from, to, prefix) = match direction {
             AutoScrollDirection::Down => {
-                let from = content.y;
-                let to = content.y.saturating_add(delta.saturating_sub(1));
+                let from = origin;
+                let to = origin.saturating_add(delta.saturating_sub(1));
                 (from, to, true)
             }
             AutoScrollDirection::Up => {
@@ -360,6 +363,19 @@ pub fn selection_text(
     } else {
         Some(lines.join("\n"))
     }
+}
+
+fn first_copyable_row(copyable: &[Rect], content: Rect) -> Option<u16> {
+    copyable
+        .iter()
+        .filter(|area| {
+            area.width > 0
+                && area.height > 0
+                && area.y >= content.y
+                && area.y < content.y.saturating_add(content.height)
+        })
+        .map(|area| area.y)
+        .min()
 }
 
 /// Copyable lines of `selection` whose screen row sits in `y_from..=y_to`.
@@ -913,5 +929,33 @@ mod tests {
             "copy must keep the start title: {text:?}"
         );
         assert!(text.contains("title-three"), "{text:?}");
+    }
+
+    #[test]
+    fn downward_autoscroll_captures_titles_below_a_sticky_header() {
+        let rows = vec![
+            "....HEADER..............".to_string(),
+            "....HEADER..............".to_string(),
+            "....start-title.........".to_string(),
+            "....next-title..........".to_string(),
+        ];
+        let copyable = vec![Rect::new(4, 2, 12, 2)];
+        let sel = TextSelection::new(pos(4, 2), pos(10, 3));
+        let mut g = DragSelectGesture::new();
+        g.capture_leaving_rows(
+            &rows,
+            &copyable,
+            sel,
+            Rect::new(0, 0, 40, 4),
+            AutoScrollDirection::Down,
+            1,
+        );
+        assert!(
+            g.captured_before()
+                .first()
+                .is_some_and(|line| line.contains("start-title")),
+            "top-to-bottom crawl must keep the start title under a sticky header, got {:?}",
+            g.captured_before()
+        );
     }
 }

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -464,7 +464,7 @@ pub fn compose_selection_copy(
     if let Some(live) = live {
         let live_lines: Vec<String> = live.split('\n').map(str::to_string).collect();
         if let (Some(last), Some(first)) = (lines.last(), live_lines.first()) {
-            if last == first {
+            if same_copy_line(last, first) {
                 lines.extend(live_lines.into_iter().skip(1));
             } else {
                 lines.extend(live_lines);
@@ -476,7 +476,7 @@ pub fn compose_selection_copy(
     lines.extend(after.iter().cloned());
     lines.retain(|line| !line.is_empty());
     if let Some(origin) = origin {
-        if let Some(i) = lines.iter().position(|line| line == origin) {
+        if let Some(i) = lines.iter().position(|line| same_copy_line(line, origin)) {
             lines.drain(..i);
         }
     }
@@ -485,6 +485,10 @@ pub fn compose_selection_copy(
     } else {
         Some(lines.join("\n"))
     }
+}
+
+fn same_copy_line(a: &str, b: &str) -> bool {
+    a == b || a.ends_with(b) || b.ends_with(a)
 }
 
 /// The copyable column spans covering one row, merged and in paint order.
@@ -1013,5 +1017,17 @@ mod tests {
         )
         .expect("copy");
         assert_eq!(text, "start\nnext\nbelow");
+        let partial = compose_selection_copy(
+            &["PR18 overflow 41".into(), "overflow 40".into()],
+            Some("PR18 overflow 40\nPR18 overflow 39".into()),
+            &[],
+            Some("overflow 40"),
+        )
+        .expect("partial origin");
+        assert!(
+            partial.starts_with("overflow 40") || partial.starts_with("PR18 overflow 40"),
+            "{partial:?}"
+        );
+        assert!(!partial.contains("overflow 41"), "{partial:?}");
     }
 }

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -25,6 +25,71 @@ use ratatui::style::Modifier;
 use ratatui::Frame;
 use unicode_width::UnicodeWidthChar;
 
+// ---------------------------------------------------------------------------
+// Drag edge auto-scroll
+// ---------------------------------------------------------------------------
+
+/// Direction for drag auto-scroll.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoScrollDirection {
+    Up,
+    Down,
+}
+
+/// Timer-driven auto-scroll while a text drag sits near a content edge.
+///
+/// Each idle tick scrolls by `speed` rows in `direction`. Pointer motion
+/// recomputes the state; leaving the edge zone or ending the drag clears it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DragAutoScrollState {
+    pub direction: AutoScrollDirection,
+    /// Rows to scroll per tick.
+    pub speed: u16,
+}
+
+/// Rows of near-edge interior that still arm auto-scroll.
+const EDGE_THRESHOLD: u16 = 2;
+
+/// Compute auto-scroll from the pointer row relative to a content area.
+///
+/// Returns `Some` when the pointer is above, below, or within [`EDGE_THRESHOLD`]
+/// rows of the content boundary; `None` when it sits comfortably inside.
+pub fn compute_autoscroll(mouse_row: u16, content_area: Rect) -> Option<DragAutoScrollState> {
+    let top = content_area.y;
+    let bottom = content_area.y.saturating_add(content_area.height);
+
+    if content_area.height == 0 {
+        return None;
+    }
+
+    if mouse_row < top.saturating_add(EDGE_THRESHOLD) {
+        let distance = top.saturating_add(EDGE_THRESHOLD).saturating_sub(mouse_row);
+        Some(DragAutoScrollState {
+            direction: AutoScrollDirection::Up,
+            speed: speed_for_distance(distance),
+        })
+    } else if mouse_row >= bottom.saturating_sub(EDGE_THRESHOLD) {
+        let distance = mouse_row
+            .saturating_sub(bottom.saturating_sub(EDGE_THRESHOLD))
+            .saturating_add(1);
+        Some(DragAutoScrollState {
+            direction: AutoScrollDirection::Down,
+            speed: speed_for_distance(distance),
+        })
+    } else {
+        None
+    }
+}
+
+fn speed_for_distance(distance: u16) -> u16 {
+    match distance {
+        0..=2 => 1,
+        3..=5 => 2,
+        6..=10 => 3,
+        _ => 5,
+    }
+}
+
 /// Left-button press → drag → release for board text selection.
 ///
 /// Clicks are deferred until release so a real drag can copy without also firing
@@ -34,6 +99,10 @@ use unicode_width::UnicodeWidthChar;
 pub struct DragSelectGesture {
     /// Down cell while a deferred click is still armed (`None` once a drag has area).
     pending_down: Option<Position>,
+    /// Edge auto-scroll armed while a drag with area sits near the content edge.
+    autoscroll: Option<DragAutoScrollState>,
+    /// Last pointer row seen during an active drag (feeds idle ticks).
+    last_drag_row: Option<u16>,
 }
 
 /// One phase of [`DragSelectGesture::handle`].
@@ -63,6 +132,35 @@ impl DragSelectGesture {
     /// Abandon a deferred click (e.g. a key pressed while the button is held).
     pub fn clear(&mut self) {
         self.pending_down = None;
+        self.autoscroll = None;
+        self.last_drag_row = None;
+    }
+
+    /// Whether edge auto-scroll is armed and needs short idle ticks.
+    pub fn has_autoscroll(&self) -> bool {
+        self.autoscroll.is_some()
+    }
+
+    /// Current auto-scroll state, if any.
+    pub fn autoscroll(&self) -> Option<DragAutoScrollState> {
+        self.autoscroll
+    }
+
+    /// Recompute auto-scroll from the pointer row and content area.
+    ///
+    /// Only arms when a drag already has area; otherwise clears.
+    pub fn update_autoscroll(
+        &mut self,
+        mouse_row: u16,
+        content_area: Rect,
+        selection_has_area: bool,
+    ) {
+        self.last_drag_row = Some(mouse_row);
+        if selection_has_area {
+            self.autoscroll = compute_autoscroll(mouse_row, content_area);
+        } else {
+            self.autoscroll = None;
+        }
     }
 
     /// Feed one left-button phase.
@@ -80,15 +178,22 @@ impl DragSelectGesture {
         match phase {
             DragSelectPhase::Press => {
                 self.pending_down = Some(position);
+                self.autoscroll = None;
+                self.last_drag_row = Some(position.y);
                 DragSelectOutcome::Continue
             }
             DragSelectPhase::Move => {
+                self.last_drag_row = Some(position.y);
                 if selection.is_some_and(|sel| sel.has_area()) {
                     self.pending_down = None;
+                } else {
+                    self.autoscroll = None;
                 }
                 DragSelectOutcome::Continue
             }
             DragSelectPhase::Release => {
+                self.autoscroll = None;
+                self.last_drag_row = None;
                 if selection.is_some_and(|sel| sel.has_area()) {
                     self.pending_down = None;
                     DragSelectOutcome::Copy
@@ -264,8 +369,8 @@ fn slice_cells(row: &str, start: u16, end: u16) -> String {
 ///
 /// Geometry matches [`selection_text`]: first/last rows use the drag edges, interior
 /// rows span their copyable columns. Chrome outside those rects (peek `│` gutter,
-/// glyphs, meta) stays unhighlighted — the same content bounds grok-build-style
-/// app selection uses, rather than painting full terminal rows.
+/// glyphs, meta) stays unhighlighted — the same content bounds the copy path
+/// uses, rather than painting full terminal rows.
 pub fn paint_selection(frame: &mut Frame<'_>, selection: &TextSelection, copyable: &[Rect]) {
     if !selection.has_area() {
         return;
@@ -623,5 +728,30 @@ mod tests {
             selection_text(&rows, &copyable, &sel).as_deref(),
             Some("abc")
         );
+    }
+
+    #[test]
+    fn autoscroll_arms_near_edges_and_clears_inside() {
+        let area = Rect::new(0, 10, 40, 20);
+        assert!(compute_autoscroll(20, area).is_none());
+        let up = compute_autoscroll(11, area).expect("near top");
+        assert_eq!(up.direction, AutoScrollDirection::Up);
+        assert_eq!(up.speed, 1);
+        let down = compute_autoscroll(28, area).expect("near bottom");
+        assert_eq!(down.direction, AutoScrollDirection::Down);
+        let far = compute_autoscroll(5, area).expect("above");
+        assert!(far.speed >= 2);
+    }
+
+    #[test]
+    fn gesture_autoscroll_only_while_selection_has_area() {
+        let mut g = DragSelectGesture::new();
+        let area = Rect::new(0, 0, 40, 20);
+        g.update_autoscroll(0, area, false);
+        assert!(!g.has_autoscroll());
+        g.update_autoscroll(0, area, true);
+        assert!(g.has_autoscroll());
+        let _ = g.handle(DragSelectPhase::Release, pos(0, 0), None);
+        assert!(!g.has_autoscroll());
     }
 }

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -176,27 +176,23 @@ impl DragSelectGesture {
             return;
         }
         let delta = u16::try_from(delta).unwrap_or(u16::MAX);
-        let (leaving, prefix) = match direction {
+        let (from, to, prefix) = match direction {
             AutoScrollDirection::Down => {
                 let from = content.y;
                 let to = content.y.saturating_add(delta.saturating_sub(1));
-                (from..=to, true)
+                (from, to, true)
             }
             AutoScrollDirection::Up => {
                 let bottom = content.y.saturating_add(content.height);
                 let to = bottom.saturating_sub(1);
                 let from = bottom.saturating_sub(delta);
-                (from..=to, false)
+                (from, to, false)
             }
         };
-        let Some(clipped) = clip_selection_to_rows(selection, *leaving.start(), *leaving.end())
-        else {
+        let lines = selection_lines(rows, copyable, &selection, from, to);
+        if lines.is_empty() {
             return;
-        };
-        let Some(text) = selection_text(rows, copyable, &clipped) else {
-            return;
-        };
-        let lines = text.split('\n').map(str::to_string);
+        }
         if prefix {
             self.captured_before.extend(lines);
         } else {
@@ -357,9 +353,35 @@ pub fn selection_text(
     if !selection.has_area() {
         return None;
     }
+    let (_, y0, _, y1) = selection.normalized();
+    let lines = selection_lines(rows, copyable, selection, y0, y1);
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+/// Copyable lines of `selection` whose screen row sits in `y_from..=y_to`.
+/// One-row slices are kept; this is how autoscroll records lines that left the window.
+fn selection_lines(
+    rows: &[String],
+    copyable: &[Rect],
+    selection: &TextSelection,
+    y_from: u16,
+    y_to: u16,
+) -> Vec<String> {
+    if y_from > y_to {
+        return Vec::new();
+    }
     let (x0, y0, x1, y1) = selection.normalized();
+    let top = y0.max(y_from);
+    let bottom = y1.min(y_to);
+    if top > bottom {
+        return Vec::new();
+    }
     let mut lines = Vec::new();
-    for y in y0..=y1 {
+    for y in top..=bottom {
         let Some(row) = rows.get(y as usize) else {
             continue;
         };
@@ -382,33 +404,7 @@ pub fn selection_text(
             lines.push(pieces.join(" "));
         }
     }
-    if lines.is_empty() {
-        None
-    } else {
-        Some(lines.join("\n"))
-    }
-}
-
-/// Clip a selection to a closed screen-row range. `None` when they do not overlap
-/// enough to still count as a selection.
-fn clip_selection_to_rows(
-    selection: TextSelection,
-    y_from: u16,
-    y_to: u16,
-) -> Option<TextSelection> {
-    if y_from > y_to {
-        return None;
-    }
-    let (x0, y0, x1, y1) = selection.normalized();
-    let top = y0.max(y_from);
-    let bottom = y1.min(y_to);
-    if top > bottom {
-        return None;
-    }
-    let start_x = if top == y0 { x0 } else { 0 };
-    let end_x = if bottom == y1 { x1 } else { u16::MAX };
-    let clipped = TextSelection::new(Position::new(start_x, top), Position::new(end_x, bottom));
-    clipped.has_area().then_some(clipped)
+    lines
 }
 
 /// Prefix (scrolled off the top) + live frame + suffix (scrolled off the bottom).
@@ -892,6 +888,8 @@ mod tests {
         let copyable = vec![Rect::new(4, 0, 12, 3)];
         let sel = TextSelection::new(pos(4, 0), pos(10, 2));
         let mut g = DragSelectGesture::new();
+        // One viewport row leaving, tall selection: must still keep that line
+        // (the old clip required has_area and dropped single rows).
         g.capture_leaving_rows(
             &rows,
             &copyable,

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -103,6 +103,10 @@ pub struct DragSelectGesture {
     autoscroll: Option<DragAutoScrollState>,
     /// Last pointer row seen during an active drag (feeds idle ticks).
     last_drag_row: Option<u16>,
+    /// Copyable lines that scrolled out of the top of the selection.
+    captured_before: Vec<String>,
+    /// Copyable lines that scrolled out of the bottom of the selection.
+    captured_after: Vec<String>,
 }
 
 /// One phase of [`DragSelectGesture::handle`].
@@ -134,6 +138,8 @@ impl DragSelectGesture {
         self.pending_down = None;
         self.autoscroll = None;
         self.last_drag_row = None;
+        self.captured_before.clear();
+        self.captured_after.clear();
     }
 
     /// Whether edge auto-scroll is armed and needs short idle ticks.
@@ -144,6 +150,58 @@ impl DragSelectGesture {
     /// Current auto-scroll state, if any.
     pub fn autoscroll(&self) -> Option<DragAutoScrollState> {
         self.autoscroll
+    }
+
+    /// Lines that left the selection through the top of the viewport.
+    pub fn captured_before(&self) -> &[String] {
+        &self.captured_before
+    }
+
+    /// Lines that left the selection through the bottom of the viewport.
+    pub fn captured_after(&self) -> &[String] {
+        &self.captured_after
+    }
+
+    /// Keep copyable lines that just scrolled out of the live highlight.
+    pub fn capture_leaving_rows(
+        &mut self,
+        rows: &[String],
+        copyable: &[Rect],
+        selection: TextSelection,
+        content: Rect,
+        direction: AutoScrollDirection,
+        delta: usize,
+    ) {
+        if delta == 0 || content.height == 0 {
+            return;
+        }
+        let delta = u16::try_from(delta).unwrap_or(u16::MAX);
+        let (leaving, prefix) = match direction {
+            AutoScrollDirection::Down => {
+                let from = content.y;
+                let to = content.y.saturating_add(delta.saturating_sub(1));
+                (from..=to, true)
+            }
+            AutoScrollDirection::Up => {
+                let bottom = content.y.saturating_add(content.height);
+                let to = bottom.saturating_sub(1);
+                let from = bottom.saturating_sub(delta);
+                (from..=to, false)
+            }
+        };
+        let Some(clipped) = clip_selection_to_rows(selection, *leaving.start(), *leaving.end())
+        else {
+            return;
+        };
+        let Some(text) = selection_text(rows, copyable, &clipped) else {
+            return;
+        };
+        let lines = text.split('\n').map(str::to_string);
+        if prefix {
+            self.captured_before.extend(lines);
+        } else {
+            self.captured_after.splice(0..0, lines);
+        }
     }
 
     /// Recompute auto-scroll from the pointer row and content area.
@@ -180,6 +238,8 @@ impl DragSelectGesture {
                 self.pending_down = Some(position);
                 self.autoscroll = None;
                 self.last_drag_row = Some(position.y);
+                self.captured_before.clear();
+                self.captured_after.clear();
                 DragSelectOutcome::Continue
             }
             DragSelectPhase::Move => {
@@ -242,6 +302,20 @@ impl TextSelection {
         let dx = self.anchor.x.abs_diff(self.head.x);
         let dy = self.anchor.y.abs_diff(self.head.y);
         dx.max(dy) >= 2
+    }
+
+    /// Keep the anchor on the same content row after the viewport scrolled.
+    /// Head stays on the pointer.
+    pub fn shift_anchor_y(&mut self, delta: i16) {
+        self.anchor.y = add_y(self.anchor.y, delta);
+    }
+}
+
+fn add_y(y: u16, delta: i16) -> u16 {
+    if delta >= 0 {
+        y.saturating_add(delta as u16)
+    } else {
+        y.saturating_sub(delta.unsigned_abs())
     }
 }
 
@@ -308,6 +382,48 @@ pub fn selection_text(
             lines.push(pieces.join(" "));
         }
     }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+/// Clip a selection to a closed screen-row range. `None` when they do not overlap
+/// enough to still count as a selection.
+fn clip_selection_to_rows(
+    selection: TextSelection,
+    y_from: u16,
+    y_to: u16,
+) -> Option<TextSelection> {
+    if y_from > y_to {
+        return None;
+    }
+    let (x0, y0, x1, y1) = selection.normalized();
+    let top = y0.max(y_from);
+    let bottom = y1.min(y_to);
+    if top > bottom {
+        return None;
+    }
+    let start_x = if top == y0 { x0 } else { 0 };
+    let end_x = if bottom == y1 { x1 } else { u16::MAX };
+    let clipped = TextSelection::new(Position::new(start_x, top), Position::new(end_x, bottom));
+    clipped.has_area().then_some(clipped)
+}
+
+/// Prefix (scrolled off the top) + live frame + suffix (scrolled off the bottom).
+pub fn compose_selection_copy(
+    before: &[String],
+    live: Option<String>,
+    after: &[String],
+) -> Option<String> {
+    let mut lines: Vec<String> = Vec::new();
+    lines.extend(before.iter().cloned());
+    if let Some(live) = live {
+        lines.extend(live.split('\n').map(str::to_string));
+    }
+    lines.extend(after.iter().cloned());
+    lines.retain(|line| !line.is_empty());
     if lines.is_empty() {
         None
     } else {
@@ -753,5 +869,51 @@ mod tests {
         assert!(g.has_autoscroll());
         let _ = g.handle(DragSelectPhase::Release, pos(0, 0), None);
         assert!(!g.has_autoscroll());
+    }
+
+    #[test]
+    fn shift_anchor_keeps_the_head_on_the_pointer() {
+        let mut sel = TextSelection::new(pos(4, 10), pos(8, 20));
+        sel.shift_anchor_y(-3);
+        assert_eq!(sel.anchor, pos(4, 7));
+        assert_eq!(sel.head, pos(8, 20));
+        sel.shift_anchor_y(2);
+        assert_eq!(sel.anchor, pos(4, 9));
+        assert_eq!(sel.head, pos(8, 20));
+    }
+
+    #[test]
+    fn autoscroll_keeps_scrolled_out_copyable_lines() {
+        let rows = vec![
+            "....title-one..........".to_string(),
+            "....title-two..........".to_string(),
+            "....title-three........".to_string(),
+        ];
+        let copyable = vec![Rect::new(4, 0, 12, 3)];
+        let sel = TextSelection::new(pos(4, 0), pos(10, 2));
+        let mut g = DragSelectGesture::new();
+        g.capture_leaving_rows(
+            &rows,
+            &copyable,
+            sel,
+            Rect::new(0, 0, 40, 3),
+            AutoScrollDirection::Down,
+            1,
+        );
+        assert!(
+            g.captured_before()
+                .first()
+                .is_some_and(|line| line.starts_with("title-one")),
+            "start title must be kept, got {:?}",
+            g.captured_before()
+        );
+        let live = Some("title-two\ntitle-three".to_string());
+        let text = compose_selection_copy(g.captured_before(), live, g.captured_after())
+            .expect("stitched copy");
+        assert!(
+            text.starts_with("title-one"),
+            "copy must keep the start title: {text:?}"
+        );
+        assert!(text.contains("title-three"), "{text:?}");
     }
 }

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -152,6 +152,10 @@ impl DragSelectGesture {
         self.autoscroll
     }
 
+    pub fn last_drag_row(&self) -> Option<u16> {
+        self.last_drag_row
+    }
+
     /// Lines that left the selection through the top of the viewport.
     pub fn captured_before(&self) -> &[String] {
         &self.captured_before

--- a/src/ui/text_select.rs
+++ b/src/ui/text_select.rs
@@ -107,6 +107,8 @@ pub struct DragSelectGesture {
     captured_before: Vec<String>,
     /// Copyable lines that scrolled out of the bottom of the selection.
     captured_after: Vec<String>,
+    /// Copyable text on the press row; copy never includes lines before this.
+    copy_origin: Option<String>,
 }
 
 /// One phase of [`DragSelectGesture::handle`].
@@ -140,6 +142,7 @@ impl DragSelectGesture {
         self.last_drag_row = None;
         self.captured_before.clear();
         self.captured_after.clear();
+        self.copy_origin = None;
     }
 
     /// Whether edge auto-scroll is armed and needs short idle ticks.
@@ -164,6 +167,17 @@ impl DragSelectGesture {
     /// Lines that left the selection through the bottom of the viewport.
     pub fn captured_after(&self) -> &[String] {
         &self.captured_after
+    }
+
+    pub fn copy_origin(&self) -> Option<&str> {
+        self.copy_origin.as_deref()
+    }
+
+    /// Remember the press-row title once, before autoscroll moves it.
+    pub fn ensure_copy_origin(&mut self, line: String) {
+        if self.copy_origin.is_none() && !line.is_empty() {
+            self.copy_origin = Some(line);
+        }
     }
 
     /// Keep copyable lines that just scrolled out of the live highlight.
@@ -243,6 +257,7 @@ impl DragSelectGesture {
                 self.last_drag_row = Some(position.y);
                 self.captured_before.clear();
                 self.captured_after.clear();
+                self.copy_origin = None;
                 DragSelectOutcome::Continue
             }
             DragSelectPhase::Move => {
@@ -427,19 +442,44 @@ fn selection_lines(
     lines
 }
 
+/// Copyable text on one screen row, same trim as a drag copy.
+pub fn copyable_line_at(rows: &[String], copyable: &[Rect], y: u16) -> Option<String> {
+    let dummy = TextSelection::new(Position::new(0, y), Position::new(u16::MAX, y));
+    selection_lines(rows, copyable, &dummy, y, y)
+        .into_iter()
+        .next()
+}
+
 /// Prefix (scrolled off the top) + live frame + suffix (scrolled off the bottom).
+/// `origin` is the press-row title: lines before it are dropped, and a duplicate
+/// of it at the live/prefix join is dropped.
 pub fn compose_selection_copy(
     before: &[String],
     live: Option<String>,
     after: &[String],
+    origin: Option<&str>,
 ) -> Option<String> {
     let mut lines: Vec<String> = Vec::new();
     lines.extend(before.iter().cloned());
     if let Some(live) = live {
-        lines.extend(live.split('\n').map(str::to_string));
+        let live_lines: Vec<String> = live.split('\n').map(str::to_string).collect();
+        if let (Some(last), Some(first)) = (lines.last(), live_lines.first()) {
+            if last == first {
+                lines.extend(live_lines.into_iter().skip(1));
+            } else {
+                lines.extend(live_lines);
+            }
+        } else {
+            lines.extend(live_lines);
+        }
     }
     lines.extend(after.iter().cloned());
     lines.retain(|line| !line.is_empty());
+    if let Some(origin) = origin {
+        if let Some(i) = lines.iter().position(|line| line == origin) {
+            lines.drain(..i);
+        }
+    }
     if lines.is_empty() {
         None
     } else {
@@ -926,7 +966,7 @@ mod tests {
             g.captured_before()
         );
         let live = Some("title-two\ntitle-three".to_string());
-        let text = compose_selection_copy(g.captured_before(), live, g.captured_after())
+        let text = compose_selection_copy(g.captured_before(), live, g.captured_after(), None)
             .expect("stitched copy");
         assert!(
             text.starts_with("title-one"),
@@ -961,5 +1001,17 @@ mod tests {
             "top-to-bottom crawl must keep the start title under a sticky header, got {:?}",
             g.captured_before()
         );
+    }
+
+    #[test]
+    fn compose_drops_unselected_titles_above_the_origin() {
+        let text = compose_selection_copy(
+            &["above".into(), "start".into(), "next".into()],
+            Some("next\nbelow".into()),
+            &[],
+            Some("start"),
+        )
+        .expect("copy");
+        assert_eq!(text, "start\nnext\nbelow");
     }
 }

--- a/tests/queue_board_loop.rs
+++ b/tests/queue_board_loop.rs
@@ -156,6 +156,44 @@ fn instrumented_loop_idle_wait_never_sustained_below_25ms_without_animation() {
     );
 }
 
+#[test]
+fn autoscroll_shortens_the_board_frame_wait() {
+    let domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    let mut recorded = None;
+    let poll = board_frame(
+        &mut model,
+        || panic!("no walkthrough"),
+        |model| {
+            terminal
+                .draw(|frame| {
+                    let _ = draw_board(frame, model);
+                })
+                .expect("draw");
+            Ok(())
+        },
+        |duration| {
+            recorded = Some(duration);
+            Ok(false)
+        },
+        true,
+    )
+    .expect("board frame");
+    assert_eq!(poll, FramePoll::Idle);
+    let wait = recorded.expect("wait recorded");
+    assert_eq!(wait, next_wait(true, DEFAULT_BASE_TICK));
+    assert!(
+        wait < Duration::from_millis(250),
+        "armed autoscroll must shorten the wait, got {wait:?}"
+    );
+    assert!(
+        wait >= Duration::from_millis(25),
+        "short tick must stay at the 25ms floor, got {wait:?}"
+    );
+}
+
 /// [`load_board_model`] (the whole the open path: store load + context snapshot + BoardModel
 /// construction, no host refresh) feeds straight into [`draw_board`] without panicking at the
 /// standard tier's floor size ( smoke;/'s "board loop stops calling attention"

--- a/tests/queue_board_loop.rs
+++ b/tests/queue_board_loop.rs
@@ -127,6 +127,7 @@ fn instrumented_loop_idle_wait_never_sustained_below_25ms_without_animation() {
                 recorded_waits.push(duration);
                 Ok(false)
             },
+            false,
         )
         .expect("board frame");
         assert_eq!(

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -13,6 +13,7 @@ use ratatui::backend::TestBackend;
 use ratatui::layout::{Position, Rect};
 use ratatui::Terminal;
 
+use tsk_tui::app::{drag_content_area, tick_drag_autoscroll};
 use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
 use tsk_tui::ui::board::{
     apply_intent, board_hit_map, board_verb_items, draw_board, resolve_board_command,
@@ -28,7 +29,9 @@ use tsk_tui::ui::mouse::{
     map_scrollbar_mouse, primary_capture_action_sample_mouse, scrollbar_intent_at, ScrollbarMouse,
 };
 use tsk_tui::ui::render::{QueueHit, QueueHitMap, QueueHitTarget};
-use tsk_tui::ui::text_select::{self, AutoScrollDirection, DragSelectGesture};
+use tsk_tui::ui::text_select::{
+    self, AutoScrollDirection, DragAutoScrollState, DragSelectGesture, DragSelectPhase,
+};
 
 const THIS_REPO: &str = "/repos/app";
 const OTHER_REPO: &str = "/repos/other";
@@ -2309,28 +2312,33 @@ fn downward_autoscroll_copy_excludes_titles_above_the_press_row() {
     model.begin_mouse_press(Position::new(10, start_y));
     model.drag_text_selection(Position::new(10, 20));
     let mut gesture = DragSelectGesture::new();
+    let _ = gesture.handle(
+        DragSelectPhase::Move,
+        Position::new(10, 20),
+        model.text_selection(),
+    );
     gesture.ensure_copy_origin(origin.clone());
 
-    let content = Rect::new(0, 2, 80, 19);
+    let content = drag_content_area(&model, STANDARD);
+    let auto = DragAutoScrollState {
+        direction: AutoScrollDirection::Down,
+        speed: 1,
+    };
     for _ in 0..12 {
         let rows = page_rows(&model);
         let hits = board_hit_map(STANDARD, &model);
-        let Some(sel) = model.text_selection() else {
-            break;
-        };
-        let delta = model.nudge_list_scroll(AutoScrollDirection::Down, 1);
-        if delta == 0 {
-            break;
-        }
-        gesture.capture_leaving_rows(
+        let before = model.list_scroll();
+        tick_drag_autoscroll(
+            &mut model,
+            &mut gesture,
+            auto,
             &rows,
             &hits.copyable,
-            sel,
             content,
-            AutoScrollDirection::Down,
-            delta,
         );
-        model.recompute_text_selection_head(Position::new(10, 20));
+        if model.list_scroll() == before {
+            break;
+        }
     }
 
     let rows = page_rows(&model);
@@ -2338,11 +2346,15 @@ fn downward_autoscroll_copy_excludes_titles_above_the_press_row() {
     let live = model
         .text_selection()
         .and_then(|sel| text_select::selection_text(&rows, &hits.copyable, &sel));
+    let from_origin = model
+        .text_selection()
+        .is_some_and(|sel| sel.anchor.y <= sel.head.y);
     let text = text_select::compose_selection_copy(
         gesture.captured_before(),
         live,
         gesture.captured_after(),
         gesture.copy_origin(),
+        from_origin,
     )
     .expect("copy");
     assert!(
@@ -2352,5 +2364,61 @@ fn downward_autoscroll_copy_excludes_titles_above_the_press_row() {
     assert!(
         text.contains("task 30"),
         "copy must include the press row:\n{text}"
+    );
+}
+
+#[test]
+fn task_page_autoscroll_tick_moves_notes() {
+    let notes = (0..30)
+        .map(|i| format!("page-scroll line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Page autoscroll",
+            Some(notes),
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
+    let _ = page_rows(&model);
+    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+    let content = drag_content_area(&model, STANDARD);
+    assert!(
+        content.y > 0 && content.height > 0,
+        "task-page content must sit below the header, got {content:?}"
+    );
+    model.begin_mouse_press(Position::new(10, content.y.saturating_add(2)));
+    model.drag_text_selection(Position::new(10, content.y.saturating_add(content.height)));
+    let mut gesture = DragSelectGesture::new();
+    let head = Position::new(
+        10,
+        content.y.saturating_add(content.height.saturating_sub(1)),
+    );
+    let _ = gesture.handle(DragSelectPhase::Move, head, model.text_selection());
+    let before = page_rows(&model);
+    let hits = board_hit_map(STANDARD, &model);
+    tick_drag_autoscroll(
+        &mut model,
+        &mut gesture,
+        DragAutoScrollState {
+            direction: AutoScrollDirection::Down,
+            speed: 2,
+        },
+        &before,
+        &hits.copyable,
+        content,
+    );
+    let after = page_rows(&model);
+    assert_ne!(
+        after,
+        before,
+        "task-page autoscroll tick must move notes:\n{}",
+        after.join("\n")
     );
 }

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::backend::TestBackend;
-use ratatui::layout::Rect;
+use ratatui::layout::{Position, Rect};
 use ratatui::Terminal;
 
 use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskScope};
@@ -28,6 +28,7 @@ use tsk_tui::ui::mouse::{
     map_scrollbar_mouse, primary_capture_action_sample_mouse, scrollbar_intent_at, ScrollbarMouse,
 };
 use tsk_tui::ui::render::{QueueHit, QueueHitMap, QueueHitTarget};
+use tsk_tui::ui::text_select::{self, AutoScrollDirection, DragSelectGesture};
 
 const THIS_REPO: &str = "/repos/app";
 const OTHER_REPO: &str = "/repos/other";
@@ -2285,5 +2286,71 @@ fn painting_clamps_an_oversize_list_scroll_back_into_the_model() {
         model.list_scroll() < 10_000,
         "paint must write the clamped offset back, got {}",
         model.list_scroll()
+    );
+}
+
+#[test]
+fn downward_autoscroll_copy_excludes_titles_above_the_press_row() {
+    let (_, mut model) = deck_of(40);
+    let _ = page_rows(&model);
+    let hits = board_hit_map(STANDARD, &model);
+    let rows = page_rows(&model);
+    let start_y = rows
+        .iter()
+        .position(|row| row.contains("task 30"))
+        .expect("task 30 visible") as u16;
+    let origin = text_select::copyable_line_at(&rows, &hits.copyable, start_y)
+        .expect("press row is copyable");
+    assert!(
+        origin.contains("task 30"),
+        "origin must be the pressed title, got {origin:?}"
+    );
+
+    model.begin_mouse_press(Position::new(10, start_y));
+    model.drag_text_selection(Position::new(10, 20));
+    let mut gesture = DragSelectGesture::new();
+    gesture.ensure_copy_origin(origin.clone());
+
+    let content = Rect::new(0, 2, 80, 19);
+    for _ in 0..12 {
+        let rows = page_rows(&model);
+        let hits = board_hit_map(STANDARD, &model);
+        let Some(sel) = model.text_selection() else {
+            break;
+        };
+        let delta = model.nudge_list_scroll(AutoScrollDirection::Down, 1);
+        if delta == 0 {
+            break;
+        }
+        gesture.capture_leaving_rows(
+            &rows,
+            &hits.copyable,
+            sel,
+            content,
+            AutoScrollDirection::Down,
+            delta,
+        );
+        model.recompute_text_selection_head(Position::new(10, 20));
+    }
+
+    let rows = page_rows(&model);
+    let hits = board_hit_map(STANDARD, &model);
+    let live = model
+        .text_selection()
+        .and_then(|sel| text_select::selection_text(&rows, &hits.copyable, &sel));
+    let text = text_select::compose_selection_copy(
+        gesture.captured_before(),
+        live,
+        gesture.captured_after(),
+        gesture.copy_origin(),
+    )
+    .expect("copy");
+    assert!(
+        !text.contains("task 39"),
+        "copy must not include titles above the press row:\n{text}"
+    );
+    assert!(
+        text.contains("task 30"),
+        "copy must include the press row:\n{text}"
     );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While a text drag sits near the top or bottom of the board list or task-page notes viewport, idle ticks scroll that surface and shorten the frame wait so motion keeps up. Leaving the edge zone or releasing clears it.

The board list keeps an independent scroll offset so auto-scroll can reveal rows without moving the pinned selection; selection-follow still pulls the pin back into view when it would leave the window.

## Stack

1. List scrollbar (#17) — base
2. **This PR** — edge auto-scroll
3. Hover feedback (follows)
4. Resize debounce (follows)
5. Mono markdown notes (follows)

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
- [x] Unit tests for edge-zone arming / clear on release
- [ ] Live herdr smoke not run (`HERDR_ENV` unset)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c02137c7-0c5d-487a-b0f8-4410c62815f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c02137c7-0c5d-487a-b0f8-4410c62815f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

