### PR TITLE
Deploy the site from a repo-root Vercel config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,9 @@ For scriptable board work, use `tsk add` and `tsk list`; read
   (`paths-ignore: site/**`). Site CI is `.github/workflows/site.yml`:
   `npm ci && npm test && npm run build` in `site/`.
 - Landing page and Starlight docs live in `site/` (Astro). They are not part of
-  the `tsk` binary. Production: https://tsk-gules.vercel.app. Point Vercel at
-  this repo with Root Directory `site`.
+  the `tsk` binary. Production: https://tsk-gules.vercel.app. Vercel connects
+  this repo with an **empty** Root Directory; the repo-root `vercel.json`
+  builds `site/` and publishes `site/dist`.
 - Changes to the keymap, status verbs, or tab/section semantics need a matching
   `site/` update (`src/content/docs/docs/{keys,board,capture,cli}.md` and
   `public/board-demo.js`). The web demo uses bare verb keys on purpose (browsers

--- a/site/README.md
+++ b/site/README.md
@@ -25,9 +25,12 @@ Output is `site/dist/`.
 
 ## Deploy
 
-Vercel should use this repository with **Root Directory** `site`.
-`vercel.json` pins install / build / output. Production is
-https://tsk-gules.vercel.app.
+Production is https://tsk-gules.vercel.app.
 
-Ignore builds that do not touch `site/**` so a Rust-only commit does not
-rebuild the landing page.
+The Vercel project must be connected to **`smarzban/herdr-tsk`**, production
+branch **`main`**. Leave **Root Directory empty**. A repo-root `vercel.json`
+runs `npm ci` / `npm run build` in `site/` and publishes `site/dist`. Setting
+Root Directory to `site` fails if Vercel is still reading `tsk-site` (that
+repo has no `site/` folder).
+
+`site/vercel.json` is only used if you later set Root Directory to `site`.

--- a/site/README.md
+++ b/site/README.md
@@ -34,3 +34,5 @@ Root Directory to `site` fails if Vercel is still reading `tsk-site` (that
 repo has no `site/` folder).
 
 `site/vercel.json` is only used if you later set Root Directory to `site`.
+It has no `ignoreCommand`: a docs-only `main` tip would cancel a new
+project's first deploy.

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -11,6 +11,13 @@ test("Vercel ignores unchanged files relative to the site root", async () => {
   assert.equal(config.ignoreCommand, "git diff --quiet HEAD^ HEAD -- .");
 });
 
+test("repo-root Vercel config builds site/ without a Root Directory setting", async () => {
+  const config = JSON.parse(await read("../../vercel.json"));
+  assert.equal(config.installCommand, "npm ci --prefix site");
+  assert.equal(config.buildCommand, "npm run build --prefix site");
+  assert.equal(config.outputDirectory, "site/dist");
+});
+
 test("demo capture keeps an absolute project path verbatim", () => {
   assert.deepEqual(parseCapture("Ship it !p /Users/saeed/Workspace/herdr-tasks !t Site-Docs", null), {
     title: "Ship it",

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -6,9 +6,9 @@ import { parseCapture } from "../public/capture.js";
 
 const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
 
-test("Vercel ignores unchanged files relative to the site root", async () => {
+test("site Vercel config does not skip the first production deploy", async () => {
   const config = JSON.parse(await read("../vercel.json"));
-  assert.equal(config.ignoreCommand, "git diff --quiet HEAD^ HEAD -- .");
+  assert.equal(config.ignoreCommand, undefined);
 });
 
 test("repo-root Vercel config builds site/ without a Root Directory setting", async () => {

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -2,6 +2,5 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "astro",
-  "installCommand": "npm ci",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+  "installCommand": "npm ci"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "installCommand": "npm ci --prefix site",
+  "buildCommand": "npm run build --prefix site",
+  "outputDirectory": "site/dist"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The new Vercel project clones `herdr-tsk` `main` at `c2bca55` (docs only) and runs `site/vercel.json`'s ignore step:

`git diff --quiet HEAD^ HEAD -- .`

That exits 0, so Vercel cancels: **Ignored Build Step**.

This PR:

- Adds a repo-root `vercel.json` (empty Root Directory still builds `site/`)
- **Removes `ignoreCommand`** so a docs-only `main` tip does not cancel the first production deploy

## Ship it

**Now (no merge):** Vercel → project → **Settings → Git → Ignored Build Step** → clear it / set to empty → **Deployments → Create Deployment** → `main`. That will build the site that is already on `main`.

**Or** deploy this branch (`feat/vercel-root-config-9040`), then merge.

## Test plan

- [x] `cd site && npm test`
- [ ] Vercel production deploy completes (not canceled)
- [ ] https://tsk-gules.vercel.app (or the new project URL) shows the board demo

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65649717-419d-48b1-a4e5-80abe2ae9040?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65649717-419d-48b1-a4e5-80abe2ae9040&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

