### PR TITLE
fix: place task steps below notes

### DIFF
--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -177,10 +177,8 @@ fn build_task_page_overlay<'a>(
     let bound_task = form
         .task_id()
         .and_then(|id| model.tasks.iter().find(|task| task.id == id));
-    // The section consumes the extracted step views, never the raw storage; with
-    // steps the layout halves the content region (AC-24), so the notes window —
-    // and with it the notes scroll bound recorded below — keys off the same halved
-    // budget the painter lays out.
+    // The section consumes the extracted step views, never the raw storage. Notes and
+    // steps share one scrollable stream, with two blank rows separating the sections.
     let step_views = bound_task.map(super::model::step_views).unwrap_or_default();
     // A step draft is windowed for the shared bottom input slot: the row less
     // the two-cell `▎ ` prompt that owns the terminal cursor.

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -325,9 +325,9 @@ fn build_task_page_overlay<'a>(
     let editing_notes = model.input_mode() == BoardInputMode::EditNotes;
     let (notes_rows, notes_cursor, more_lines, notes_scroll) = if editing_notes {
         let (all_rows, cursor_row, cursor_column) = wrapped_edit_rows(&form.notes, notes_width);
-        // Wheel and arrow scrolling are inert while the editor owns the page, so the
-        // frame's scroll may follow the caret without fighting a reading position:
-        // keep the minimal window that still shows the caret's wrapped row.
+        // The notes editor owns the page viewport, so wheel and page scrolling stay inert
+        // while the caret is active. Keep the minimal window that shows the caret's wrapped
+        // row; Esc returns to page view, where below-fold steps can be scrolled into view.
         let follow = form.notes_scroll.clamp(
             cursor_row.saturating_sub(want.saturating_sub(1)),
             cursor_row,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1719,9 +1719,8 @@ pub enum StepsSection {
     /// editor no longer reserves a section row — since T-7 it paints on the page
     /// footer, so an open line over an empty steps is still no section.
     None,
-    /// At least one step: the content region halves and the section owns the bottom
-    /// half, however many steps there are — the `+N more ↓` affordance names the
-    /// tail the half cannot show.
+    /// At least one step: the section follows the notes after two blank rows, and
+    /// the shared content viewport scrolls when the resulting page overflows.
     Steps,
 }
 
@@ -1753,8 +1752,8 @@ pub struct StepsWindow {
     pub affordance: bool,
 }
 
-/// A shared page-content flow: notes occupy at least the first half when steps
-/// exist, longer notes push the steps down, and the whole resulting stream scrolls.
+/// A shared page-content flow: steps follow the notes with two blank rows between
+/// them, and the whole resulting stream scrolls.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PageContentLayout {
     pub steps_start: usize,
@@ -1769,13 +1768,13 @@ pub fn page_content_layout(
 ) -> PageContentLayout {
     let note_rows = note_rows.max(1);
     let viewport = viewport_rows as usize;
-    // The blank after notes is part of the flow, even when their natural height
-    // already exceeds half the viewport. A trailing blank similarly separates the
-    // final content section from the fixed footer when it scrolls into view.
+    // Two blank rows after notes keep the steps visually separated from the note,
+    // regardless of viewport size. A trailing blank similarly separates the final
+    // content section from the fixed footer when it scrolls into view.
     let steps_start = if steps == 0 {
         note_rows
     } else {
-        note_rows.saturating_add(1).max(viewport.div_ceil(2))
+        note_rows.saturating_add(2)
     };
     let total_rows = steps_start + usize::from(steps > 0) + steps + 1;
     PageContentLayout {
@@ -1991,9 +1990,8 @@ fn paint_task_page(
         );
     }
 
-    // Notes and steps form one vertical stream. With steps, short notes reserve the
-    // first half of the viewport; long notes take the rows they need and push the
-    // steps downward. The header and metadata footer never participate in this scroll.
+    // Notes and steps form one vertical stream. Steps begin two blank rows after the
+    // notes, and the header and metadata footer never participate in this scroll.
     let note_count = notes_rows.len().max(1);
     let content = page_content_layout(note_count, step_views.len(), lay.notes_rows);
     let scroll = step_scroll.min(content.max_scroll);
@@ -3364,6 +3362,15 @@ mod tests {
             })
             .expect("draw");
         terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn steps_start_two_rows_after_the_notes_block() {
+        let layout = page_content_layout(1, 3, 16);
+        assert_eq!(layout.steps_start, 3);
+
+        let layout = page_content_layout(5, 3, 16);
+        assert_eq!(layout.steps_start, 7);
     }
 
     #[test]

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -1051,8 +1051,8 @@ fn task_page_paints_steps_section_between_notes_and_footer() {
     );
 
     // The compact tier stays operable: the notes and their two-row separation remain
-    // visible, while the steps section can be reached by scrolling, and every row stays
-    // width-bounded.
+    // visible at the head, while the steps section can be reached by scrolling. Every
+    // scroll position must preserve the fixed chrome and the frame width.
     let compact = board_rows(&model, 40, 10);
     let compact_shown: Vec<String> = compact.iter().map(|row| trimmed(row)).collect();
     let compact_note = compact_shown
@@ -1065,10 +1065,53 @@ fn task_page_paints_steps_section_between_notes_and_footer() {
         "compact page must keep two blank rows before steps:\n{}",
         compact_shown.join("\n")
     );
+
+    let mut saw_label = false;
+    let mut saw_first = false;
+    let mut saw_second = false;
+    let mut saw_third = false;
+    for scroll in 0..=5 {
+        let rows = board_rows(&model, 40, 10);
+        let geo = tier::resolve(40, 10);
+        let body = rows
+            .iter()
+            .map(|row| trimmed(row))
+            .collect::<Vec<_>>()
+            .join("\n");
+        saw_label |= body.contains("steps 2/3");
+        saw_first |= body.contains("✓ first step");
+        saw_second |= body.contains("✓ second step");
+        saw_third |= body.contains("▪ third step");
+        let rule_row = geo.rule_row.expect("compact rule row");
+        let status_row = geo.status_row.expect("compact status row");
+        let verb_row = geo.verb_row.expect("compact verb row");
+        assert!(
+            rows[rule_row as usize].contains('─')
+                && !trimmed(&rows[status_row as usize]).is_empty()
+                && !trimmed(&rows[verb_row as usize]).is_empty(),
+            "compact fixed chrome must remain intact at scroll {scroll}:\n{body}"
+        );
+        assert!(
+            rows.iter().all(|row| row_display_width(row) == 40),
+            "compact steps rows exceeded the frame width at scroll {scroll}:\n{body}"
+        );
+        if scroll < 5 {
+            apply_intent(
+                &mut domain,
+                &mut model,
+                BoardIntent::PageWheelScrollDown,
+                None,
+            )
+            .expect("scroll compact task page");
+        }
+    }
+    assert!(saw_label, "compact scrolling never reached the steps label");
+    assert!(saw_first, "compact scrolling never reached the first step");
     assert!(
-        compact.iter().all(|row| row_display_width(row) == 40),
-        "compact steps rows exceeded the frame width"
+        saw_second,
+        "compact scrolling never reached the second step"
     );
+    assert!(saw_third, "compact scrolling never reached the third step");
 }
 
 /// T-2 (AC-6): a task with no steps steps paints no steps section at all --
@@ -1111,7 +1154,8 @@ fn task_page_without_steps_paints_no_steps_section() {
 }
 
 /// At the 40x10 compact floor, a notes edit keeps its draft row visible and preserves
-/// the two blank rows before the steps section, even though the section is below the fold.
+/// the two blank rows before the steps section. The notes editor owns the viewport, so
+/// below-fold steps become reachable after Esc returns to page view.
 #[test]
 fn task_page_notes_edit_keeps_a_visible_row_and_spacing_at_the_compact_floor() {
     let mut domain = DomainState::new();
@@ -1154,6 +1198,42 @@ fn task_page_notes_edit_keeps_a_visible_row_and_spacing_at_the_compact_floor() {
         rows.iter().all(|row| row_display_width(row) == 40),
         "compact edit page exceeded the frame width"
     );
+
+    apply_intent(&mut domain, &mut model, BoardIntent::CancelEdit, None)
+        .expect("return to page view");
+    let mut saw_label = false;
+    let mut saw_step = false;
+    for scroll in 0..=5 {
+        let rows = board_rows(&model, 40, 10);
+        let geo = tier::resolve(40, 10);
+        let body = rows
+            .iter()
+            .map(|row| trimmed(row))
+            .collect::<Vec<_>>()
+            .join("\n");
+        saw_label |= body.contains("steps 1/3");
+        saw_step |= body.contains("✓ first step");
+        let rule_row = geo.rule_row.expect("compact rule row");
+        let status_row = geo.status_row.expect("compact status row");
+        let verb_row = geo.verb_row.expect("compact verb row");
+        assert!(
+            rows[rule_row as usize].contains('─')
+                && !trimmed(&rows[status_row as usize]).is_empty()
+                && !trimmed(&rows[verb_row as usize]).is_empty(),
+            "compact fixed chrome must remain intact after notes edit at scroll {scroll}:\n{body}"
+        );
+        if scroll < 5 {
+            apply_intent(
+                &mut domain,
+                &mut model,
+                BoardIntent::PageWheelScrollDown,
+                None,
+            )
+            .expect("scroll compact page after notes edit");
+        }
+    }
+    assert!(saw_label, "steps label was not reachable after notes edit");
+    assert!(saw_step, "steps were not reachable after notes edit");
 }
 
 #[test]

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -1029,9 +1029,10 @@ fn task_page_paints_steps_section_between_notes_and_footer() {
     let notes_row = find("the notes body", &shown);
     let label_row = find("steps 2/3", &shown);
     let meta_row = find("created", &shown);
-    assert!(
-        notes_row < label_row,
-        "steps section must sit after the notes block:\n{}",
+    assert_eq!(
+        label_row,
+        notes_row + 3,
+        "steps label must follow the notes with two blank rows:\n{}",
         shown.join("\n")
     );
     assert!(
@@ -1049,18 +1050,19 @@ fn task_page_paints_steps_section_between_notes_and_footer() {
         shown.join("\n")
     );
 
-    // The compact tier stays operable: the section still paints and never reaches the
-    // bottom chrome rows, and every row stays width-bounded.
+    // The compact tier stays operable: the notes and their two-row separation remain
+    // visible, while the steps section can be reached by scrolling, and every row stays
+    // width-bounded.
     let compact = board_rows(&model, 40, 10);
     let compact_shown: Vec<String> = compact.iter().map(|row| trimmed(row)).collect();
-    let compact_label = compact_shown
+    let compact_note = compact_shown
         .iter()
-        .position(|row| row.contains("steps 2/3"))
-        .unwrap_or_else(|| panic!("compact page omitted the steps label:\n{compact:#?}"));
-    let geo = tier::resolve(40, 10);
+        .position(|row| row.contains("the notes body"))
+        .expect("compact page omitted the notes");
     assert!(
-        (compact_label as u16) < geo.rule_row.expect("compact rule row"),
-        "compact steps section must stay above the chrome rows:\n{}",
+        list_body(&compact[compact_note + 1]).is_empty()
+            && list_body(&compact[compact_note + 2]).is_empty(),
+        "compact page must keep two blank rows before steps:\n{}",
         compact_shown.join("\n")
     );
     assert!(
@@ -1108,13 +1110,10 @@ fn task_page_without_steps_paints_no_steps_section() {
     }
 }
 
-/// T-2 remediation 1 (review round 0, Important): at the 40x10 compact floor a >=3-step
-/// steps clamps to the whole content region, and the notes edit that shared those
-/// rows painted NOTHING -- keystrokes worked, nothing rendered. A notes edit must always
-/// keep at least one visible draft row; the steps section yields the row (it caps,
-/// it does not vanish).
+/// At the 40x10 compact floor, a notes edit keeps its draft row visible and preserves
+/// the two blank rows before the steps section, even though the section is below the fold.
 #[test]
-fn task_page_notes_edit_keeps_a_visible_row_at_the_compact_floor_alongside_steps() {
+fn task_page_notes_edit_keeps_a_visible_row_and_spacing_at_the_compact_floor() {
     let mut domain = DomainState::new();
     let id = domain
         .create(
@@ -1143,9 +1142,13 @@ fn task_page_notes_edit_keeps_a_visible_row_at_the_compact_floor_alongside_steps
         body.contains("draft line under edit"),
         "a notes edit must paint at least one draft row at 40x10:\n{body}"
     );
+    let note_row = shown
+        .iter()
+        .position(|row| row.contains("draft line under edit"))
+        .expect("notes edit row missing");
     assert!(
-        body.contains("steps 1/3"),
-        "the steps section must cap to make room, not vanish:\n{body}"
+        list_body(&rows[note_row + 1]).is_empty() && list_body(&rows[note_row + 2]).is_empty(),
+        "notes edit must preserve two blank rows before steps:\n{body}"
     );
     assert!(
         rows.iter().all(|row| row_display_width(row) == 40),
@@ -1502,10 +1505,9 @@ fn task_page_view_wraps_long_notes_instead_of_truncating() {
     );
 }
 
-/// Long notes and steps form one scrollable page body. Notes use at least the
-/// first half of the viewport, then push the steps below the viewport instead of
-/// clipping them. The header and meta footer remain fixed while PageScroll reveals
-/// the deferred steps and the side scrollbar reports the overflow.
+/// Long notes and steps form one scrollable page body. Steps follow the notes after
+/// two blank rows instead of being positioned at a viewport fraction. The header and
+/// meta footer remain fixed while PageScroll reveals the deferred steps and scrollbar.
 #[test]
 fn task_page_scrolls_notes_and_steps_as_one_content_region() {
     let notes = (0..20)
@@ -1545,7 +1547,7 @@ fn task_page_scrolls_notes_and_steps_as_one_content_region() {
         shown.join("\n")
     );
 
-    for _ in 0..7 {
+    for _ in 0..8 {
         apply_intent(
             &mut domain,
             &mut model,
@@ -1588,9 +1590,8 @@ fn task_page_scrolls_notes_and_steps_as_one_content_region() {
     );
 }
 
-/// T-6 (AC-24): steps stack from the TOP of the steps half — step 1 directly
-/// under the section label, each next step directly below the previous — so a
-/// fourth step lands below the third, never pinned to the row above the footer.
+/// Steps stack from the top of their section, with step 1 directly under the section
+/// label and each next step directly below the previous, never pinned to the footer.
 #[test]
 fn steps_stack_from_the_top_below_the_divider() {
     let mut domain = DomainState::new();
@@ -1610,19 +1611,22 @@ fn steps_stack_from_the_top_below_the_divider() {
     let mut model = BoardModel::from_domain(&domain, None);
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open task page");
 
-    // 78x24: label opens the bottom half on row 12; steps 1..3 stack downward
-    // from it while the footer-side rows of the half stay empty.
+    // 78x24: the note is on row 3, the two-row gap follows, and the label is on row 6;
+    // steps 1..3 stack downward from it while the footer-side rows stay empty.
     let rows = board_rows(&model, 78, 24);
     let shown: Vec<String> = rows.iter().map(|row| trimmed(row)).collect();
     let label = shown
         .iter()
         .position(|row| row.contains("steps 0/3"))
         .unwrap_or_else(|| panic!("steps label missing:\n{}", shown.join("\n")));
-    assert_eq!(label, 12, "the half opens on the halfway row");
+    assert_eq!(
+        label, 6,
+        "the steps label follows the notes and two-row gap"
+    );
     assert!(
-        shown[13].contains("▪ first step")
-            && shown[14].contains("▪ second step")
-            && shown[15].contains("▪ third step"),
+        shown[7].contains("▪ first step")
+            && shown[8].contains("▪ second step")
+            && shown[9].contains("▪ third step"),
         "steps must stack one directly under another from the top of the half:\n{}",
         shown.join("\n")
     );
@@ -1638,7 +1642,7 @@ fn steps_stack_from_the_top_below_the_divider() {
     let rows4 = board_rows(&model, 78, 24);
     let shown4: Vec<String> = rows4.iter().map(|row| trimmed(row)).collect();
     assert!(
-        shown4[16].contains("▪ fourth step"),
+        shown4[10].contains("▪ fourth step"),
         "the fourth step must land directly below the third:\n{}",
         shown4.join("\n")
     );


### PR DESCRIPTION
## Summary

Task-page steps now follow the rendered notes block with exactly two blank rows between them. This removes the previous viewport-half placement, so short notes no longer push steps down to the middle of the page.

## Changes

- Replace the half-viewport `steps_start` calculation with `note_rows + 2`.
- Keep the shared notes-and-steps scrolling behavior and fixed page chrome.
- Update renderer and integration regression coverage for standard and compact layouts.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo build --release`

All passed: 279 unit/integration tests, with 2 ignored doc tests and 2 ignored benchmark tests.

## Spec note

The existing checklist spec's AC-24 still describes the superseded half-viewport behavior. This PR implements the requested two-row spacing and updates the executable regression coverage; the spec wording should be aligned with this behavior.

## Review scope

Please review the task-page layout and scroll behavior, especially compact terminals where the steps section may begin below the initial viewport and must remain reachable by scrolling.
