### PR TITLE
feat: mono markdown subset for notes view and peek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Mono markdown notes: view-mode task page notes and peek paint a small markdown
 subset with bold / dim / underline / reverse only — `**strong**`, `*em*` /
-`_em_`, `` `code` `` (reverse), fenced ` ``` ` blocks (dim fence, plain body), `#` headings (bold+underline, distinct from `**strong**`), and `-` / `*` list markers. Edit mode stays
+`_em_`, `` `code` `` (dim, ticks kept), fenced code blocks (dim fence ticks, plain body), `#` headings (bold+underline, distinct from `**strong**`), and `-` / `*` list markers. Peek uses the same markers, all dim. Edit mode stays
 raw source. Checkbox-looking lines stay literal text (structured steps own
 checklists).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Mono markdown notes: view-mode task page notes and peek paint a small markdown
+subset with bold / dim / underline / reverse only — `**strong**`, `*em*` /
+`_em_`, `` `code` ``, `#` headings, and `-` / `*` list markers. Edit mode stays
+raw source. Checkbox-looking lines stay literal text (structured steps own
+checklists).
+
 Resize debounce: a burst of terminal `Resize` events (pane-edge drag) waits a
 short quiet window and paints layout once at the settled size. A key or mouse
 event that arrives during that window is deferred until after that paint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Mono markdown notes: view-mode task page notes and peek paint a small markdown
 subset with bold / dim / underline / reverse only — `**strong**`, `*em*` /
-`_em_`, `` `code` ``, `#` headings, and `-` / `*` list markers. Edit mode stays
+`_em_`, `` `code` ``, `#` headings (bold+underline, distinct from `**strong**`), and `-` / `*` list markers. Edit mode stays
 raw source. Checkbox-looking lines stay literal text (structured steps own
 checklists).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Mono markdown notes: view-mode task page notes and peek paint a small markdown
 subset with bold / dim / underline / reverse only — `**strong**`, `*em*` /
-`_em_`, `` `code` ``, `#` headings (bold+underline, distinct from `**strong**`), and `-` / `*` list markers. Edit mode stays
+`_em_`, `` `code` `` (reverse), fenced ` ``` ` blocks (dim fence, plain body), `#` headings (bold+underline, distinct from `**strong**`), and `-` / `*` list markers. Edit mode stays
 raw source. Checkbox-looking lines stay literal text (structured steps own
 checklists).
 

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -3,16 +3,49 @@
 //! Markers are styled with bold / dim / underline only — never color. Edit mode
 //! keeps the raw source; this module paints the reading surface.
 //!
-//! Supported inline: `**strong**`, `*em*` / `_em_`, `` `code` ``.
+//! Supported inline: `**strong**`, `*em*` / `_em_`, `` `code` `` (reverse).
 //! Supported line starts: `#`…`######` headings (bold+underline body), `-` / `*` lists
-//! (dim marker). Task-list markers like `- [ ]` stay literal text (structured
-//! steps own checklists).
+//! (dim marker), fenced ` ``` ` blocks (dim fence, plain body). Task-list markers
+//! like `- [ ]` stay literal text (structured steps own checklists).
 
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
 use super::present_line;
-use super::render::{style_bold, style_dim, style_heading, style_plain, style_underline};
+use super::render::{
+    style_bold, style_dim, style_heading, style_plain, style_reverse, style_underline,
+};
+
+/// A line that opens or closes a fenced code block (` ``` ` after indent).
+pub fn is_fence_line(text: &str) -> bool {
+    text.trim_start().starts_with("```")
+}
+
+/// Paint one already-wrapped notes row, tracking fenced-code state.
+///
+/// Fence lines are dim. Body lines inside a fence stay plain (no inline md).
+/// Other lines use [`paint_md_line`].
+pub fn paint_notes_line(
+    text: &str,
+    width: usize,
+    base: Style,
+    in_fence: &mut bool,
+) -> Line<'static> {
+    if width == 0 {
+        return Line::from("");
+    }
+    if is_fence_line(text) {
+        *in_fence = !*in_fence;
+        return bound_styled_line(
+            vec![Span::styled(text.trim_end().to_string(), style_dim())],
+            width,
+        );
+    }
+    if *in_fence {
+        return bound_styled_line(vec![Span::styled(text.trim_end().to_string(), base)], width);
+    }
+    paint_md_line(text, width, base)
+}
 
 /// Paint one already-wrapped notes row with mono markdown styling.
 pub fn paint_md_line(text: &str, width: usize, base: Style) -> Line<'static> {
@@ -78,7 +111,7 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
             InlineKind::Plain => base,
             InlineKind::Strong => style_bold(),
             InlineKind::Em => style_underline(),
-            InlineKind::Code => style_dim(),
+            InlineKind::Code => style_reverse(),
         };
         spans.push(Span::styled(std::mem::take(buf), style));
     };
@@ -170,8 +203,8 @@ mod tests {
             .iter()
             .find(|s| s.content.as_ref() == "d")
             .expect("code span");
-        assert!(code.style.add_modifier.contains(Modifier::DIM));
-        assert!(!code.style.add_modifier.contains(Modifier::REVERSED));
+        assert!(code.style.add_modifier.contains(Modifier::REVERSED));
+        assert!(!code.style.add_modifier.contains(Modifier::DIM));
         let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(flat, "a b c d");
         let strong = line
@@ -207,5 +240,22 @@ mod tests {
         let line = paint_md_line("- [ ] not a step", 40, style_plain());
         let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(flat.contains("[ ] not a step"));
+    }
+
+    #[test]
+    fn fenced_block_dims_the_fence_and_leaves_body_unparsed() {
+        let mut in_fence = false;
+        let open = paint_notes_line("```rust", 40, style_plain(), &mut in_fence);
+        assert!(in_fence);
+        assert!(has_mod(&open, Modifier::DIM));
+        let body = paint_notes_line("**not bold**", 40, style_plain(), &mut in_fence);
+        let flat: String = body.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(flat, "**not bold**");
+        assert!(!has_mod(&body, Modifier::BOLD));
+        let close = paint_notes_line("```", 40, style_plain(), &mut in_fence);
+        assert!(!in_fence);
+        assert!(has_mod(&close, Modifier::DIM));
+        let after = paint_notes_line("**bold**", 40, style_plain(), &mut in_fence);
+        assert!(has_mod(&after, Modifier::BOLD));
     }
 }

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -12,9 +12,7 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
 use super::present_line;
-use super::render::{
-    style_bold, style_dim, style_heading, style_plain, style_reverse_dim, style_underline,
-};
+use super::render::{style_bold, style_dim, style_heading, style_plain, style_underline};
 
 /// Paint one already-wrapped notes row with mono markdown styling.
 pub fn paint_md_line(text: &str, width: usize, base: Style) -> Line<'static> {
@@ -80,7 +78,7 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
             InlineKind::Plain => base,
             InlineKind::Strong => style_bold(),
             InlineKind::Em => style_underline(),
-            InlineKind::Code => style_reverse_dim(),
+            InlineKind::Code => style_dim(),
         };
         spans.push(Span::styled(std::mem::take(buf), style));
     };
@@ -167,13 +165,13 @@ mod tests {
         let line = paint_md_line("a **b** *c* `d`", 40, style_plain());
         assert!(has_mod(&line, Modifier::BOLD));
         assert!(has_mod(&line, Modifier::UNDERLINED));
-        assert!(has_mod(&line, Modifier::REVERSED));
         let code = line
             .spans
             .iter()
             .find(|s| s.content.as_ref() == "d")
             .expect("code span");
         assert!(code.style.add_modifier.contains(Modifier::DIM));
+        assert!(!code.style.add_modifier.contains(Modifier::REVERSED));
         let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(flat, "a b c d");
         let strong = line

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -3,7 +3,7 @@
 //! Markers are styled with bold / dim / underline only — never color. Edit mode
 //! keeps the raw source; this module paints the reading surface.
 //!
-//! Supported inline: `**strong**`, `*em*` / `_em_`, `` `code` `` (reverse).
+//! Supported inline: `**strong**`, `*em*` / `_em_`, `` `code` `` (dim, ticks kept).
 //! Supported line starts: `#`…`######` headings (bold+underline body), `-` / `*` lists
 //! (dim marker), fenced ` ``` ` blocks (dim fence, plain body). Task-list markers
 //! like `- [ ]` stay literal text (structured steps own checklists).
@@ -12,9 +12,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use super::present_line;
-use super::render::{
-    style_bold, style_dim, style_heading, style_plain, style_reverse, style_underline,
-};
+use super::render::{style_bold, style_dim, style_heading, style_plain, style_underline};
 
 /// A line that opens or closes a fenced code block (` ``` ` after indent).
 pub fn is_fence_line(text: &str) -> bool {
@@ -121,7 +119,7 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
             InlineKind::Plain => base,
             InlineKind::Strong => style_bold(),
             InlineKind::Em => style_underline(),
-            InlineKind::Code => style_reverse(),
+            InlineKind::Code => style_dim(),
         };
         spans.push(Span::styled(std::mem::take(buf), style));
     };
@@ -132,6 +130,7 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
                 if chars[i] == '`' {
                     flush(&mut buf, kind, &mut spans);
                     kind = InlineKind::Code;
+                    buf.push('`');
                     i += 1;
                 } else if chars[i] == '*' && i + 1 < chars.len() && chars[i + 1] == '*' {
                     flush(&mut buf, kind, &mut spans);
@@ -168,6 +167,7 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
             }
             InlineKind::Code => {
                 if chars[i] == '`' {
+                    buf.push('`');
                     flush(&mut buf, kind, &mut spans);
                     kind = InlineKind::Plain;
                     i += 1;
@@ -211,12 +211,12 @@ mod tests {
         let code = line
             .spans
             .iter()
-            .find(|s| s.content.as_ref() == "d")
+            .find(|s| s.content.as_ref() == "`d`")
             .expect("code span");
-        assert!(code.style.add_modifier.contains(Modifier::REVERSED));
-        assert!(!code.style.add_modifier.contains(Modifier::DIM));
+        assert!(code.style.add_modifier.contains(Modifier::DIM));
+        assert!(!code.style.add_modifier.contains(Modifier::REVERSED));
         let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert_eq!(flat, "a b c d");
+        assert_eq!(flat, "a b c `d`");
         let strong = line
             .spans
             .iter()
@@ -290,9 +290,9 @@ mod tests {
         let span = code
             .spans
             .iter()
-            .find(|s| s.content.as_ref() == "x")
+            .find(|s| s.content.as_ref() == "`x`")
             .expect("code");
-        assert!(span.style.add_modifier.contains(Modifier::REVERSED));
+        assert!(!span.style.add_modifier.contains(Modifier::REVERSED));
         assert!(span.style.add_modifier.contains(Modifier::DIM));
     }
 }

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -1,0 +1,192 @@
+//! Mono markdown subset for task notes (view / peek).
+//!
+//! Markers are styled with bold / dim / underline only — never color. Edit mode
+//! keeps the raw source; this module paints the reading surface.
+//!
+//! Supported inline: `**strong**`, `*em*` / `_em_`, `` `code` ``.
+//! Supported line starts: `#`…`######` headings (bold body), `-` / `*` lists
+//! (dim marker). Task-list markers like `- [ ]` stay literal text (structured
+//! steps own checklists).
+
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+
+use super::present_line;
+use super::render::{style_bold, style_dim, style_plain, style_reverse, style_underline};
+
+/// Paint one already-wrapped notes row with mono markdown styling.
+pub fn paint_md_line(text: &str, width: usize, base: Style) -> Line<'static> {
+    if width == 0 {
+        return Line::from("");
+    }
+    let trimmed = text.trim_end();
+    if trimmed.is_empty() {
+        return Line::from(Span::styled(" ".repeat(width.min(1)), base));
+    }
+
+    let (prefix_spans, body, heading) = line_prefix(trimmed);
+    let mut spans = prefix_spans;
+    let body_base = if heading { style_bold() } else { base };
+    spans.extend(inline_spans(body, body_base));
+    bound_styled_line(spans, width)
+}
+
+/// Dim list / heading markers; return the remainder and whether it is a heading.
+fn line_prefix(text: &str) -> (Vec<Span<'static>>, &str, bool) {
+    let lead = text.len() - text.trim_start().len();
+    let (indent, rest) = text.split_at(lead);
+    let mut spans = Vec::new();
+    if !indent.is_empty() {
+        spans.push(Span::styled(indent.to_string(), style_plain()));
+    }
+    let bytes = rest.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() && bytes[i] == b'#' && i < 6 {
+        i += 1;
+    }
+    if i > 0 && i < bytes.len() && bytes[i] == b' ' {
+        spans.push(Span::styled(rest[..i + 1].to_string(), style_dim()));
+        return (spans, &rest[i + 1..], true);
+    }
+    if bytes.len() >= 2 && matches!(bytes[0], b'-' | b'*') && bytes[1] == b' ' {
+        spans.push(Span::styled(rest[..2].to_string(), style_dim()));
+        return (spans, &rest[2..], false);
+    }
+    (spans, rest, false)
+}
+
+#[derive(Clone, Copy)]
+enum InlineKind {
+    Plain,
+    Strong,
+    Em,
+    Code,
+}
+
+fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0usize;
+    let mut kind = InlineKind::Plain;
+    let mut buf = String::new();
+
+    let flush = |buf: &mut String, kind: InlineKind, spans: &mut Vec<Span<'static>>| {
+        if buf.is_empty() {
+            return;
+        }
+        let style = match kind {
+            InlineKind::Plain => base,
+            InlineKind::Strong => style_bold(),
+            InlineKind::Em => style_underline(),
+            InlineKind::Code => style_reverse(),
+        };
+        spans.push(Span::styled(std::mem::take(buf), style));
+    };
+
+    while i < chars.len() {
+        match kind {
+            InlineKind::Plain => {
+                if chars[i] == '`' {
+                    flush(&mut buf, kind, &mut spans);
+                    kind = InlineKind::Code;
+                    i += 1;
+                } else if chars[i] == '*' && i + 1 < chars.len() && chars[i + 1] == '*' {
+                    flush(&mut buf, kind, &mut spans);
+                    kind = InlineKind::Strong;
+                    i += 2;
+                } else if chars[i] == '*' || chars[i] == '_' {
+                    flush(&mut buf, kind, &mut spans);
+                    kind = InlineKind::Em;
+                    i += 1;
+                } else {
+                    buf.push(chars[i]);
+                    i += 1;
+                }
+            }
+            InlineKind::Strong => {
+                if chars[i] == '*' && i + 1 < chars.len() && chars[i + 1] == '*' {
+                    flush(&mut buf, kind, &mut spans);
+                    kind = InlineKind::Plain;
+                    i += 2;
+                } else {
+                    buf.push(chars[i]);
+                    i += 1;
+                }
+            }
+            InlineKind::Em => {
+                if chars[i] == '*' || chars[i] == '_' {
+                    flush(&mut buf, kind, &mut spans);
+                    kind = InlineKind::Plain;
+                    i += 1;
+                } else {
+                    buf.push(chars[i]);
+                    i += 1;
+                }
+            }
+            InlineKind::Code => {
+                if chars[i] == '`' {
+                    flush(&mut buf, kind, &mut spans);
+                    kind = InlineKind::Plain;
+                    i += 1;
+                } else {
+                    buf.push(chars[i]);
+                    i += 1;
+                }
+            }
+        }
+    }
+    flush(&mut buf, kind, &mut spans);
+    if spans.is_empty() {
+        spans.push(Span::styled(String::new(), base));
+    }
+    spans
+}
+
+fn bound_styled_line(spans: Vec<Span<'static>>, width: usize) -> Line<'static> {
+    let flat: String = spans.iter().map(|s| s.content.as_ref()).collect();
+    let shown = present_line(&flat, width);
+    if shown == flat {
+        return Line::from(spans);
+    }
+    Line::from(Span::styled(shown, style_plain()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::Modifier;
+
+    fn has_mod(line: &Line<'_>, m: Modifier) -> bool {
+        line.spans.iter().any(|s| s.style.add_modifier.contains(m))
+    }
+
+    #[test]
+    fn strong_and_em_and_code() {
+        let line = paint_md_line("a **b** *c* `d`", 40, style_plain());
+        assert!(has_mod(&line, Modifier::BOLD));
+        assert!(has_mod(&line, Modifier::UNDERLINED));
+        assert!(has_mod(&line, Modifier::REVERSED));
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(flat, "a b c d");
+    }
+
+    #[test]
+    fn heading_and_list_markers_dim() {
+        let h = paint_md_line("# Title", 40, style_plain());
+        assert_eq!(h.spans[0].content.as_ref(), "# ");
+        assert!(h.spans[0].style.add_modifier.contains(Modifier::DIM));
+        assert!(has_mod(&h, Modifier::BOLD));
+        let indented = paint_md_line("  # Title", 40, style_plain());
+        assert!(indented.spans.iter().any(|s| s.content.as_ref() == "# "));
+        let list = paint_md_line("- item", 40, style_plain());
+        assert_eq!(list.spans[0].content.as_ref(), "- ");
+        assert!(list.spans[0].style.add_modifier.contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn task_list_stays_literal_text() {
+        let line = paint_md_line("- [ ] not a step", 40, style_plain());
+        let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(flat.contains("[ ] not a step"));
+    }
+}

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -12,7 +12,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use super::present_line;
-use super::render::{style_bold, style_dim, style_heading, style_plain, style_underline};
+use super::render::{style_dim, style_heading, style_plain};
 
 /// A line that opens or closes a fenced code block (` ``` ` after indent).
 pub fn is_fence_line(text: &str) -> bool {
@@ -120,8 +120,8 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
         }
         let style = match kind {
             InlineKind::Plain => base,
-            InlineKind::Strong => style_bold(),
-            InlineKind::Em => style_underline(),
+            InlineKind::Strong => base.add_modifier(Modifier::BOLD),
+            InlineKind::Em => base.add_modifier(Modifier::UNDERLINED),
             InlineKind::Code => style_dim(),
         };
         spans.push(Span::styled(std::mem::take(buf), style));
@@ -136,10 +136,17 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
                     buf.push('`');
                     i += 1;
                 } else if chars[i] == '*' && i + 1 < chars.len() && chars[i + 1] == '*' {
-                    flush(&mut buf, kind, &mut spans);
-                    kind = InlineKind::Strong;
-                    i += 2;
-                } else if chars[i] == '*' || chars[i] == '_' {
+                    if rest_has_starstar(&chars, i + 2) {
+                        flush(&mut buf, kind, &mut spans);
+                        kind = InlineKind::Strong;
+                        i += 2;
+                    } else {
+                        buf.push('*');
+                        i += 1;
+                    }
+                } else if (chars[i] == '*' && rest_has_char(&chars, i + 1, '*'))
+                    || (chars[i] == '_' && can_open_underscore(&chars, i))
+                {
                     flush(&mut buf, kind, &mut spans);
                     kind = InlineKind::Em;
                     i += 1;
@@ -186,6 +193,19 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
         spans.push(Span::styled(String::new(), base));
     }
     spans
+}
+
+fn rest_has_starstar(chars: &[char], from: usize) -> bool {
+    chars[from..].windows(2).any(|w| w[0] == '*' && w[1] == '*')
+}
+
+fn rest_has_char(chars: &[char], from: usize, needle: char) -> bool {
+    chars[from..].contains(&needle)
+}
+
+fn can_open_underscore(chars: &[char], i: usize) -> bool {
+    let left_ok = i == 0 || !chars[i - 1].is_alphanumeric();
+    left_ok && rest_has_char(chars, i + 1, '_')
 }
 
 fn bound_styled_line(spans: Vec<Span<'static>>, width: usize) -> Line<'static> {
@@ -298,5 +318,27 @@ mod tests {
             .expect("code");
         assert!(!span.style.add_modifier.contains(Modifier::REVERSED));
         assert!(span.style.add_modifier.contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn unmatched_stars_and_word_underscores_stay_literal() {
+        let glob = paint_md_line("*.rs", 40, style_plain());
+        let flat: String = glob.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(flat, "*.rs");
+        let ident = paint_md_line("test_foo", 40, style_plain());
+        let flat: String = ident.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(flat, "test_foo");
+    }
+
+    #[test]
+    fn heading_keeps_bold_when_the_body_is_emphasized() {
+        let h = paint_md_line("# *Release*", 40, style_plain());
+        let body = h
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "Release")
+            .expect("heading em");
+        assert!(body.style.add_modifier.contains(Modifier::BOLD));
+        assert!(body.style.add_modifier.contains(Modifier::UNDERLINED));
     }
 }

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -21,7 +21,7 @@ pub fn is_fence_line(text: &str) -> bool {
 
 /// Paint one already-wrapped notes row, tracking fenced-code state.
 ///
-/// Fence lines are dim. Body lines inside a fence stay plain (no inline md).
+/// Fence lines and body are dim. Body does not run inline md.
 /// Other lines use [`paint_md_line`].
 pub fn paint_notes_line(
     text: &str,
@@ -40,7 +40,10 @@ pub fn paint_notes_line(
         );
     }
     if *in_fence {
-        return bound_styled_line(vec![Span::styled(text.trim_end().to_string(), base)], width);
+        return bound_styled_line(
+            vec![Span::styled(text.trim_end().to_string(), style_dim())],
+            width,
+        );
     }
     paint_md_line(text, width, base)
 }
@@ -262,6 +265,7 @@ mod tests {
         let flat: String = body.spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(flat, "**not bold**");
         assert!(!has_mod(&body, Modifier::BOLD));
+        assert!(has_mod(&body, Modifier::DIM));
         let close = paint_notes_line("```", 40, style_plain(), &mut in_fence);
         assert!(!in_fence);
         assert!(has_mod(&close, Modifier::DIM));

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -8,7 +8,7 @@
 //! (dim marker), fenced ` ``` ` blocks (dim fence, plain body). Task-list markers
 //! like `- [ ]` stay literal text (structured steps own checklists).
 
-use ratatui::style::Style;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use super::present_line;
@@ -45,6 +45,16 @@ pub fn paint_notes_line(
         return bound_styled_line(vec![Span::styled(text.trim_end().to_string(), base)], width);
     }
     paint_md_line(text, width, base)
+}
+
+/// Same styles as view, with dim on every span (peek).
+pub fn dim_line(line: Line<'static>) -> Line<'static> {
+    Line::from(
+        line.spans
+            .into_iter()
+            .map(|span| Span::styled(span.content, span.style.add_modifier(Modifier::DIM)))
+            .collect::<Vec<_>>(),
+    )
 }
 
 /// Paint one already-wrapped notes row with mono markdown styling.
@@ -257,5 +267,32 @@ mod tests {
         assert!(has_mod(&close, Modifier::DIM));
         let after = paint_notes_line("**bold**", 40, style_plain(), &mut in_fence);
         assert!(has_mod(&after, Modifier::BOLD));
+    }
+
+    #[test]
+    fn dim_line_keeps_heading_and_code_and_adds_dim() {
+        let mut in_fence = false;
+        let heading = dim_line(paint_notes_line(
+            "# Title",
+            40,
+            style_plain(),
+            &mut in_fence,
+        ));
+        let title = heading
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "Title")
+            .expect("heading");
+        assert!(title.style.add_modifier.contains(Modifier::BOLD));
+        assert!(title.style.add_modifier.contains(Modifier::UNDERLINED));
+        assert!(title.style.add_modifier.contains(Modifier::DIM));
+        let code = dim_line(paint_md_line("`x`", 40, style_plain()));
+        let span = code
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "x")
+            .expect("code");
+        assert!(span.style.add_modifier.contains(Modifier::REVERSED));
+        assert!(span.style.add_modifier.contains(Modifier::DIM));
     }
 }

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -4,7 +4,7 @@
 //! keeps the raw source; this module paints the reading surface.
 //!
 //! Supported inline: `**strong**`, `*em*` / `_em_`, `` `code` ``.
-//! Supported line starts: `#`…`######` headings (bold body), `-` / `*` lists
+//! Supported line starts: `#`…`######` headings (bold+underline body), `-` / `*` lists
 //! (dim marker). Task-list markers like `- [ ]` stay literal text (structured
 //! steps own checklists).
 
@@ -12,7 +12,9 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
 use super::present_line;
-use super::render::{style_bold, style_dim, style_plain, style_reverse, style_underline};
+use super::render::{
+    style_bold, style_dim, style_heading, style_plain, style_reverse, style_underline,
+};
 
 /// Paint one already-wrapped notes row with mono markdown styling.
 pub fn paint_md_line(text: &str, width: usize, base: Style) -> Line<'static> {
@@ -26,7 +28,7 @@ pub fn paint_md_line(text: &str, width: usize, base: Style) -> Line<'static> {
 
     let (prefix_spans, body, heading) = line_prefix(trimmed);
     let mut spans = prefix_spans;
-    let body_base = if heading { style_bold() } else { base };
+    let body_base = if heading { style_heading() } else { base };
     spans.extend(inline_spans(body, body_base));
     bound_styled_line(spans, width)
 }
@@ -168,6 +170,13 @@ mod tests {
         assert!(has_mod(&line, Modifier::REVERSED));
         let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(flat, "a b c d");
+        let strong = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "b")
+            .expect("strong span");
+        assert!(strong.style.add_modifier.contains(Modifier::BOLD));
+        assert!(!strong.style.add_modifier.contains(Modifier::UNDERLINED));
     }
 
     #[test]
@@ -175,7 +184,13 @@ mod tests {
         let h = paint_md_line("# Title", 40, style_plain());
         assert_eq!(h.spans[0].content.as_ref(), "# ");
         assert!(h.spans[0].style.add_modifier.contains(Modifier::DIM));
-        assert!(has_mod(&h, Modifier::BOLD));
+        let title = h
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "Title")
+            .expect("heading body");
+        assert!(title.style.add_modifier.contains(Modifier::BOLD));
+        assert!(title.style.add_modifier.contains(Modifier::UNDERLINED));
         let indented = paint_md_line("  # Title", 40, style_plain());
         assert!(indented.spans.iter().any(|s| s.content.as_ref() == "# "));
         let list = paint_md_line("- item", 40, style_plain());

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -13,7 +13,7 @@ use ratatui::text::{Line, Span};
 
 use super::present_line;
 use super::render::{
-    style_bold, style_dim, style_heading, style_plain, style_reverse, style_underline,
+    style_bold, style_dim, style_heading, style_plain, style_reverse_dim, style_underline,
 };
 
 /// Paint one already-wrapped notes row with mono markdown styling.
@@ -80,7 +80,7 @@ fn inline_spans(text: &str, base: Style) -> Vec<Span<'static>> {
             InlineKind::Plain => base,
             InlineKind::Strong => style_bold(),
             InlineKind::Em => style_underline(),
-            InlineKind::Code => style_reverse(),
+            InlineKind::Code => style_reverse_dim(),
         };
         spans.push(Span::styled(std::mem::take(buf), style));
     };
@@ -168,6 +168,12 @@ mod tests {
         assert!(has_mod(&line, Modifier::BOLD));
         assert!(has_mod(&line, Modifier::UNDERLINED));
         assert!(has_mod(&line, Modifier::REVERSED));
+        let code = line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "d")
+            .expect("code span");
+        assert!(code.style.add_modifier.contains(Modifier::DIM));
         let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(flat, "a b c d");
         let strong = line

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod board;
 pub mod capture;
 pub mod edit;
 pub mod input;
+pub mod markdown;
 pub mod mouse;
 pub mod queue;
 pub mod render;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -73,6 +73,11 @@ pub fn style_bold() -> Style {
     mono_style(Modifier::BOLD)
 }
 
+/// Heading body: bold and underlined, so it does not collapse into `**strong**`.
+pub fn style_heading() -> Style {
+    mono_style(Modifier::BOLD.union(Modifier::UNDERLINED))
+}
+
 pub fn style_dim() -> Style {
     mono_style(Modifier::DIM)
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -2017,7 +2017,7 @@ fn paint_task_page(
             } else {
                 notes_style
             };
-            let painted = if notes_rows.is_empty() {
+            let painted = if notes_rows.is_empty() || focus == Some(CaptureField::Notes) {
                 paint_bounded_line(&format!("  {text} "), content_width, style)
             } else {
                 crate::ui::markdown::paint_md_line(

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -2025,10 +2025,18 @@ fn paint_task_page(
             let painted = if notes_rows.is_empty() || focus == Some(CaptureField::Notes) {
                 paint_bounded_line(&format!("  {text} "), content_width, style)
             } else {
-                crate::ui::markdown::paint_md_line(
+                let mut in_fence = notes_rows
+                    .iter()
+                    .take(absolute)
+                    .filter(|row| crate::ui::markdown::is_fence_line(row))
+                    .count()
+                    % 2
+                    == 1;
+                crate::ui::markdown::paint_notes_line(
                     &format!("  {text} "),
                     content_width as usize,
                     style,
+                    &mut in_fence,
                 )
             };
             put_line(frame, y, content_width, painted);
@@ -2484,12 +2492,18 @@ fn detail_lines_for_task(
         let room = (width as usize).saturating_sub(display_width(indent) + 1);
         let mut shown = 0usize;
         let mut remaining = 0usize;
+        let mut in_fence = false;
         for note_row in crate::ui::edit::wrap_text(notes_text, room) {
             if shown < PEEK_NOTES_LINE_LIMIT {
                 let body = format!("{indent}{}", note_row.text);
                 push(
                     &mut lines,
-                    crate::ui::markdown::paint_md_line(&body, width as usize, style_dim()),
+                    crate::ui::markdown::paint_notes_line(
+                        &body,
+                        width as usize,
+                        style_dim(),
+                        &mut in_fence,
+                    ),
                 );
                 shown += 1;
             } else {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -2495,16 +2495,15 @@ fn detail_lines_for_task(
         let mut in_fence = false;
         for note_row in crate::ui::edit::wrap_text(notes_text, room) {
             if shown < PEEK_NOTES_LINE_LIMIT {
-                let body = format!("{indent}{}", note_row.text);
-                push(
-                    &mut lines,
-                    crate::ui::markdown::dim_line(crate::ui::markdown::paint_notes_line(
-                        &body,
-                        width as usize,
-                        style_plain(),
-                        &mut in_fence,
-                    )),
+                let md = crate::ui::markdown::paint_notes_line(
+                    &note_row.text,
+                    room,
+                    style_plain(),
+                    &mut in_fence,
                 );
+                let mut spans = vec![Span::styled(indent.to_string(), style_dim())];
+                spans.extend(md.spans);
+                push(&mut lines, crate::ui::markdown::dim_line(Line::from(spans)));
                 shown += 1;
             } else {
                 remaining += 1;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -2017,12 +2017,16 @@ fn paint_task_page(
             } else {
                 notes_style
             };
-            put_line(
-                frame,
-                y,
-                content_width,
-                paint_bounded_line(&format!("  {text} "), content_width, style),
-            );
+            let painted = if notes_rows.is_empty() {
+                paint_bounded_line(&format!("  {text} "), content_width, style)
+            } else {
+                crate::ui::markdown::paint_md_line(
+                    &format!("  {text} "),
+                    content_width as usize,
+                    style,
+                )
+            };
+            put_line(frame, y, content_width, painted);
             hits.push(
                 QueueHitTarget::FormNotes(absolute),
                 Rect::new(0, y, content_width, 1),
@@ -2477,9 +2481,10 @@ fn detail_lines_for_task(
         let mut remaining = 0usize;
         for note_row in crate::ui::edit::wrap_text(notes_text, room) {
             if shown < PEEK_NOTES_LINE_LIMIT {
+                let body = format!("{indent}{}", note_row.text);
                 push(
                     &mut lines,
-                    paint_bounded_line(&format!("{indent}{}", note_row.text), width, style_dim()),
+                    crate::ui::markdown::paint_md_line(&body, width as usize, style_dim()),
                 );
                 shown += 1;
             } else {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -2498,12 +2498,12 @@ fn detail_lines_for_task(
                 let body = format!("{indent}{}", note_row.text);
                 push(
                     &mut lines,
-                    crate::ui::markdown::paint_notes_line(
+                    crate::ui::markdown::dim_line(crate::ui::markdown::paint_notes_line(
                         &body,
                         width as usize,
-                        style_dim(),
+                        style_plain(),
                         &mut in_fence,
-                    ),
+                    )),
                 );
                 shown += 1;
             } else {

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -1153,6 +1153,42 @@ fn task_page_notes_edit_keeps_a_visible_row_at_the_compact_floor_alongside_steps
     );
 }
 
+#[test]
+fn notes_edit_shows_raw_markdown_markers_that_view_mode_strips() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Markdown notes",
+            Some("see *em* and **strong** here".into()),
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open");
+    let view = board_rows(&model, 80, 24).join("\n");
+    assert!(
+        !view.contains("*em*"),
+        "view must strip em markers:\n{view}"
+    );
+    assert!(
+        view.contains("em"),
+        "view must still show the em text:\n{view}"
+    );
+    apply_intent(&mut domain, &mut model, BoardIntent::BeginEditNotes, None).expect("edit");
+    let edit = board_rows(&model, 80, 24).join("\n");
+    assert!(
+        edit.contains("*em*"),
+        "notes edit must show raw *em* markers:\n{edit}"
+    );
+    assert!(
+        edit.contains("**strong**"),
+        "notes edit must show raw **strong** markers:\n{edit}"
+    );
+}
+
 /// T-10 (AC-27): a Notes caret uses the same shared-stream offset as its rows.
 #[test]
 fn notes_edit_caret_accounts_for_shared_stream_scroll() {

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -1189,6 +1189,64 @@ fn notes_edit_shows_raw_markdown_markers_that_view_mode_strips() {
     );
 }
 
+#[test]
+fn task_page_view_leaves_fence_body_unparsed() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Fenced",
+            Some("```\n**not bold**\n```".into()),
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open");
+    let view = board_rows(&model, 80, 24).join("\n");
+    assert!(view.contains("```"), "page must show fence ticks:\n{view}");
+    assert!(
+        view.contains("**not bold**"),
+        "fence body must not run inline markdown:\n{view}"
+    );
+}
+
+#[test]
+fn task_page_fence_stays_closed_after_the_opener_scrolls_off() {
+    let mut notes = String::from("```\n");
+    for i in 0..40 {
+        notes.push_str(&format!("pad-line-{i}\n"));
+    }
+    notes.push_str("**still stars**\n```\n");
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Long fence",
+            Some(notes),
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open");
+    let _ = board_rows(&model, 80, 24);
+    for _ in 0..30 {
+        apply_intent(&mut domain, &mut model, BoardIntent::PageScrollDown, None).expect("scroll");
+    }
+    let view = board_rows(&model, 80, 24).join("\n");
+    assert!(
+        !view.contains("pad-line-0"),
+        "fence opener should have left the viewport:\n{view}"
+    );
+    assert!(
+        view.contains("**still stars**"),
+        "scrolled fence body must still skip inline markdown:\n{view}"
+    );
+}
+
 /// T-10 (AC-27): a Notes caret uses the same shared-stream offset as its rows.
 #[test]
 fn notes_edit_caret_accounts_for_shared_stream_scroll() {
@@ -2612,6 +2670,32 @@ fn peek_shows_inline_backticks_and_fence_ticks() {
     assert!(
         body.contains("fn x() {}"),
         "peek must show the fence body:\n{body}"
+    );
+}
+
+#[test]
+fn peek_runs_markdown_not_plain_dim_text() {
+    let mut coded = task(203, "peek-md", HumanStatus::Ready, TaskScope::Global, 1);
+    coded.notes = Some("# Title\n**strong** here\n```\n**still stars**\n```".into());
+    let mut model = BoardModel::from_tasks(vec![coded], None);
+    let mut domain = DomainState::new();
+    apply_intent(&mut domain, &mut model, BoardIntent::PeekDetail, None).expect("peek");
+    let body = board_rows(&model, 80, 24).join("\n");
+    assert!(
+        !body.contains("**strong**"),
+        "peek must strip strong markers like the page:\n{body}"
+    );
+    assert!(
+        body.contains("strong"),
+        "peek must keep strong text:\n{body}"
+    );
+    assert!(
+        body.contains("# ") || body.contains("# Title"),
+        "peek must keep heading hashes:\n{body}"
+    );
+    assert!(
+        body.contains("**still stars**"),
+        "peek fence must leave body markers:\n{body}"
     );
 }
 

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -2597,6 +2597,25 @@ fn peek_shows_thread_line_only_for_threaded_task() {
 }
 
 #[test]
+fn peek_shows_inline_backticks_and_fence_ticks() {
+    let mut coded = task(202, "coded", HumanStatus::Ready, TaskScope::Global, 1);
+    coded.notes = Some("`code`\n```\nfn x() {}\n```".into());
+    let mut model = BoardModel::from_tasks(vec![coded], None);
+    let mut domain = DomainState::new();
+    apply_intent(&mut domain, &mut model, BoardIntent::PeekDetail, None).expect("peek");
+    let body = board_rows(&model, 80, 24).join("\n");
+    assert!(
+        body.contains("`code`"),
+        "peek must keep inline backticks:\n{body}"
+    );
+    assert!(body.contains("```"), "peek must keep fenced ticks:\n{body}");
+    assert!(
+        body.contains("fn x() {}"),
+        "peek must show the fence body:\n{body}"
+    );
+}
+
+#[test]
 fn all_golden_frames_pass_no_color_sgr_scan() {
     let dir = golden_fixtures_dir();
     let mut scanned = 0usize;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

View-mode task page notes and peek paint a small markdown subset with mono modifiers only (bold / dim / underline / reverse): `**strong**`, `*em*` / `_em_`, `` `code` ``, `#` headings, and `-` / `*` list markers. Edit mode stays raw source. Checkbox-looking lines stay literal text — structured steps own checklists.

## Stack

1. List scrollbar (#17)
2. Edge auto-scroll (#18)
3. Hover feedback (#19)
4. Resize debounce (#20) — base
5. **This PR** — mono markdown notes

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
- [x] Unit tests for strong/em/code, headings/lists, task-list literal
- [ ] Live herdr smoke not run (`HERDR_ENV` unset)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c02137c7-0c5d-487a-b0f8-4410c62815f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c02137c7-0c5d-487a-b0f8-4410c62815f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

