### PR TITLE
feat: debounce terminal resize bursts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Resize debounce: a burst of terminal `Resize` events (pane-edge drag) waits a
+short quiet window and paints layout once at the settled size. A key or mouse
+event that arrives during that window is deferred until after that paint.
+
 Edge auto-scroll during text drag-select: holding a selection near the top or
 bottom of the board list or task-page notes viewport scrolls that surface while
 the drag stays armed, with a faster idle tick so the motion keeps up with the

--- a/src/app.rs
+++ b/src/app.rs
@@ -309,48 +309,64 @@ fn run_board() -> Result<(), Box<dyn Error>> {
         // felt reliable on the task page where Down is inert over notes.
         let mut drag_gesture = crate::ui::text_select::DragSelectGesture::new();
         let mut scrollbar_drag = false;
+        // Non-resize event that arrived during a resize debounce window; handled
+        // after one settled-size paint so a key typed mid-drag is not dropped.
+        let mut pending_event: Option<Event> = None;
         loop {
             // Settle, paint, then wait. The board frame path does no host polling, so the
             // wait is only the Frame Scheduler's idle floor. All three are one call because
             // the order is the correctness property: the walkthrough's report from the
             // previous iteration is written before this frame is painted and before the wait
             // can time out into the `continue` below.
-            let poll = board_idle_tick(
-                &mut model,
-                || walkthrough.record_dismissed(),
-                |model: &BoardModel| {
-                    terminal
-                        .draw(|frame| {
-                            let hits = draw_board(frame, model);
-                            frame_rows = frame_text_rows(frame.buffer_mut());
-                            frame_copyable = hits.copyable.clone();
-                            frame_hits = hits;
-                        })
-                        .map(|_| ())
-                },
-                event::poll,
-                &store,
-                &mut domain,
-                &mut store_watch,
-                &save_recovery,
-                drag_gesture.has_autoscroll(),
-            )?;
-            if poll == FramePoll::Idle {
-                if let Some(auto) = drag_gesture.autoscroll() {
-                    let area = terminal_area(terminal)?;
-                    let content = drag_content_area(&model, area);
-                    tick_drag_autoscroll(
-                        &mut model,
-                        &mut drag_gesture,
-                        auto,
-                        &frame_rows,
-                        &frame_copyable,
-                        content,
-                    );
+            let next = if let Some(event) = pending_event.take() {
+                // Paint once at the settled size before applying a key/mouse that
+                // arrived during the resize quiet window.
+                terminal.draw(|frame| {
+                    let hits = draw_board(frame, &model);
+                    frame_rows = frame_text_rows(frame.buffer_mut());
+                    frame_copyable = hits.copyable.clone();
+                    frame_hits = hits;
+                })?;
+                event
+            } else {
+                let poll = board_idle_tick(
+                    &mut model,
+                    || walkthrough.record_dismissed(),
+                    |model: &BoardModel| {
+                        terminal
+                            .draw(|frame| {
+                                let hits = draw_board(frame, model);
+                                frame_rows = frame_text_rows(frame.buffer_mut());
+                                frame_copyable = hits.copyable.clone();
+                                frame_hits = hits;
+                            })
+                            .map(|_| ())
+                    },
+                    event::poll,
+                    &store,
+                    &mut domain,
+                    &mut store_watch,
+                    &save_recovery,
+                    drag_gesture.has_autoscroll(),
+                )?;
+                if poll == FramePoll::Idle {
+                    if let Some(auto) = drag_gesture.autoscroll() {
+                        let area = terminal_area(terminal)?;
+                        let content = drag_content_area(&model, area);
+                        tick_drag_autoscroll(
+                            &mut model,
+                            &mut drag_gesture,
+                            auto,
+                            &frame_rows,
+                            &frame_copyable,
+                            content,
+                        );
+                    }
+                    continue;
                 }
-                continue;
-            }
-            match event::read()? {
+                event::read()?
+            };
+            match next {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     // A key while the mouse button is held abandons the deferred click so
                     // Up does not fire a stale peek/select after the keyboard moved on.
@@ -522,7 +538,15 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                         break;
                     }
                 }
-                Event::Resize(_, _) => {}
+                Event::Resize(_, _) => {
+                    // Dragging a pane edge fires a burst of resizes; wait them out
+                    // so the next paint rebuilds layout once at the settled size.
+                    pending_event =
+                        scheduler::coalesce_resizes(event::poll, event::read, |event| {
+                            matches!(event, Event::Resize(_, _))
+                        })?;
+                    continue;
+                }
                 _ => {}
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -177,6 +177,21 @@ pub fn board_poll_duration(active_animations: bool) -> Duration {
     scheduler::next_wait(active_animations, scheduler::DEFAULT_BASE_TICK)
 }
 
+/// Paint once at the settled size, then yield the event that interrupted a resize burst.
+///
+/// `run_board` uses this after [`scheduler::coalesce_resizes`] so a key or click typed
+/// during a pane-edge drag is not dispatched against the pre-resize layout.
+pub fn take_pending_after_paint<E>(
+    pending: &mut Option<Event>,
+    paint: impl FnOnce() -> Result<(), E>,
+) -> Result<Option<Event>, E> {
+    let Some(event) = pending.take() else {
+        return Ok(None);
+    };
+    paint()?;
+    Ok(Some(event))
+}
+
 /// One board frame in the only order survives: **settle, paint, wait**.
 ///
 /// The settle lives here rather than at the caller's convenience because the *placement* is
@@ -318,15 +333,15 @@ fn run_board() -> Result<(), Box<dyn Error>> {
             // the order is the correctness property: the walkthrough's report from the
             // previous iteration is written before this frame is painted and before the wait
             // can time out into the `continue` below.
-            let next = if let Some(event) = pending_event.take() {
-                // Paint once at the settled size before applying a key/mouse that
-                // arrived during the resize quiet window.
+            let next = if let Some(event) = take_pending_after_paint(&mut pending_event, || {
                 terminal.draw(|frame| {
                     let hits = draw_board(frame, &model);
                     frame_rows = frame_text_rows(frame.buffer_mut());
                     frame_copyable = hits.copyable.clone();
                     frame_hits = hits;
                 })?;
+                Ok::<(), io::Error>(())
+            })? {
                 event
             } else {
                 let poll = board_idle_tick(
@@ -541,10 +556,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                 Event::Resize(_, _) => {
                     // Dragging a pane edge fires a burst of resizes; wait them out
                     // so the next paint rebuilds layout once at the settled size.
-                    pending_event =
-                        scheduler::coalesce_resizes(event::poll, event::read, |event| {
-                            matches!(event, Event::Resize(_, _))
-                        })?;
+                    pending_event = scheduler::coalesce_resizes(event::poll, event::read)?;
                     continue;
                 }
                 _ => {}

--- a/src/ui/scheduler.rs
+++ b/src/ui/scheduler.rs
@@ -13,6 +13,12 @@ const SHORT_TICK_FLOOR: Duration = Duration::from_millis(25);
 /// Prototype-like animation frame interval (~30 Hz, within 16–33 ms).
 const SHORT_TICK: Duration = Duration::from_millis(33);
 
+/// Quiet window after a terminal resize before the next forced layout paint.
+///
+/// Dragging a pane edge fires many `Event::Resize` reports; waiting this long
+/// after the latest one lets the size settle so the board rebuilds once.
+pub const RESIZE_DEBOUNCE: Duration = Duration::from_millis(50);
+
 /// Next input-wait duration for one frame-loop cycle.
 ///
 /// - Idle (`active_animations == false`): at least `base` and
@@ -26,9 +32,39 @@ pub fn next_wait(active_animations: bool, base: Duration) -> Duration {
     }
 }
 
+/// Drain a burst of resize events, returning the first non-resize (if any).
+///
+/// `poll` / `read` are injected so the policy is unit-testable without a tty.
+/// Each resize resets the quiet window; when the window elapses with no further
+/// event, returns `None` so the caller can paint once at the settled size.
+pub fn coalesce_resizes<E>(
+    mut poll: impl FnMut(Duration) -> Result<bool, E>,
+    mut read: impl FnMut() -> Result<crossterm::event::Event, E>,
+    is_resize: impl Fn(&crossterm::event::Event) -> bool,
+) -> Result<Option<crossterm::event::Event>, E> {
+    let mut deadline = std::time::Instant::now() + RESIZE_DEBOUNCE;
+    loop {
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            return Ok(None);
+        }
+        let wait = deadline.saturating_duration_since(now);
+        if !poll(wait)? {
+            return Ok(None);
+        }
+        let event = read()?;
+        if is_resize(&event) {
+            deadline = std::time::Instant::now() + RESIZE_DEBOUNCE;
+            continue;
+        }
+        return Ok(Some(event));
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{next_wait, DEFAULT_BASE_TICK};
+    use super::{coalesce_resizes, next_wait, DEFAULT_BASE_TICK, RESIZE_DEBOUNCE};
+    use crossterm::event::Event;
     use std::time::Duration;
 
     #[test]
@@ -95,5 +131,48 @@ mod tests {
                 "idle wait must preserve base {base:?}, got {wait:?}"
             );
         }
+    }
+
+    #[test]
+    fn coalesce_resizes_returns_none_when_only_resizes_arrive() {
+        use std::cell::Cell;
+        let sizes = [(80u16, 24u16), (90, 30), (100, 40)];
+        let idx = Cell::new(0usize);
+        let out = coalesce_resizes(
+            |_| Ok::<_, ()>(idx.get() < sizes.len()),
+            || {
+                let i = idx.get();
+                let (w, h) = sizes[i];
+                idx.set(i + 1);
+                Ok(Event::Resize(w, h))
+            },
+            |e| matches!(e, Event::Resize(_, _)),
+        )
+        .expect("coalesce");
+        assert!(out.is_none());
+        assert!(RESIZE_DEBOUNCE >= Duration::from_millis(16));
+    }
+
+    #[test]
+    fn coalesce_resizes_surfaces_the_first_non_resize() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use std::cell::Cell;
+        let events = [
+            Event::Resize(80, 24),
+            Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+        ];
+        let idx = Cell::new(0usize);
+        let out = coalesce_resizes(
+            |_| Ok::<_, ()>(idx.get() < events.len()),
+            || {
+                let i = idx.get();
+                let event = events[i].clone();
+                idx.set(i + 1);
+                Ok(event)
+            },
+            |e| matches!(e, Event::Resize(_, _)),
+        )
+        .expect("coalesce");
+        assert!(matches!(out, Some(Event::Key(_))));
     }
 }

--- a/src/ui/scheduler.rs
+++ b/src/ui/scheduler.rs
@@ -19,6 +19,10 @@ const SHORT_TICK: Duration = Duration::from_millis(33);
 /// after the latest one lets the size settle so the board rebuilds once.
 pub const RESIZE_DEBOUNCE: Duration = Duration::from_millis(50);
 
+/// Hard cap on one coalesce call so a continuous resize stream cannot freeze the loop.
+/// A long pane-edge drag still paints about once per idle tick.
+pub const RESIZE_COALESCE_MAX: Duration = Duration::from_millis(250);
+
 /// Next input-wait duration for one frame-loop cycle.
 ///
 /// - Idle (`active_animations == false`): at least `base` and
@@ -32,38 +36,74 @@ pub fn next_wait(active_animations: bool, base: Duration) -> Duration {
     }
 }
 
-/// Drain a burst of resize events, returning the first non-resize (if any).
+/// Drain a burst of resize events, returning the first real input (if any).
 ///
 /// `poll` / `read` are injected so the policy is unit-testable without a tty.
-/// Each resize resets the quiet window; when the window elapses with no further
-/// event, returns `None` so the caller can paint once at the settled size.
+/// Each resize resets the quiet window. Mouse motion/drag is noise from the
+/// pane-edge pointer and does not reset or abort. Keys, clicks, wheel, and
+/// paste interrupt and are returned so the caller can paint then dispatch.
+/// The call always returns within [`RESIZE_COALESCE_MAX`].
 pub fn coalesce_resizes<E>(
+    poll: impl FnMut(Duration) -> Result<bool, E>,
+    read: impl FnMut() -> Result<crossterm::event::Event, E>,
+) -> Result<Option<crossterm::event::Event>, E> {
+    coalesce_resizes_at(poll, read, std::time::Instant::now)
+}
+
+fn resize_burst_kind(event: &crossterm::event::Event) -> BurstKind {
+    use crossterm::event::{Event, MouseEventKind};
+    match event {
+        Event::Resize(_, _) => BurstKind::Resize,
+        Event::Mouse(mouse)
+            if matches!(mouse.kind, MouseEventKind::Moved | MouseEventKind::Drag(_)) =>
+        {
+            BurstKind::Noise
+        }
+        _ => BurstKind::Interrupt,
+    }
+}
+
+enum BurstKind {
+    Resize,
+    Noise,
+    Interrupt,
+}
+
+/// Same as [`coalesce_resizes`] with an injected clock for tests.
+pub fn coalesce_resizes_at<E>(
     mut poll: impl FnMut(Duration) -> Result<bool, E>,
     mut read: impl FnMut() -> Result<crossterm::event::Event, E>,
-    is_resize: impl Fn(&crossterm::event::Event) -> bool,
+    mut now: impl FnMut() -> std::time::Instant,
 ) -> Result<Option<crossterm::event::Event>, E> {
-    let mut deadline = std::time::Instant::now() + RESIZE_DEBOUNCE;
+    let start = now();
+    let mut quiet = start + RESIZE_DEBOUNCE;
+    let hard = start + RESIZE_COALESCE_MAX;
     loop {
-        let now = std::time::Instant::now();
-        if now >= deadline {
+        let t = now();
+        if t >= hard || t >= quiet {
             return Ok(None);
         }
-        let wait = deadline.saturating_duration_since(now);
+        let wait = quiet.min(hard).saturating_duration_since(t);
         if !poll(wait)? {
             return Ok(None);
         }
         let event = read()?;
-        if is_resize(&event) {
-            deadline = std::time::Instant::now() + RESIZE_DEBOUNCE;
-            continue;
+        match resize_burst_kind(&event) {
+            BurstKind::Resize => {
+                quiet = now() + RESIZE_DEBOUNCE;
+            }
+            BurstKind::Noise => {}
+            BurstKind::Interrupt => return Ok(Some(event)),
         }
-        return Ok(Some(event));
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{coalesce_resizes, next_wait, DEFAULT_BASE_TICK, RESIZE_DEBOUNCE};
+    use super::{
+        coalesce_resizes, coalesce_resizes_at, next_wait, DEFAULT_BASE_TICK, RESIZE_COALESCE_MAX,
+        RESIZE_DEBOUNCE,
+    };
     use crossterm::event::Event;
     use std::time::Duration;
 
@@ -133,6 +173,21 @@ mod tests {
         }
     }
 
+    fn mouse_moved() -> Event {
+        use crossterm::event::{MouseEvent, MouseEventKind};
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Moved,
+            column: 10,
+            row: 10,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        })
+    }
+
+    fn key_j() -> Event {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE))
+    }
+
     #[test]
     fn coalesce_resizes_returns_none_when_only_resizes_arrive() {
         use std::cell::Cell;
@@ -146,7 +201,6 @@ mod tests {
                 idx.set(i + 1);
                 Ok(Event::Resize(w, h))
             },
-            |e| matches!(e, Event::Resize(_, _)),
         )
         .expect("coalesce");
         assert!(out.is_none());
@@ -154,12 +208,14 @@ mod tests {
     }
 
     #[test]
-    fn coalesce_resizes_surfaces_the_first_non_resize() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn coalesce_resizes_surfaces_the_first_key_not_mouse_motion() {
         use std::cell::Cell;
         let events = [
             Event::Resize(80, 24),
-            Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+            mouse_moved(),
+            Event::Resize(90, 30),
+            mouse_moved(),
+            key_j(),
         ];
         let idx = Cell::new(0usize);
         let out = coalesce_resizes(
@@ -170,9 +226,106 @@ mod tests {
                 idx.set(i + 1);
                 Ok(event)
             },
-            |e| matches!(e, Event::Resize(_, _)),
         )
         .expect("coalesce");
         assert!(matches!(out, Some(Event::Key(_))));
+        assert_eq!(
+            idx.get(),
+            5,
+            "must consume motion and resizes before the key"
+        );
+    }
+
+    #[test]
+    fn coalesce_poll_wait_is_the_remaining_quiet_window() {
+        use std::cell::Cell;
+        let start = std::time::Instant::now();
+        let t = Cell::new(start);
+        let waits = Cell::new(Vec::<Duration>::new());
+        let idx = Cell::new(0usize);
+        let events = [Event::Resize(80, 24)];
+        let _ = coalesce_resizes_at(
+            |wait| {
+                waits.set({
+                    let mut v = waits.take();
+                    v.push(wait);
+                    v
+                });
+                Ok::<_, ()>(idx.get() < events.len())
+            },
+            || {
+                let i = idx.get();
+                idx.set(i + 1);
+                Ok(events[i].clone())
+            },
+            || t.get(),
+        )
+        .expect("coalesce");
+        let recorded = waits.take();
+        assert!(
+            recorded.first().is_some_and(|w| *w == RESIZE_DEBOUNCE),
+            "first poll must ask for the quiet window, got {recorded:?}"
+        );
+        assert!(
+            recorded.iter().all(|w| *w <= RESIZE_COALESCE_MAX),
+            "poll wait must stay inside the hard cap, got {recorded:?}"
+        );
+    }
+
+    #[test]
+    fn a_resize_restarts_the_quiet_window() {
+        use std::cell::Cell;
+        let start = std::time::Instant::now();
+        let t = Cell::new(start);
+        let idx = Cell::new(0usize);
+        let waits = Cell::new(Vec::<Duration>::new());
+        let events = [Event::Resize(80, 24), Event::Resize(90, 30)];
+        let _ = coalesce_resizes_at(
+            |wait| {
+                waits.set({
+                    let mut v = waits.take();
+                    v.push(wait);
+                    v
+                });
+                Ok::<_, ()>(idx.get() < events.len())
+            },
+            || {
+                let i = idx.get();
+                idx.set(i + 1);
+                t.set(t.get() + Duration::from_millis(10));
+                Ok(events[i].clone())
+            },
+            || t.get(),
+        )
+        .expect("coalesce");
+        let recorded = waits.take();
+        assert!(
+            recorded.get(1).is_some_and(|w| *w == RESIZE_DEBOUNCE),
+            "a resize must restart a full quiet window, got {recorded:?}"
+        );
+    }
+
+    #[test]
+    fn coalesce_returns_none_at_the_hard_cap_even_if_resizes_continue() {
+        use std::cell::Cell;
+        let start = std::time::Instant::now();
+        let t = Cell::new(start);
+        let idx = Cell::new(0usize);
+        let out = coalesce_resizes_at(
+            |_| Ok::<_, ()>(true),
+            || {
+                idx.set(idx.get() + 1);
+                t.set(t.get() + RESIZE_COALESCE_MAX);
+                Ok(Event::Resize(80, 24))
+            },
+            || t.get(),
+        )
+        .expect("coalesce");
+        assert!(out.is_none());
+        assert!(
+            idx.get() <= 2,
+            "hard cap must stop the loop, reads={}",
+            idx.get()
+        );
     }
 }

--- a/tests/queue_board_loop.rs
+++ b/tests/queue_board_loop.rs
@@ -248,3 +248,16 @@ fn no_pending_event_skips_the_settled_paint() {
     assert_eq!(painted, 0);
     assert!(out.is_none());
 }
+
+#[test]
+fn run_board_resize_arm_drains_through_coalesce_then_paints() {
+    let src = include_str!("../src/app.rs");
+    assert!(
+        src.contains("pending_event = scheduler::coalesce_resizes(event::poll, event::read)?"),
+        "run_board Resize arm must call coalesce_resizes"
+    );
+    assert!(
+        src.contains("take_pending_after_paint(&mut pending_event"),
+        "run_board must paint the settled size before a deferred event"
+    );
+}

--- a/tests/queue_board_loop.rs
+++ b/tests/queue_board_loop.rs
@@ -8,9 +8,12 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
-use tsk_tui::app::{board_frame, board_poll_duration, load_board_model, FramePoll};
+use tsk_tui::app::{
+    board_frame, board_poll_duration, load_board_model, take_pending_after_paint, FramePoll,
+};
 use tsk_tui::domain::DomainState;
 use tsk_tui::ui::scheduler::{next_wait, DEFAULT_BASE_TICK};
 use tsk_tui::ui::{draw_board, BoardModel};
@@ -213,4 +216,35 @@ fn load_board_and_draw_path_smoke_at_80x24() {
             let _ = draw_board(frame, &model);
         })
         .expect("draw the loaded board without panicking");
+}
+
+#[test]
+fn pending_resize_event_paints_before_it_is_returned() {
+    let key = Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+    let mut pending = Some(key.clone());
+    let mut painted = 0usize;
+    let out = take_pending_after_paint(&mut pending, || {
+        painted += 1;
+        Ok::<_, ()>(())
+    })
+    .expect("paint");
+    assert_eq!(
+        painted, 1,
+        "settled size must paint before the deferred event"
+    );
+    assert_eq!(out, Some(key));
+    assert!(pending.is_none());
+}
+
+#[test]
+fn no_pending_event_skips_the_settled_paint() {
+    let mut pending: Option<Event> = None;
+    let mut painted = 0usize;
+    let out = take_pending_after_paint(&mut pending, || {
+        painted += 1;
+        Ok::<_, ()>(())
+    })
+    .expect("paint");
+    assert_eq!(painted, 0);
+    assert!(out.is_none());
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Coalesce a stream of terminal `Resize` events into a short quiet window so a pane-edge drag rebuilds board layout once at the settled size. A key or mouse event that arrives during that window is deferred until after that paint.

## Stack

1. List scrollbar (#17)
2. Edge auto-scroll (#18)
3. Hover feedback (#19) — base
4. **This PR** — resize debounce
5. Mono markdown notes (follows)

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
- [x] Unit tests for coalesce (resize-only → None; resize then key → key)
- [ ] Live herdr smoke not run (`HERDR_ENV` unset)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c02137c7-0c5d-487a-b0f8-4410c62815f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c02137c7-0c5d-487a-b0f8-4410c62815f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

