### PR TITLE
feat: underline hover on board list rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Board list hover: moving the pointer over a task row underlines it (mono only).
+Selection stays reverse; hover clears when the pointer leaves task rows or the
+board leaves normal list mode.
+
 Edge auto-scroll during text drag-select: holding a selection near the top or
 bottom of the board list or task-page notes viewport scrolls that surface while
 the drag stays armed, with a faster idle tick so the motion keeps up with the

--- a/src/app.rs
+++ b/src/app.rs
@@ -491,6 +491,11 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                             }
                             continue;
                         }
+                        MouseEventKind::Moved => {
+                            let area = terminal_area(terminal)?;
+                            update_board_hover(&mut model, area, mouse.column, mouse.row);
+                            continue;
+                        }
                         _ => {}
                     }
                     let area = terminal_area(terminal)?;
@@ -615,6 +620,26 @@ pub fn tick_drag_autoscroll(
         let x = model.text_selection().map(|s| s.head.x).unwrap_or(0);
         model.recompute_text_selection_head(ratatui::layout::Position::new(x, y));
     }
+}
+
+/// Track which board-list task sits under the pointer (underline hover).
+fn update_board_hover(model: &mut BoardModel, area: Rect, column: u16, row: u16) {
+    if model.input_mode() != BoardInputMode::Normal {
+        model.set_hover_id(None);
+        return;
+    }
+    let hits = crate::ui::board::board_hit_map(area, model);
+    let pos = Position::new(column, row);
+    let id = hits
+        .regions
+        .iter()
+        .rev()
+        .find(|hit| hit.area.contains(pos))
+        .and_then(|hit| match hit.target {
+            crate::ui::render::QueueHitTarget::Task(id) => Some(id),
+            _ => None,
+        });
+    model.set_hover_id(id);
 }
 
 /// Whether save recovery permits the board to apply background state changes.

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -638,6 +638,7 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
         detail_open: model.detail_open,
         list_scroll: model.list_scroll.get(),
         follow_list: model.follow_list.get(),
+        hover_id: model.hover_id,
     };
     let (hits, painted_list_scroll) = render::draw_queue_frame(frame, &frame_model, &geo);
     if let Some((scroll, max_scroll)) = painted_list_scroll {

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -526,6 +526,8 @@ pub struct BoardModel {
     pub(super) detail_open: Option<Uuid>,
     /// Id-pinned selection into the queue-visible row set.
     pub(super) selection_id: Option<Uuid>,
+    /// Task under the pointer on the board list (underline hover). Session-only.
+    pub(super) hover_id: Option<Uuid>,
     /// The last task-row click (time + id), kept only to detect a double-click that opens
     /// the task page. Presentation-only, never persisted.
     pub(super) last_row_click: Option<(Instant, Uuid)>,
@@ -628,6 +630,7 @@ impl BoardModel {
             drawer_open: false,
             detail_open: None,
             selection_id: None,
+            hover_id: None,
             last_row_click: None,
             last_project_header_click: None,
             input_mode: BoardInputMode::Normal,
@@ -1181,6 +1184,16 @@ impl BoardModel {
     /// Current list viewport offset.
     pub fn list_scroll(&self) -> usize {
         self.list_scroll.get()
+    }
+
+    /// Task under the pointer, if the board list is tracking hover.
+    pub fn hover_id(&self) -> Option<Uuid> {
+        self.hover_id
+    }
+
+    /// Update list-row hover from a pointer move (or clear it).
+    pub fn set_hover_id(&mut self, id: Option<Uuid>) {
+        self.hover_id = id;
     }
 }
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -103,6 +103,8 @@ pub struct TaskRowPaint<'a> {
     pub selected: bool,
     /// Bold the title when unselected (e.g. attention emphasis).
     pub title_bold: bool,
+    /// Pointer rests on this row (and it is not selected): underline, not reverse.
+    pub hovered: bool,
 }
 
 /// One painted task-row line plus the title-content cells a text selection may copy.
@@ -157,6 +159,8 @@ pub fn paint_task_row_lines(
     let indent = " ".repeat(prefix_cells);
     let continuation_style = if row.selected {
         style_reverse()
+    } else if row.hovered {
+        style_underline()
     } else {
         style_plain()
     };
@@ -233,6 +237,8 @@ fn paint_task_row_with_indent(
 
     let (left_style, leader_style, meta_style) = if row.selected {
         (style_reverse(), style_reverse_dim(), style_reverse_dim())
+    } else if row.hovered {
+        (style_underline(), style_dim(), style_dim())
     } else {
         let title_style = if row.title_bold {
             style_bold()
@@ -507,6 +513,8 @@ pub struct QueueFrameModel<'a> {
     pub list_scroll: usize,
     /// Nudge `list_scroll` so the selection (or its peek) stays on screen.
     pub follow_list: bool,
+    /// Task id under the pointer (board list hover), if any.
+    pub hover_id: Option<Uuid>,
 }
 
 /// Logical control under a painted rectangle (rebuilt every frame).
@@ -2557,6 +2565,7 @@ fn build_list_rows(
         let meta = row_meta(task, model.now, in_project_section);
         let selected = model.selection_id == Some(task.id)
             && !matches!(model.overlay, QueueOverlay::ScopeDropdown { .. });
+        let hovered = !selected && model.hover_id == Some(task.id);
         // A long title wraps onto continuation lines indented under its own first
         // row; every painted line carries the task's hit target and selection.
         let lines = paint_task_row_lines(
@@ -2566,6 +2575,7 @@ fn build_list_rows(
                 meta: &meta,
                 selected,
                 title_bold: false,
+                hovered,
             },
             geo,
             usize::from(indented_under_thread) * 2,
@@ -3359,6 +3369,7 @@ mod tests {
                 meta: long_meta,
                 selected: false,
                 title_bold: false,
+                hovered: false,
             },
             &geo,
         );
@@ -3404,6 +3415,7 @@ mod tests {
                 meta: "1h",
                 selected: false,
                 title_bold: false,
+                hovered: false,
             },
             &geo,
         );
@@ -3419,6 +3431,7 @@ mod tests {
                 meta: long_meta,
                 selected: false,
                 title_bold: false,
+                hovered: false,
             },
             &geo,
         );
@@ -3465,6 +3478,7 @@ mod tests {
                                 meta,
                                 selected,
                                 title_bold: selected,
+                                hovered: false,
                             },
                             &geo,
                         );
@@ -3537,6 +3551,7 @@ mod tests {
                 meta: "1h",
                 selected: false,
                 title_bold: false,
+                hovered: false,
             },
             TaskRowPaint {
                 glyph: "▲",
@@ -3544,6 +3559,7 @@ mod tests {
                 meta: "tsk · 2m",
                 selected: false,
                 title_bold: true,
+                hovered: false,
             },
             TaskRowPaint {
                 glyph: "◓",
@@ -3551,6 +3567,7 @@ mod tests {
                 meta: "3d",
                 selected: true,
                 title_bold: false,
+                hovered: false,
             },
         ];
 

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -2422,3 +2422,35 @@ fn task_page_autoscroll_tick_moves_notes() {
         after.join("\n")
     );
 }
+
+#[test]
+fn pointer_move_over_a_task_row_sets_hover_without_changing_selection() {
+    let (domain, mut model) = deck_of(3);
+    let visible = model.visible_ids();
+    let first = visible[0];
+    let second = visible[1];
+    assert_eq!(model.selected_id(), Some(first));
+    assert_eq!(model.hover_id(), None);
+
+    let hits = board_hit_map(STANDARD, &model);
+    let area = hits
+        .regions
+        .iter()
+        .find(|hit| hit.target == QueueHitTarget::Task(second))
+        .expect("second row hit")
+        .area;
+    model.set_hover_id(Some(second));
+    assert_eq!(model.hover_id(), Some(second));
+    assert_eq!(
+        model.selected_id(),
+        Some(first),
+        "hover must not move selection"
+    );
+
+    // Painting with hover_id set must still keep selection reverse and not panic.
+    let mut hovered = model;
+    hovered.set_hover_id(Some(second));
+    let _ = board_hit_map(STANDARD, &hovered);
+    let _ = domain;
+    let _ = area;
+}

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -339,6 +339,7 @@ fn fixture_model_on_tab<'a>(
         detail_open: None,
         list_scroll: 0,
         follow_list: true,
+        hover_id: None,
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moving the pointer over a board-list task row underlines it (mono only). Selection stays reverse; hover clears when the pointer leaves task rows or the board leaves normal list mode.

## Stack

1. List scrollbar (#17)
2. Edge auto-scroll (#18) — base
3. **This PR** — hover feedback
4. Resize debounce (follows)
5. Mono markdown notes (follows)

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
- [x] Hover does not move selection
- [ ] Live herdr smoke not run (`HERDR_ENV` unset)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c02137c7-0c5d-487a-b0f8-4410c62815f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c02137c7-0c5d-487a-b0f8-4410c62815f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

