### PR TITLE
feat: store-global task numbers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ For scriptable board work, use `tsk add` and `tsk list`; read
   project-scoped · done drawer (`z`). Scoped ON DECK thread blocks paint dim `#name`
   headers with open counts; headers consume row budget but are not selectable or
   hit-testable.
-- Standard ≥78×24, compact below, operable to 40×10
+- Standard ≥78×24, compact below, operable to 40×10. Persisted task rows paint their
+  bare task number as dim meta chrome, including peek, task page, and done drawer; drafts
+  without a number paint none.
 - Human status: `ready` · `started` · `blocked` · `review` · `done`. The store
   still reads old `todo`/`doing` values.
 - Mutating verbs (`space` `d` `o` `b` `e` `n` `x` `u` `q`) need Alt, or Ctrl

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,8 @@ Canonical terms for this repo. No implementation detail.
 - **step done**: a step's checked state. Progress information only; it never implies, drives, or auto-applies a task status change.
 - **toggle**: flip one step's done flag. The only step state change that is not a text change.
 - **step cursor**: the task page's step-row focus. Inactive on page open; a bare ↓ activates it (again after any deactivation), ↑ from the first step deactivates it. While active, bare arrows move it and modifier-protected verbs act on it; a single click on a step row moves it.
-- **step short id**: an unambiguous prefix of a step's stable identity, the way tasks are addressed from the CLI.
+- **task number**: the store-global sequential integer assigned when a task is durably created. Spoken and typed as `12`. Unique across desk, every project, and every thread, including done and soft-deleted tasks. An address, not identity and not an ordering promise. Never reused.
+- **step short id**: an unambiguous prefix of a step's stable identity, used to address a step within one task from the CLI.
 - **thread**: an optional single name a task carries, grouping it with same-named tasks in the same scope. Not an entity: no identity beyond the name, no status, no lifecycle. It presents on the board exactly while at least one open task in its scope carries it; the field itself persists on the task regardless of status.
 - **thread token**: the `!t name` capture directive, sibling of `!p`; bare `!t` means unthreaded. Stripped from the saved title.
 - **thread header**: a derived, non-selectable board row above a thread's open tasks in a scoped deck group, showing the thread name and open count. Chrome, not a task.

--- a/docs/specs/adr/0004-store-global-task-number.md
+++ b/docs/specs/adr/0004-store-global-task-number.md
@@ -1,0 +1,45 @@
+# ADR-0004: Task numbers are store-global, not per-project
+
+Date: 2026-08-31 · Status: accepted
+
+## Context
+
+tsk needs a human-readable task address so a person can say "implement task 12"
+and an agent can resolve it. Identity today is a UUID. Three numbering scopes
+were considered: (A) one sequential integer unique across the whole store;
+(B) per-project (and per-desk) integers, GitHub-style, with a prefix or cwd
+to disambiguate; (C) no new number, expose a UUID short prefix the way steps
+already do. Independent spawn reviews (fable, sol, kimi) all recommended (A).
+The owner settled on (A) with canonical form `12`.
+
+## Decision
+
+Assign each durably created task one store-global sequential integer. The
+number is unique across desk, every project path, and every thread, including
+done and soft-deleted tasks. Cwd does not participate in resolution. UUID
+remains internal identity.
+
+## Why
+
+- **"Task 12" has to mean one task.** Under (B), desk-12 and widget-12 are both
+  "task 12" until the speaker adds a prefix. The spoken form the feature exists
+  to support becomes ambiguous the moment two scopes each have a 12.
+- **The store is the ambiguity unit.** One JSON document, one person. Numbering
+  per project copies a multi-repo forge model onto a single personal store.
+- **Project identity here is a path, not a key.** Basenames collide, paths
+  move, desk is not a project. A `proj-12` form needs a second identity system
+  just to avoid a global counter, and it eats board cells.
+- **cwd-relative 12 is the same bug.** The same words would mean different
+  tasks in different terminals, including a project cwd hiding a desk task.
+- **UUID prefixes fail as speech.** They are not memorable, and a shortest
+  unambiguous prefix lengthens as the store grows, so a handle an agent cached
+  last week can become ambiguous. Step prefixes work because their namespace
+  is one task's small sibling list.
+
+## Consequences
+
+- Numbers grow across the whole store (3 to 4 digits in ordinary use). Still
+  speakable, still a few cells on a row.
+- A task that changes project keeps its number. That is the point.
+- An older writer that dropped the number on save would silently invalidate
+  every spoken handle, so the store must refuse that rewrite.

--- a/docs/specs/task-numbers/build-report.md
+++ b/docs/specs/task-numbers/build-report.md
@@ -1,0 +1,86 @@
+# Build report — task-numbers
+
+Branch: `feat/task-numbers` in `.worktrees/task-numbers` (from `origin/main` @ `c2bca55`).
+Baseline green bar: passed 2026-08-31 in this worktree.
+
+## Task ledger
+
+| Task | Status | Commit | AC advanced | Notes |
+| --- | --- | --- | --- | --- |
+| T-1 | done | 77a352f0ce54bb42c5e45ee4eac77b97b27cc83b | AC-1 AC-2 AC-3 AC-4 AC-6 AC-7 AC-9 AC-10 AC-11 AC-12 AC-13 | one remediations pass on tests; no second review |
+| T-2 | done | 0614f1f5983b1e7f4f7cf6b4c83a2b039b2e9794 | AC-5 AC-20 AC-21 AC-22 | initial review clean |
+| T-3 | done | 75b522da022876f68c7266c17be8fdb63233ac43 | AC-8 AC-14 AC-15 AC-16 AC-17 AC-18 AC-19 AC-28 | remediations on test oracles |
+| T-4 | done | 9c1ccad4c4e4186a8eb0d98b16378ebbebffba9b | AC-23 AC-24 AC-25 AC-26 AC-27 | remediations: scope hits + real-path footer test |
+| T-5 | done | 1b5f96086bfedf4ddbc56e6632b07d9cd5dd7590 | AC-29 | remediations: compact board.md wording |
+
+### T-1 (@ `77a352f0ce54bb42c5e45ee4eac77b97b27cc83b`)
+
+Green bar: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release` exit 0.
+
+```
+test domain::task::tests::locked_create_assigns_number_one_then_two ... ok
+test domain::task::tests::edit_status_scope_thread_complete_soft_delete_leave_number_unchanged ... ok
+test domain::task::tests::undo_of_complete_and_of_soft_delete_keeps_the_same_number ... ok
+test pre_number_store_upgrades_assigning_distinct_numbers_including_done_and_deleted ... ok
+test upgraded_store_preserves_numbers_on_second_load ... ok
+test overlapping_creates_under_lock_receive_distinct_numbers ... ok
+test v2_store_is_refused_when_writer_format_is_older_and_the_file_is_unwritten ... ok
+test reload_merge_save_keeps_numbers_and_counter_across_another_writer ... ok
+```
+
+### T-2 (@ `0614f1f5983b1e7f4f7cf6b4c83a2b039b2e9794`)
+
+Green bar exit 0. Initial review: no blocking findings.
+
+```
+test json_list_rows_include_number ... ok
+test human_list_rows_show_bare_digits ... ok
+test json_created_and_existing_include_number ... ok
+test plan_created_and_existing_include_number ... ok
+test existing_add_does_not_advance_the_counter ... ok
+```
+
+### T-3 (@ `75b522da022876f68c7266c17be8fdb63233ac43`)
+
+Green bar exit 0.
+
+```
+test list_bare_digits_finds_the_task_from_another_cwd ... ok
+test list_bare_digits_finds_done_and_deleted_tasks ... ok
+test list_uuid_still_finds_the_task ... ok
+test list_bare_digits_with_scope_or_status_flags_is_usage ... ok
+test list_unknown_number_matches_unknown_uuid_refusal ... ok
+test steps_bare_digits_act_on_the_task ... ok
+test steps_uuid_still_acts_on_the_task ... ok
+test steps_unknown_number_is_unknown_task ... ok
+```
+
+### T-4 (@ `9c1ccad4c4e4186a8eb0d98b16378ebbebffba9b`)
+
+Green bar exit 0 after remediations.
+
+```
+test board_row_meta_shows_bare_digits_not_hash_or_t_prefix ... ok
+test peek_shows_bare_digits ... ok
+test task_page_footer_shows_bare_digits ... ok
+test done_drawer_rows_show_bare_digits ... ok
+test numbered_board_at_40x10_paints_in_bounds_wraps_titles_and_keeps_tasks_reachable ... ok
+test ac_25_task_page_footer_number_precedes_the_form_scope_hit_target ... ok
+```
+
+### T-5 (@ `1b5f96086bfedf4ddbc56e6632b07d9cd5dd7590`)
+
+`cd site && npm test` exit 0, 4 passed.
+
+```
+demo rows paint bare task numbers ... ok
+```
+
+## Deviations
+
+Isolation created at `.worktrees/task-numbers`; parent clone stays on `fix/steps-notes-spacing`.
+T-1 High findings remediated (tests). Owner skipped a second review.
+T-3 Medium test-oracle findings remediated.
+T-4 blocked on red suite; remediations updated hit tests and added a real-path footer test.
+T-5 Medium compact-docs finding remediated.
+Live herdr smoke of the board was not run.

--- a/docs/specs/task-numbers/gate-report.md
+++ b/docs/specs/task-numbers/gate-report.md
@@ -1,0 +1,88 @@
+# Gate report — task-numbers
+
+Spec: `docs/specs/task-numbers/task-numbers.md` · gated 2026-08-31 · read-only; nothing
+modified but this report.
+
+## Chain coverage (criterion → component → product → task)
+
+`## Tech Stack` declares the in-stack fast-path (**No new products — reuses the
+declared stack**), which the walk honours as the component → product link for all
+components at once. Product column therefore reads `in-stack` throughout.
+
+| AC | Component(s) | Product | Task(s) | Gap |
+| --- | --- | --- | --- | --- |
+| AC-1 | Number allocator, Task number field | in-stack | T-1 | — |
+| AC-2 | Number allocator, Task number field | in-stack | T-1 | — |
+| AC-3 | Number allocator | in-stack | T-1 | — |
+| AC-4 | Number allocator | in-stack | T-1 | — |
+| AC-5 | CLI number presentation, Number allocator | in-stack | T-2 | note F-3 |
+| AC-6 | Task number field | in-stack | T-1 | — |
+| AC-7 | Task number field | in-stack | T-1 | — |
+| AC-8 | Operand resolver | in-stack | T-3 | — |
+| AC-9 | Number allocator | in-stack | T-1 | — |
+| AC-10 | Number allocator | in-stack | T-1 | — |
+| AC-11 | Number allocator, Task number field | in-stack | T-1 | — |
+| AC-12 | Number allocator, Task number field | in-stack | T-1 | — |
+| AC-13 | Number allocator | in-stack | T-1 | — |
+| AC-14 | Operand resolver | in-stack | T-3 | — |
+| AC-15 | Operand resolver | in-stack | T-3 | — |
+| AC-16 | Operand resolver | in-stack | T-3 | — |
+| AC-17 | Operand resolver | in-stack | T-3 | — |
+| AC-18 | Operand resolver | in-stack | T-3 | — |
+| AC-19 | Operand resolver | in-stack | T-3 | — |
+| AC-20 | CLI number presentation | in-stack | T-2 | — |
+| AC-21 | CLI number presentation | in-stack | T-2 | — |
+| AC-22 | CLI number presentation | in-stack | T-2 | — |
+| AC-23 | Board number chrome | in-stack | T-4 | — |
+| AC-24 | Board number chrome | in-stack | T-4 | — |
+| AC-25 | Board number chrome | in-stack | T-4 | — |
+| AC-26 | Board number chrome | in-stack | T-4 | — |
+| AC-27 | Board number chrome | in-stack | T-4 | — |
+| AC-28 | CLI skills doc | in-stack | T-3 | note F-2 |
+| AC-29 | Site number docs | in-stack | T-5 | — |
+
+Reverse walk: every task (T-1..T-5) advances ≥1 AC (no gold-plating). Every AC
+reaches ≥1 task. NC-1..NC-12 are `NC`-prefixed and outside the mechanical coverage
+set. Reviewer-checked AC-28 and AC-29 have carrying tasks (T-3 produces
+`skills/tsk-cli/SKILL.md`; T-5 produces the site files).
+
+Green bar declared: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`.
+
+## Mid-chain entry / coverage note
+
+`## Brief` carries provenance `spawn investigation (fable, sol, kimi) settled with
+the user on store-global 12, 2026-08-31`. Later sections are hand-authored in this
+run. No `untraced` links. Chain entered at idea.
+
+## Findings
+
+**Critical:** none. **High:** none.
+
+**F-1 · Low · owner: plan.** Design component **Task number field** is not named in
+any task's `*Component:*` field. T-1 implements it (literals, immutability tests)
+under **Number allocator**. Acceptable slice; recorded so build does not treat the
+field as unowned.
+
+**F-2 · Low · owner: plan.** Design component **CLI skills doc** is not named in
+any task's `*Component:*` field. T-3's `*Advances:*` includes AC-28 and its files
+list `skills/tsk-cli/SKILL.md`. Coverage-forward holds; the `*Component:*` line
+names Operand resolver.
+
+**F-3 · Low · owner: plan.** AC-5's design owners include Number allocator, but
+only T-2 advances it (`existing_add_does_not_advance_the_counter`). The allocator
+half lives in that CLI test. No action required.
+
+## Checker corroboration
+
+`sdlc-check 0.20.1: all checks passed — 0 findings, 0 notes.`
+Invoked as `node /Users/saeed/.pi/agent/git/github.com/smarzban/agent-sdlc/checker/sdlc-check.mjs docs/specs/task-numbers/task-numbers.md`. Exit 0.
+
+Load-bearing library claims: none (in-stack fast-path; integer fields and format
+refusal are in-repo precedent).
+
+Constitution: no `constitution.md`; standing `AGENTS.md` product rules checked,
+no conflict.
+
+## Verdict
+
+**Ready to build.** No Critical or High findings. Checker passed.

--- a/docs/specs/task-numbers/task-numbers.md
+++ b/docs/specs/task-numbers/task-numbers.md
@@ -1,0 +1,555 @@
+# Task numbers
+
+Feature: a store-global sequential task number so a person can say "implement
+task 12" and an agent can resolve that to one task.
+
+## Brief
+
+<!-- source: spawn investigation (fable, sol, kimi) settled with the user on store-global 12, 2026-08-31 · ingested 2026-08-31 -->
+
+**Problem.** Tasks are identified by UUID. A person cannot tell an agent
+"implement task 12" and have it resolve. `tsk list` and `tsk steps` already take
+that UUID; step short ids already exist inside one task. Neither is speakable as
+a handle for the task itself.
+
+**Scope.** Every durably created task receives one store-global sequential
+integer, the task number, spoken and typed as `12`. It is unique across desk,
+every project, and every thread, including done and soft-deleted tasks. Cwd does
+not participate once the number is present: `tsk list 12` finds that task
+whether it lives on the desk or in another project. The number is shown on the
+board row, peek, task page, and human `tsk list`; JSON `list` / `add` emit it
+beside the UUID; `tsk list` and `tsk steps` accept it wherever they accept a
+task UUID today. UUID still works. The skills doc tells agents to resolve
+"task 12" through `tsk list 12`. Existing tasks, including done and
+soft-deleted, receive numbers on upgrade. An older binary must not rewrite the
+store and erase numbers.
+
+**Non-goals.** No per-project, per-desk, or per-thread numbering; no
+cwd-relative "12 means this repo"; no `proj-12` composite; no UUID short prefix
+as the human form; no title slug; no reuse after delete; no `T12` or `#12` as
+the board form (`#` is the thread glyph); no create-undo; no SQLite or sidecar
+index; no dark-engine revival; UUID remains internal identity; human status
+remains the only status source of truth.
+
+**Chosen approach.** One store-wide counter, over (a) per-project integers and
+(b) UUID prefixes. The store is one JSON document for one person, so the
+numbering unit matches the ambiguity unit. Per-project numbers make "task 12"
+mean two tasks the moment desk and a project both hold 12, and then every spoken
+reference needs a prefix. UUID prefixes are unspeakable, and the shortest
+unambiguous prefix lengthens as the store grows, so a handle recorded last week
+can go stale. Recorded as ADR-0004.
+
+**Resolved key decisions.**
+
+- Canonical form is bare digits: spoken "task 12", typed `12`, painted `12`.
+  Not `#12` on the board (`#` is the thread glyph, and `12` is a valid thread
+  name). Not `T12` on the board (owner settled).
+- CLI addressing accepts the bare number anywhere a task UUID is accepted
+  today. UUID remains valid. Direct lookup ignores cwd and scope flags, the
+  same rule UUID lookup already has.
+- Assigned once, when creation is durably accepted. Never reused, never
+  changed by edit, status, scope move, thread, complete, or soft-delete.
+  Done drawer and deleted view still show it. Restore brings the same number
+  back.
+- Title-idempotent add that finds an existing task returns that task's number
+  and does not consume a new one.
+- The number is an address, not an ordering promise. Gaps are valid.
+- Internals stay UUID-only: selection, revisions, merge matching, undo,
+  history, dispatch-attempt links. The number is a boundary alias.
+- Step identity is unchanged: step short ids remain prefixes of step UUIDs
+  inside one task.
+- Board chrome: the number is extra cells, titles still wrap, nothing
+  truncates. Compact 40×10 stays operable.
+- Site docs and the web demo follow the board/CLI change (keymap unchanged, so
+  `keys.md` is untouched unless a later stage finds a key).
+
+**Glossary terms touched.** task number (added); step short id (wording
+corrected so it no longer claims to be how tasks are addressed).
+
+**ADR.** `docs/specs/adr/0004-store-global-task-number.md`.
+
+## Acceptance Criteria
+
+Term pins for this section: a task **carries** number N when its stored task
+number equals N. **Direct lookup** is `list` or `steps` invoked with a
+single-task operand. **Bare digits** are a decimal integer with no prefix
+character (`12`, not `#12`, not `T12`). **Same class of error as unknown UUID**
+means that command's existing unknown-UUID refusal (list: usage refusal; steps:
+`unknown-task`), never an empty success.
+
+### Assignment
+
+**AC-1** A newly persisted task carries a task number. *(Verification type:
+**test-backed** — integration)*
+
+**AC-2** No two tasks in the store carry the same task number. *(Verification
+type: **test-backed** — integration)*
+
+**AC-3** Of two tasks persisted in sequence, the later carries a strictly greater
+number. *(Verification type: **test-backed** — integration)*
+
+**AC-4** Two overlapping durable creates assign two different numbers.
+*(Verification type: **test-backed** — integration)*
+
+**AC-5** An add that reports the task as already existing returns that task's
+number, and no task's number changes. *(Verification type: **test-backed** —
+integration)*
+
+### Stability
+
+**AC-6** After a task carries a number, every later mutation of that task leaves
+the number unchanged. *(Verification type: **test-backed** — integration)*
+
+**AC-7** Undo of complete or of soft-delete leaves the task carrying the same
+number. *(Verification type: **test-backed** — integration)*
+
+**AC-8** Direct lookup by number finds the task when it is done and when it is
+soft-deleted. *(Verification type: **test-backed** — integration)*
+
+**AC-9** A later create never carries a number that any task has already carried,
+including soft-deleted tasks. *(Verification type: **test-backed** —
+integration)*
+
+### Upgrade
+
+**AC-10** A store written before this feature loads without error. *(Verification
+type: **test-backed** — integration)*
+
+**AC-11** After opening that store, every task in it, including done and
+soft-deleted, carries a distinct task number. *(Verification type:
+**test-backed** — integration)*
+
+**AC-12** A second load of that store preserves each task number exactly.
+*(Verification type: **test-backed** — integration)*
+
+**AC-13** A binary that cannot preserve task numbers refuses a store that has
+them, and does not write that store. *(Verification type: **test-backed** —
+integration)*
+
+### CLI
+
+**AC-14** Direct lookup with bare digits N lists the unique task that carries N.
+The result does not depend on cwd or invocation default. *(Verification type:
+**test-backed** — integration)*
+
+**AC-15** Direct lookup with bare digits combined with a scope, thread, or status
+filter is refused with the same class of error as combining a UUID with those
+filters. *(Verification type: **test-backed** — integration)*
+
+**AC-16** Direct lookup with the task's UUID still lists that task.
+*(Verification type: **test-backed** — integration)*
+
+**AC-17** Direct lookup with bare digits no task carries fails with the same
+class of error as unknown UUID on that command. *(Verification type:
+**test-backed** — integration)*
+
+**AC-18** `steps` with bare digits N acts on the unique task that carries N.
+*(Verification type: **test-backed** — integration)*
+
+**AC-19** `steps` with the task's UUID still acts on that task. *(Verification
+type: **test-backed** — integration)*
+
+**AC-20** JSON list output includes each row's task number. *(Verification type:
+**test-backed** — integration)*
+
+**AC-21** JSON add output includes the task number on created and on existing
+outcomes, including plan rows. *(Verification type: **test-backed** —
+integration)*
+
+**AC-22** Human list output shows each row's task number as bare digits.
+*(Verification type: **test-backed** — integration)*
+
+### Board
+
+**AC-23** A board task row shows the task number as bare digits. *(Verification
+type: **test-backed** — unit)*
+
+**AC-24** Peek shows the task number as bare digits. *(Verification type:
+**test-backed** — unit)*
+
+**AC-25** The task page shows the task number as bare digits. *(Verification
+type: **test-backed** — unit)*
+
+**AC-26** The done drawer shows the task number as bare digits. *(Verification
+type: **test-backed** — unit)*
+
+**AC-27** At 40×10, numbered rows paint in bounds, titles wrap rather than
+truncate, and every listed task remains reachable by arrow navigation.
+*(Verification type: **test-backed** — unit)*
+
+### Docs
+
+**AC-28** The CLI skills doc documents task number as the human handle, UUID
+still valid, cwd ignored on direct lookup, and the verify-before-retry rules
+unchanged. *(Verification type: **reviewer-checked** — axis: Spec Conformance.
+Pass/fail: does `skills/tsk-cli/SKILL.md` document bare-digit lookup for `list`
+and `steps`, JSON emission of the task number, UUID still valid, cwd ignored,
+and the existing retry/exit contract? Justification: prose-contract completeness
+is not cheaply automatable; the carrying task is the CLI task that produces the
+doc.)*
+
+**AC-29** Site board and CLI docs, and the board demo, show the task number as
+bare digits. *(Verification type: **reviewer-checked** — axis: Spec Conformance.
+Pass/fail: do `site/src/content/docs/docs/board.md`, `cli.md`, and
+`site/public/board-demo.js` show `12` not `#12` or `T12`, with no keymap change
+in `keys.md`? Justification: site copy and the demo are not in the Rust test
+bar; the carrying task is the site-docs task that produces those files.)*
+
+### Negative criteria (out of bounds)
+
+**NC-1** No two scopes independently number from 1: a desk task and a project
+task never both carry 12.
+
+**NC-2** Direct lookup never uses cwd to choose among tasks.
+
+**NC-3** No surface accepts or paints `proj-N` as the task number.
+
+**NC-4** No surface paints a UUID prefix as the task number.
+
+**NC-5** No title slug is used as the task number.
+
+**NC-6** The board never paints the task number as `#N` or `TN`.
+
+**NC-7** No create-undo is added.
+
+**NC-8** No second store, sidecar index, or database is introduced.
+
+**NC-9** Addressing a task by number does not change its human status.
+
+**NC-10** No attention, park/resume, linking, or dispatch surface returns.
+
+**NC-11** Step short ids remain prefixes of step identity, not task numbers.
+
+**NC-12** `keys.md` is unchanged.
+
+### Verification map
+
+| Criterion | Oracle kind / review axis |
+| --- | --- |
+| AC-1 | integration |
+| AC-2 | integration |
+| AC-3 | integration |
+| AC-4 | integration |
+| AC-5 | integration |
+| AC-6 | integration |
+| AC-7 | integration |
+| AC-8 | integration |
+| AC-9 | integration |
+| AC-10 | integration |
+| AC-11 | integration |
+| AC-12 | integration |
+| AC-13 | integration |
+| AC-14 | integration |
+| AC-15 | integration |
+| AC-16 | integration |
+| AC-17 | integration |
+| AC-18 | integration |
+| AC-19 | integration |
+| AC-20 | integration |
+| AC-21 | integration |
+| AC-22 | integration |
+| AC-23 | unit |
+| AC-24 | unit |
+| AC-25 | unit |
+| AC-26 | unit |
+| AC-27 | unit |
+| AC-28 | Spec Conformance (reviewer-checked) |
+| AC-29 | Spec Conformance (reviewer-checked) |
+
+### Deferred
+
+None. CLI input sugar (`#12`, `T12`) is not in scope; the canonical form is bare
+digits.
+
+### Glossary terms touched
+
+None beyond **task number** (already in `CONTEXT.md`). **Bare digits** and
+**direct lookup** are pinned above, local to this section.
+
+## Design
+
+Feature-level: every component is a change to an existing surface except the
+allocator, which is new. The load-bearing shape: the task number is an immutable
+alias on the task record, minted only at the locked document-write boundary;
+selection, revisions, merge, undo, and history stay on task identity (ADR-0004).
+Board paint puts bare digits in the existing dim meta run, not in the title.
+
+### Components
+
+1. **Task number field** — the integer address stored on the task. Input: a
+   number produced by the allocator. Output: that integer for presentation and
+   lookup. Never present on a draft. Errors: none at read. Edits, status, scope,
+   thread, complete, and soft-delete do not take this field as input, so they
+   cannot change it. Uniqueness is an invariant of the document: two tasks never
+   carry the same number.
+2. **Number allocator** — the only writer of new numbers. Kind: a monotonic
+   counter on the versioned document, advanced under the existing exclusive lock.
+   Input: a locked document plus either a newly persisted task or a pre-feature
+   document whose tasks have no numbers. Output: those tasks carrying numbers,
+   counter at least one greater than every assigned number, document version that
+   old writers cannot round-trip. Errors: overlapping creates are serialized by
+   the lock (two creates, two numbers); an upgrade that cannot be written refuses
+   the open and does not expose temporary numbers; a binary that cannot preserve
+   numbers refuses a numbered store and does not write it. Idempotent add that
+   finds an existing task returns that number and does not advance the counter.
+   Legacy assignment covers every task including done and soft-deleted, once, in
+   created-at order (identity as the deterministic tie-break), then persists
+   before any lookup is served.
+3. **Operand resolver** — CLI boundary that turns a single-task operand into task
+   identity. Input: argv string. Output: the existing UUID lookup path. Accepts a
+   UUID or bare digits; bare digits resolve to the unique task that carries that
+   number, including done and soft-deleted, ignoring cwd and invocation default.
+   Errors: malformed operand is usage; unknown number uses the same class of
+   error as unknown UUID on that command; combining a number with scope, thread,
+   or status filters uses the same refusal as combining a UUID with those
+   filters. Domain commands never see a number.
+4. **CLI number presentation** — list and add output. Input: tasks that carry
+   numbers. Output: JSON rows and add results include a numeric `number` beside
+   `id`; human list rows show bare digits. Created and existing add outcomes both
+   emit it, including plan rows. Errors: none beyond existing add/list failures.
+5. **Board number chrome** — paints the number as dim bare digits in the existing
+   row-meta run (with age and project), on peek meta, on the task-page footer, and
+   on done-drawer rows. Input: the task's number. Output: painted cells; titles
+   still wrap; copied title text stays title-only. Registers no new hit target
+   and no selectable identity. Errors: none (read-only). At 40×10 the extra cells
+   ride the existing wrap engine so every listed task stays reachable by arrows.
+6. **CLI skills doc** — the skills file that agents read. Input: the CLI
+   contract above. Output: prose that names task number as the human handle, UUID
+   still valid, cwd ignored on direct lookup, JSON `number`, and the existing
+   retry/exit rules. Errors: none.
+7. **Site number docs** — board and CLI pages plus the board demo. Input: the
+   board/CLI contract. Output: those pages and the demo show `12`, not `#12` or
+   `T12`. `keys.md` is not edited. Errors: none.
+
+Rejected shapes: a per-scope counter (ADR-0004); minting in memory before the
+lock (two creators can mint the same number); deriving the number from created-at
+rank at read time (a later compact or reorder would renumber spoken handles);
+prefixing the title (spends wrap budget on every row; meta is already the small-fact
+column).
+
+### Data flow and key state
+
+Durable create → exclusive lock → allocator mints → document write → board chrome
+and CLI presentation. Direct lookup: argv → operand resolver → domain by identity
+→ list/steps as today. Pre-feature open: exclusive lock → allocator backfills →
+versioned write → then serve. Key state lives in one place: the task record plus
+one document-level next-number counter. No session state, no secondary index.
+Selection stays identity-pinned; the number is not a selection key.
+
+### Trust and failure boundaries
+
+Untrusted input is the CLI operand (and, for agents, whatever they copy from
+list). The resolver validates at that boundary; the domain and store only ever
+see task identity. Failure modes: malformed or unknown operand → command-local
+refusal, nothing persisted; store I/O on create → existing exit-3 indeterminate
+contract, verify with list; overlapping creates → lock, distinct numbers; upgrade
+write failure → refuse open; old writer against a numbered store → refuse, live
+file untouched. Renderer failure cannot mint or change a number.
+
+### Criterion → component map
+
+| Criterion | Component(s) |
+| --- | --- |
+| AC-1 | Number allocator, Task number field |
+| AC-2 | Number allocator, Task number field |
+| AC-3 | Number allocator |
+| AC-4 | Number allocator |
+| AC-5 | CLI number presentation, Number allocator |
+| AC-6 | Task number field |
+| AC-7 | Task number field |
+| AC-8 | Operand resolver |
+| AC-9 | Number allocator |
+| AC-10 | Number allocator |
+| AC-11 | Number allocator, Task number field |
+| AC-12 | Number allocator, Task number field |
+| AC-13 | Number allocator |
+| AC-14 | Operand resolver |
+| AC-15 | Operand resolver |
+| AC-16 | Operand resolver |
+| AC-17 | Operand resolver |
+| AC-18 | Operand resolver |
+| AC-19 | Operand resolver |
+| AC-20 | CLI number presentation |
+| AC-21 | CLI number presentation |
+| AC-22 | CLI number presentation |
+| AC-23 | Board number chrome |
+| AC-24 | Board number chrome |
+| AC-25 | Board number chrome |
+| AC-26 | Board number chrome |
+| AC-27 | Board number chrome |
+| AC-28 | CLI skills doc |
+| AC-29 | Site number docs |
+
+### ADRs created
+
+- `docs/specs/adr/0004-store-global-task-number.md` (idea stage): numbers are
+  store-global, not per-project.
+
+No new ADR for the document-version bump: it is the existing "older writer cannot
+round-trip" rule applied to this field, already named in ADR-0004 consequences.
+
+### Glossary terms touched
+
+None. **Task number** already in `CONTEXT.md`.
+
+Constitution check: no `constitution.md` exists in this repo; the shape was
+checked against `AGENTS.md` standing product rules (human status sovereignty, UUID
+selection pinning, wrap-never-truncate, one JSON document) with no conflict.
+
+## Tech Stack
+
+**No new products — reuses the declared stack.** Every component is work in this
+crate: the allocator is a counter on the existing JSON document, the field is an
+integer on the existing task record, CLI and board ride the existing binary, docs
+are Markdown and the existing board demo. No dependency is added to `Cargo.toml`;
+no version changes. (Green bar: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`, per `AGENTS.md`; CI Rust
+1.96.0.)
+
+No load-bearing external-library claims exist to probe: integer fields and
+`format_version` refusal are already exercised by this store (`format_version` is
+a document integer; newer documents are refused, not rewritten). In-repo
+precedent, not an external claim.
+
+Unverified: none. Glossary terms touched: none.
+
+## Plan
+
+**T-1 — Domain field, allocator, upgrade, format bump.** Add `number: Option<u64>`
+on the task (absent means unassigned: drafts and pre-upgrade rows) and
+`next_task_number: u64` on the document. Mint only inside the exclusive locked
+save: a newly persisted UUID receives the counter, the counter advances, merge
+takes `max` of the two counters and never assigns a number an existing UUID
+already has. Bump `STORE_FORMAT_VERSION` to 2; keep `LEGACY_STORE_FORMAT_VERSION`
+at 1. A v1 document, on first locked open, assigns distinct numbers to every
+task including done and soft-deleted, in `created_at` order with id as
+tie-break, writes the v2 document, then serves lookups. A binary that cannot
+preserve numbers refuses a v2 store and does not write it. Edit, status, scope,
+thread, complete, and soft-delete do not take `number` as input. Include compile
+fallout of the new fields on every `Task` / `DomainState` literal.
+
+- Files: `src/domain/task.rs`, `src/store.rs`, `src/ui/queue.rs`,
+  `src/ui/render.rs`, `src/capture.rs`, `src/domain/undo.rs`,
+  `tests/store_persist.rs`, `tests/queue_board_model.rs`,
+  `tests/queue_board_render.rs`, `tests/e2e_persist.rs`.
+- Test first: in `src/domain/task.rs`,
+  `locked_create_assigns_number_one_then_two`,
+  `edit_status_scope_thread_complete_soft_delete_leave_number_unchanged`,
+  `undo_of_complete_and_of_soft_delete_keeps_the_same_number`. In
+  `tests/store_persist.rs`,
+  `pre_number_store_upgrades_assigning_distinct_numbers_including_done_and_deleted`,
+  `upgraded_store_preserves_numbers_on_second_load`,
+  `overlapping_creates_under_lock_receive_distinct_numbers`,
+  `v2_store_is_refused_when_writer_format_is_older_and_the_file_is_unwritten`.
+- *Advances:* AC-1, AC-2, AC-3, AC-4, AC-6, AC-7, AC-9, AC-10, AC-11, AC-12, AC-13.
+  *Component:* Number allocator. *Deps:* none.
+
+**T-2 — CLI presentation.** List JSON rows and add JSON (flag created/existing and
+plan created/existing rows) include numeric `number` beside `id`. Human list rows
+show bare digits. Idempotent add that reports existing emits that task's number
+and does not advance the counter.
+
+- Files: `src/cli/list.rs`, `src/cli/add.rs`, `src/cli/presenter.rs`,
+  `tests/cli_list.rs`, `tests/cli_add.rs`.
+- Test first: in `tests/cli_list.rs`, `json_list_rows_include_number`,
+  `human_list_rows_show_bare_digits`. In `tests/cli_add.rs`,
+  `json_created_and_existing_include_number`,
+  `plan_created_and_existing_include_number`,
+  `existing_add_does_not_advance_the_counter`.
+- *Advances:* AC-5, AC-20, AC-21, AC-22.
+  *Component:* CLI number presentation. *Deps:* T-1.
+
+**T-3 — CLI addressing and skills.** Direct lookup accepts bare digits N or a UUID.
+`list N` and `steps N` act on the unique task that carries N, including done and
+soft-deleted, ignoring cwd and invocation default. Combining a number with scope,
+thread, or status filters is refused the same way as combining a UUID with those
+filters. Unknown number uses the same class of error as unknown UUID on that
+command. Update `skills/tsk-cli/SKILL.md` so agents resolve "task 12" via
+`tsk list 12`, UUID still valid, cwd ignored, JSON `number`, retry/exit contract
+unchanged.
+
+- Files: `src/cli/parser.rs`, `src/cli/list.rs`, `src/cli/steps.rs`,
+  `src/cli/presenter.rs`, `tests/cli_list.rs`, `tests/cli_steps.rs`,
+  `skills/tsk-cli/SKILL.md`.
+- Test first: in `tests/cli_list.rs`,
+  `list_bare_digits_finds_the_task_from_another_cwd`,
+  `list_bare_digits_finds_done_and_deleted_tasks`,
+  `list_uuid_still_finds_the_task`,
+  `list_bare_digits_with_scope_or_status_flags_is_usage`,
+  `list_unknown_number_matches_unknown_uuid_refusal`. In `tests/cli_steps.rs`,
+  `steps_bare_digits_act_on_the_task`,
+  `steps_uuid_still_acts_on_the_task`,
+  `steps_unknown_number_is_unknown_task`.
+- *Advances:* AC-8, AC-14, AC-15, AC-16, AC-17, AC-18, AC-19, AC-28.
+  *Component:* Operand resolver. *Deps:* T-1, T-2.
+
+**T-4 — Board number chrome.** Paint dim bare digits in the existing row-meta run
+(with age and project), on peek meta, on the task-page footer as the first
+component, and on done-drawer rows. Titles still wrap. No `#` or `T` prefix. No
+new hit target. Document the painted number in `AGENTS.md`'s board section.
+Regenerate golden fixtures via the ignored test, never by hand.
+
+- Files: `src/ui/render.rs`, `src/ui/board/draw.rs`, `AGENTS.md`,
+  `tests/queue_board_render.rs`, `tests/fixtures/` (golden board renders).
+- Test first: in `tests/queue_board_render.rs`,
+  `board_row_meta_shows_bare_digits_not_hash_or_t_prefix`,
+  `peek_shows_bare_digits`,
+  `task_page_footer_shows_bare_digits`,
+  `done_drawer_rows_show_bare_digits`,
+  `numbered_board_at_40x10_paints_in_bounds_wraps_titles_and_keeps_tasks_reachable`.
+- *Advances:* AC-23, AC-24, AC-25, AC-26, AC-27.
+  *Component:* Board number chrome. *Deps:* T-1.
+
+**T-5 — Site number docs.** Board and CLI pages and the board demo show `12`, not
+`#12` or `T12`. Do not edit `keys.md`.
+
+- Files: `site/src/content/docs/docs/board.md`, `site/src/content/docs/docs/cli.md`,
+  `site/public/board-demo.js`.
+- Test first: in `site/` the existing `npm test` assertions (extend the demo/docs
+  tests if present; otherwise the verification is the reviewer pass/fail on AC-29
+  plus `npm test` still green). Add a demo fixture assertion that a painted row
+  contains `12` and does not contain `#12` or `T12`.
+- *Advances:* AC-29.
+  *Component:* Site number docs. *Deps:* T-4.
+
+### Task-to-criterion coverage map
+
+| Criterion | Advanced by |
+| --- | --- |
+| AC-1 | T-1 |
+| AC-2 | T-1 |
+| AC-3 | T-1 |
+| AC-4 | T-1 |
+| AC-5 | T-2 |
+| AC-6 | T-1 |
+| AC-7 | T-1 |
+| AC-8 | T-3 |
+| AC-9 | T-1 |
+| AC-10 | T-1 |
+| AC-11 | T-1 |
+| AC-12 | T-1 |
+| AC-13 | T-1 |
+| AC-14 | T-3 |
+| AC-15 | T-3 |
+| AC-16 | T-3 |
+| AC-17 | T-3 |
+| AC-18 | T-3 |
+| AC-19 | T-3 |
+| AC-20 | T-2 |
+| AC-21 | T-2 |
+| AC-22 | T-2 |
+| AC-23 | T-4 |
+| AC-24 | T-4 |
+| AC-25 | T-4 |
+| AC-26 | T-4 |
+| AC-27 | T-4 |
+| AC-28 | T-3 |
+| AC-29 | T-5 |
+
+### Notes
+
+Mint inside the locked save, never in the in-memory `create` helper: two CLI
+processes must not both mint 13. Golden fixtures regenerate with
+`cargo test --test queue_board_render regenerate_golden_fixtures -- --ignored`.
+Do not rewrite `HANDOFF.md`. Live board smoke uses an isolated `TSK_STATE_DIR`,
+never `~/.tsk`. Site-only files are outside the Rust green bar; T-5 still runs
+`npm test` in `site/`.

--- a/docs/specs/task-numbers/verification-report.md
+++ b/docs/specs/task-numbers/verification-report.md
@@ -1,0 +1,36 @@
+# Verification report — task-numbers
+
+Pre-PR AC → proof map. Proof identifiers are taken from `build-report.md`
+evidence blocks. Checker corroboration runs after this file is written.
+
+| Criterion | Type | Proof |
+| --- | --- | --- |
+| AC-1 | test-backed | locked_create_assigns_number_one_then_two |
+| AC-2 | test-backed | overlapping_creates_under_lock_receive_distinct_numbers |
+| AC-3 | test-backed | locked_create_assigns_number_one_then_two |
+| AC-4 | test-backed | overlapping_creates_under_lock_receive_distinct_numbers |
+| AC-5 | test-backed | existing_add_does_not_advance_the_counter |
+| AC-6 | test-backed | edit_status_scope_thread_complete_soft_delete_leave_number_unchanged |
+| AC-7 | test-backed | undo_of_complete_and_of_soft_delete_keeps_the_same_number |
+| AC-8 | test-backed | list_bare_digits_finds_done_and_deleted_tasks |
+| AC-9 | test-backed | reload_merge_save_keeps_numbers_and_counter_across_another_writer |
+| AC-10 | test-backed | pre_number_store_upgrades_assigning_distinct_numbers_including_done_and_deleted |
+| AC-11 | test-backed | pre_number_store_upgrades_assigning_distinct_numbers_including_done_and_deleted |
+| AC-12 | test-backed | upgraded_store_preserves_numbers_on_second_load |
+| AC-13 | test-backed | v2_store_is_refused_when_writer_format_is_older_and_the_file_is_unwritten |
+| AC-14 | test-backed | list_bare_digits_finds_the_task_from_another_cwd |
+| AC-15 | test-backed | list_bare_digits_with_scope_or_status_flags_is_usage |
+| AC-16 | test-backed | list_uuid_still_finds_the_task |
+| AC-17 | test-backed | list_unknown_number_matches_unknown_uuid_refusal |
+| AC-18 | test-backed | steps_bare_digits_act_on_the_task |
+| AC-19 | test-backed | steps_uuid_still_acts_on_the_task |
+| AC-20 | test-backed | json_list_rows_include_number |
+| AC-21 | test-backed | json_created_and_existing_include_number |
+| AC-22 | test-backed | human_list_rows_show_bare_digits |
+| AC-23 | test-backed | board_row_meta_shows_bare_digits_not_hash_or_t_prefix |
+| AC-24 | test-backed | peek_shows_bare_digits |
+| AC-25 | test-backed | ac_25_task_page_footer_number_precedes_the_form_scope_hit_target |
+| AC-26 | test-backed | done_drawer_rows_show_bare_digits |
+| AC-27 | test-backed | numbered_board_at_40x10_paints_in_bounds_wraps_titles_and_keeps_tasks_reachable |
+| AC-28 | reviewer-checked | Pass: `skills/tsk-cli/SKILL.md` documents `tsk list 12` and `tsk steps 12`, JSON `number`, UUID still valid, cwd ignored on direct lookup, and the existing retry/exit contract. |
+| AC-29 | reviewer-checked | Pass: `board.md` and `cli.md` show store-global bare digits; `board-demo.js` paints them; `keys.md` is unchanged. |

--- a/site/public/board-demo.js
+++ b/site/public/board-demo.js
@@ -20,9 +20,10 @@ import { parseCapture } from "./capture.js";
   const DAY = 24 * HOUR;
 
   const seed = () => {
-    let n = 1;
+    let n = 12;
     const task = (partial) => ({
-      id: `t${n++}`,
+      id: `t${n}`,
+      number: n++,
       notes: "",
       thread: null,
       project: null,
@@ -131,6 +132,7 @@ import { parseCapture } from "./capture.js";
     undo: null,
     refuse: "",
     nextId: 20,
+    nextNumber: 22,
   };
 
   const esc = (s) =>
@@ -339,6 +341,7 @@ import { parseCapture } from "./capture.js";
 
   function metaFor(task) {
     const bits = [];
+    bits.push(String(task.number));
     if (state.tab === "desk" && task.project) bits.push(task.project);
     bits.push(age(task.updatedAt));
     return bits.join(" · ");
@@ -470,6 +473,7 @@ import { parseCapture } from "./capture.js";
     const now = Date.now();
     const task = {
       id,
+      number: state.nextNumber++,
       title: parsed.title,
       notes: "",
       status: "ready",
@@ -595,7 +599,7 @@ import { parseCapture } from "./capture.js";
         ${title}
         <div class="dim">${esc(task.status)} · ${esc(projectName(task))}${task.thread ? ` · #${esc(task.thread)}` : ""}</div>
         ${notes}
-        <div class="foot dim">esc close · alt+e title · alt+n notes · alt+d done · alt+b block</div>
+        <div class="foot dim">${task.number} · esc close · alt+e title · alt+n notes · alt+d done · alt+b block</div>
       </div>`;
   }
 

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -10,7 +10,7 @@ Home is a tabbed board: **desk** · **projects** · **threads** (`1` / `2` / `3`
 - **threads**: cross-project thread names with project sub-groups
 
 Project focus (`P` → project) hides the tabs and paints the project name chip.
-Collapse state is session-only.
+Collapse state is session-only. Each row's dim meta includes its store-global task number as bare digits, alongside its age and project when shown.
 
 ## Sections
 
@@ -25,7 +25,7 @@ One urgency-ordered list. Sections are computed, not navigated.
 | Pane | What you get |
 | --- | --- |
 | at least 78×24 | standard board |
-| smaller | compact: glyph and title only |
+| smaller | compact: glyph, bare task number, and title |
 | down to 40×10 | still operable |
 
 ## Human status

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -13,6 +13,10 @@ tsk list
 `add` creates tasks without opening the TUI. `list` prints tasks from the store
 without changing them.
 
+Task numbers are store-global, so `tsk list 12` finds task `12` regardless of
+your current directory. JSON output exposes that value as `number`; UUID lookup
+continues to work too.
+
 State is still `~/.tsk` whether you use the board, herdr, or the CLI.
 
 See the app README and `skills/tsk-cli/SKILL.md` in

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -25,3 +25,12 @@ test("the shared theme script is loaded once from the Starlight head", async () 
   assert.match(config, /attrs: \{ src: ['"]\/theme\.js['"] \}/);
   assert.doesNotMatch(themeSelect, /theme\.js/);
 });
+
+test("demo rows paint bare task numbers", async () => {
+  const demo = await read("../public/board-demo.js");
+  assert.match(demo, /let n = 12;/);
+  assert.match(demo, /number: n\+\+,/);
+  assert.match(demo, /bits\.push\(String\(task\.number\)\)/);
+  assert.doesNotMatch(demo, /#\$\{task\.number\}/);
+  assert.doesNotMatch(demo, /T\$\{task\.number\}/);
+});

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -25,7 +25,7 @@ Use `--title=<value>`, `--notes=<value>`, `--project=<value>`,
 plus `--file` are usage (exit 2, nothing persists). Piped stdin with item flags
 is ignored and not read. Use `--json` with a flag add when another
 tool needs one result object. It contains `outcome` (`created` or `existing`),
-`id`, trimmed `title`, and resolved `project` (or `null` for the desk).
+`id`, numeric `number`, trimmed `title`, and resolved `project` (or `null` for the desk).
 
 Plan JSON accepts a per-item `thread` string or `null`, for example
 `[{"title":"Release notes","thread":"release-2026"}]`. Invalid plan thread
@@ -62,22 +62,28 @@ exclusive, as are `--done` and `--deleted`.
 A typo in a project name silently files the task under a new scope. Use
 `tsk list --all --json` to recover the resulting scope.
 
-## Steps
+## Direct task lookup and steps
+
+A task number is the human handle: resolve “task 12” with `tsk list 12`.
+Bare digits and UUIDs are both valid task operands. Direct lookup ignores cwd,
+invocation default, and task scope: `tsk list 12` finds its one task even in
+another project, including done and soft-deleted tasks. JSON list rows include
+numeric `number` beside `id`. Do not combine a direct task operand with scope,
+thread, or status filters.
 
 ```sh
-tsk steps <task-id> add "Draft outline"
-tsk steps <task-id> toggle <step-short-id>
-tsk list <task-id>
+tsk steps 12 add "Draft outline"
+tsk steps 12 toggle <step-short-id>
+tsk list 12
 ```
 
-`<task-id>` is a task UUID from `tsk list --json`. A step short id is
-the shortest unambiguous prefix of the step id. `tsk list <task-id>`
+A step short id is the shortest unambiguous prefix of the step id. `tsk list 12`
 prints one line per step with its `[x]`/`[ ]` state and short id; with `--json`
 the row's `steps` array carries each step's `id`, `text`, `done`, and
-`short_id`.
+`short_id`. UUID remains valid in each command where a task number is shown.
 
 `toggle` flips the step state: a retry after an unseen success flips it back.
-Never blind-retry a `steps` invocation — run `tsk list <task-id>`
+Never blind-retry a `steps` invocation, run `tsk list 12`
 first and retry only a real refusal. `steps` exits 0 when the step was created
 or toggled, 1 for a refusal (stable tokens `empty-step-text`,
 `invalid-step-text`, `unknown-task`, `soft-deleted-task`, `unknown-step`,

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -46,6 +46,7 @@ impl PlanResult {
 struct Created {
     i: usize,
     id: Uuid,
+    number: u64,
     title: String,
 }
 
@@ -54,6 +55,7 @@ struct Created {
 struct Existing {
     i: usize,
     id: Uuid,
+    number: u64,
     title: String,
 }
 
@@ -88,11 +90,13 @@ struct ResolvedPlanItem {
 pub enum FlagAddResult {
     Created {
         id: Uuid,
+        number: u64,
         title: String,
         project: Option<String>,
     },
     Existing {
         id: Uuid,
+        number: u64,
         title: String,
         project: Option<String>,
     },
@@ -123,6 +127,9 @@ pub fn run(input: FlagAdd) -> Result<FlagAddResult, AddError> {
                 return Ok((
                     FlagAddResult::Existing {
                         id: task.id,
+                        number: task
+                            .number
+                            .expect("loaded tasks receive a number before CLI presentation"),
                         title: task.title.clone(),
                         project: scope_project(&task.scope),
                     },
@@ -141,7 +148,20 @@ pub fn run(input: FlagAdd) -> Result<FlagAddResult, AddError> {
                     thread,
                 )
                 .map_err(|error| error.to_string())?;
-            Ok((FlagAddResult::Created { id, title, project }, true))
+            domain.assign_numbers_for_persistence();
+            let number = domain
+                .get(id)
+                .and_then(|task| task.number)
+                .expect("new tasks receive a number while the store lock is held");
+            Ok((
+                FlagAddResult::Created {
+                    id,
+                    number,
+                    title,
+                    project,
+                },
+                true,
+            ))
         })
         .map_err(AddError::Store)
 }
@@ -182,6 +202,9 @@ pub fn run_plan(
                     existing.push(Existing {
                         i: item.i,
                         id: task.id,
+                        number: task
+                            .number
+                            .expect("loaded tasks receive a number before CLI presentation"),
                         title: item.title,
                     });
                     continue;
@@ -197,9 +220,15 @@ pub fn run_plan(
                         item.thread,
                     )
                     .expect("plan item titles and threads are validated before domain creation");
+                domain.assign_numbers_for_persistence();
+                let number = domain
+                    .get(id)
+                    .and_then(|task| task.number)
+                    .expect("new tasks receive a number while the store lock is held");
                 created.push(Created {
                     i: item.i,
                     id,
+                    number,
                     title: item.title,
                 });
             }

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -47,6 +47,7 @@ pub enum ListError {
 #[derive(Debug, Serialize)]
 pub(crate) struct ListRow {
     pub(crate) id: Uuid,
+    pub(crate) number: u64,
     pub(crate) title: String,
     pub(crate) status: HumanStatus,
     pub(crate) project: Option<String>,
@@ -245,6 +246,9 @@ pub fn run(input: ListInput) -> Result<ListResult, ListError> {
 fn row_for(task: &crate::domain::Task) -> ListRow {
     ListRow {
         id: task.id,
+        number: task
+            .number
+            .expect("loaded tasks receive a number before CLI presentation"),
         title: task.title.clone(),
         status: task.status,
         project: match &task.scope {

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use serde::Serialize;
 use uuid::Uuid;
 
+use crate::cli::parser::{parse_task_address, TaskAddress};
 use crate::context::snapshot_from_env;
 use crate::domain::{normalize_thread, HumanStatus, TaskScope};
 use crate::scope::resolve_flag_scope;
@@ -21,8 +22,8 @@ pub struct ListInput {
     pub deleted: bool,
     /// Normalized at the argv boundary so filtering only compares valid names.
     pub thread: Option<String>,
-    /// One task addressed by id: single-task listing with step lines.
-    pub task: Option<Uuid>,
+    /// One task addressed by UUID or human number: single-task listing with step lines.
+    pub task: Option<TaskAddress>,
     pub state_dir: Option<PathBuf>,
     pub help: bool,
 }
@@ -39,8 +40,8 @@ pub(crate) enum ListView {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ListError {
     Store(String),
-    /// A well-formed task id that addresses no task in the store.
-    UnknownTask(Uuid),
+    /// A well-formed task address that addresses no task in the store.
+    UnknownTask,
 }
 
 /// One task visible to the list command.
@@ -147,8 +148,7 @@ pub fn parse(args: &[String]) -> Result<ListInput, String> {
                 if input.task.is_some() {
                     return Err(format!("unknown list argument {flag}"));
                 }
-                input.task =
-                    Some(Uuid::parse_str(flag).map_err(|_| format!("invalid task id {flag}"))?);
+                input.task = Some(parse_task_address(flag)?);
                 index += 1;
             }
             _ => return Err(format!("unknown list argument {flag}")),
@@ -158,10 +158,12 @@ pub fn parse(args: &[String]) -> Result<ListInput, String> {
     if input.task.is_some()
         && (input.all || input.global || input.project.is_some() || input.thread.is_some())
     {
-        return Err("task id cannot be used with --project, --desk, --all, or --thread".into());
+        return Err(
+            "task operand cannot be used with --project, --desk, --all, or --thread".into(),
+        );
     }
     if input.task.is_some() && (input.done || input.deleted) {
-        return Err("task id cannot be used with --done or --deleted".into());
+        return Err("task operand cannot be used with --done or --deleted".into());
     }
     if input.all && (input.global || input.project.is_some()) {
         return Err("--all cannot be used with --project or --desk".into());
@@ -181,13 +183,13 @@ pub fn run(input: ListInput) -> Result<ListResult, ListError> {
     let domain = store
         .load()
         .map_err(|error| ListError::Store(error.to_string()))?;
-    if let Some(task_id) = input.task {
-        // Single-task listing: id addressing, no scope or filter, step lines included.
+    if let Some(task_address) = input.task {
+        // Single-task listing ignores cwd and filters, and includes step lines.
         let task = domain
             .tasks()
             .iter()
-            .find(|task| task.id == task_id)
-            .ok_or(ListError::UnknownTask(task_id))?;
+            .find(|task| task_address.matches(task))
+            .ok_or(ListError::UnknownTask)?;
         let view = if task.soft_deleted {
             ListView::Deleted
         } else if task.status == HumanStatus::Done {

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -7,6 +7,35 @@ use uuid::Uuid;
 use super::steps::StepsAction;
 use crate::domain::normalize_thread;
 
+/// A direct task operand, either the internal UUID or its human task number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskAddress {
+    Id(Uuid),
+    Number(u64),
+}
+
+impl TaskAddress {
+    pub fn matches(self, task: &crate::domain::Task) -> bool {
+        match self {
+            Self::Id(id) => task.id == id,
+            Self::Number(number) => task.number == Some(number),
+        }
+    }
+}
+
+/// Parse a task UUID or its bare-decimal human number.
+pub fn parse_task_address(value: &str) -> Result<TaskAddress, String> {
+    if value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return value
+            .parse::<u64>()
+            .map(TaskAddress::Number)
+            .map_err(|_| format!("invalid task id {value}"));
+    }
+    Uuid::parse_str(value)
+        .map(TaskAddress::Id)
+        .map_err(|_| format!("invalid task id {value}"))
+}
+
 /// Parsed add input. A plan source is selected by `file` or piped stdin.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FlagAdd {
@@ -144,7 +173,7 @@ pub fn parse_flag_add(args: &[String]) -> Result<FlagAdd, String> {
 /// and the action's operand.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FlagSteps {
-    pub task: Option<Uuid>,
+    pub task: Option<TaskAddress>,
     pub action: Option<StepsAction>,
     pub state_dir: Option<PathBuf>,
     pub help: bool,
@@ -204,9 +233,7 @@ pub fn parse_flag_steps(args: &[String]) -> Result<FlagSteps, String> {
                 "steps action is required".into()
             });
         }
-        let task = positionals[0]
-            .parse::<Uuid>()
-            .map_err(|_| format!("invalid task id {}", positionals[0]))?;
+        let task = parse_task_address(positionals[0])?;
         let operand = positionals
             .get(2)
             .copied()

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -18,9 +18,9 @@ pub fn add_help() -> CliOutput {
 pub fn list_help() -> CliOutput {
     CliOutput {
         stdout: concat!(
-            "usage: tsk list [<task-id>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n\n",
+            "usage: tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n\n",
             "Lists ready, started, blocked, and review tasks in the invocation project by default, or your desk outside a repository.\n",
-            "With a task id (a task UUID from add --json or list --json), lists that one task alone and prints its steps: one line per step with its [x]/[ ] state and step short id. A task id cannot be combined with scope, thread, or status filters.\n",
+            "With a task number (bare digits) or UUID from add --json or list --json, lists that one task alone and prints its steps: one line per step with its [x]/[ ] state and step short id. Direct lookup ignores cwd. A task operand cannot be combined with scope, thread, or status filters.\n",
             "--project uses the same basename-or-path scope resolution as add; --desk selects your desk, tasks not tied to a project; --all selects every scope. --thread normalizes a thread name and filters within the selected scope; an invalid name is a usage error (exit 2). For dash-leading project and state-directory values, use --project=<scope> and --state-dir=<dir>.\n",
             "--done lists done tasks only. --deleted lists soft-deleted tasks only, regardless of status.\n",
             "To recover a typo scope, use tsk list --all --json.\n",
@@ -383,11 +383,11 @@ fn path_segments(path: &str) -> Vec<String> {
 pub fn steps_help() -> CliOutput {
     CliOutput {
         stdout: concat!(
-            "usage: tsk steps <task-id> add <text> [--state-dir <dir>]\n",
-            "       tsk steps <task-id> toggle <step-short-id> [--state-dir <dir>]\n\n",
-            "steps adds one step to a task or toggles one step's done flag. The task id is a task UUID from tsk list --json.\n",
-            "A step short id is the shortest unambiguous prefix of the step id, as printed by tsk list <task-id>.\n",
-            "toggle flips the step state: a blind retry after an unseen success flips it back, so verify with tsk list <task-id> before retrying.\n\n",
+            "usage: tsk steps <task> add <text> [--state-dir <dir>]\n",
+            "       tsk steps <task> toggle <step-short-id> [--state-dir <dir>]\n\n",
+            "steps adds one step to a task or toggles one step's done flag. The task is a bare task number or UUID from tsk list --json; direct lookup ignores cwd.\n",
+            "A step short id is the shortest unambiguous prefix of the step id, as printed by tsk list <task>.\n",
+            "toggle flips the step state: a blind retry after an unseen success flips it back, so verify with tsk list <task> before retrying.\n\n",
             "Refusal tokens (exit 1): empty-step-text, invalid-step-text, unknown-task, soft-deleted-task, unknown-step, ambiguous-step.\n\n",
             "Exit contract:\n",
             "  exit 0: step created or toggled\n",
@@ -424,7 +424,7 @@ pub fn steps_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk steps: {reason}\nusage: tsk steps <task-id> add <text> | toggle <step-short-id> [--state-dir <dir>]\n"
+            "tsk steps: {reason}\nusage: tsk steps <task> add <text> | toggle <step-short-id> [--state-dir <dir>]\n"
         ),
         code: 2,
     }
@@ -446,7 +446,7 @@ pub fn list_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk list: {reason}\nusage: tsk list [<task-id>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n"
+            "tsk list: {reason}\nusage: tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]\n"
         ),
         code: 2,
     }
@@ -459,8 +459,8 @@ pub fn list_rejected(error: ListError) -> CliOutput {
             stderr: format!("tsk list: {detail}\n"),
             code: 3,
         },
-        // A well-formed id that addresses no task: the invocation is wrong, not the store.
-        ListError::UnknownTask(id) => list_usage(&format!("unknown task id {id}")),
+        // A well-formed address that addresses no task: the invocation is wrong, not the store.
+        ListError::UnknownTask => list_usage("unknown task"),
     }
 }
 

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -24,7 +24,7 @@ pub fn list_help() -> CliOutput {
             "--project uses the same basename-or-path scope resolution as add; --desk selects your desk, tasks not tied to a project; --all selects every scope. --thread normalizes a thread name and filters within the selected scope; an invalid name is a usage error (exit 2). For dash-leading project and state-directory values, use --project=<scope> and --state-dir=<dir>.\n",
             "--done lists done tasks only. --deleted lists soft-deleted tasks only, regardless of status.\n",
             "To recover a typo scope, use tsk list --all --json.\n",
-            "--json emits a flat array of id, title, status, project, and thread (or null) in displayed group order. Human --all groups rows by status, then project scope, using a unique concise trailing path or desk.\n\n",
+            "--json emits a flat array of id, number, title, status, project, and thread (or null) in displayed group order. Human --all groups rows by status, then project scope, using a unique concise trailing path or desk.\n\n",
             "Exit contract:\n",
             "  exit 0: tasks were listed\n",
             "  exit 2: usage or parse error, nothing persisted\n",
@@ -39,7 +39,7 @@ pub fn list_help() -> CliOutput {
 fn help_output(usage: &str) -> CliOutput {
     CliOutput {
         stdout: format!(
-            "{usage}\n\nExamples:\n  tsk add -t \"Draft release notes\"\n  tsk add -t \"Buy milk\" --desk\n  tsk add -t \"Fix widget\" --project widget --thread release-2026\n  tsk add --title=\"-fix parser\" --notes=\"-5 degrees\" --project=\"-maintenance\"\n  tsk add --file plan.json\n  cat plan.json | tsk add\n\nValues beginning with - must use --title=<value>, --notes=<value>, --project=<value>, --state-dir=<dir>, or --file=<path>.\nItem flags plus --file are usage (exit 2, nothing persists). Piped stdin with item flags is ignored and not read. An add whose trimmed title, resolved project scope, and normalized thread already exist succeeds without changing the task. With --json, flag add emits one object with outcome, id, title, and project (or null).\nPlan JSON: [{{\"title\": \"...\", \"notes\": \"...\", \"project\": \"...\", \"thread\": \"...\"}}] (thread may also be null)\nPlan result: {{\"created\": [...], \"existing\": [...], \"failed\": [...]}}\n\nExit contract:\n  exit 0: every item was created or already existed\n  exit 1: one or more items were refused, retry failed only\n  exit 2: usage or parse error, nothing persisted\n  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
+            "{usage}\n\nExamples:\n  tsk add -t \"Draft release notes\"\n  tsk add -t \"Buy milk\" --desk\n  tsk add -t \"Fix widget\" --project widget --thread release-2026\n  tsk add --title=\"-fix parser\" --notes=\"-5 degrees\" --project=\"-maintenance\"\n  tsk add --file plan.json\n  cat plan.json | tsk add\n\nValues beginning with - must use --title=<value>, --notes=<value>, --project=<value>, --state-dir=<dir>, or --file=<path>.\nItem flags plus --file are usage (exit 2, nothing persists). Piped stdin with item flags is ignored and not read. An add whose trimmed title, resolved project scope, and normalized thread already exist succeeds without changing the task. With --json, flag add emits one object with outcome, id, number, title, and project (or null).\nPlan JSON: [{{\"title\": \"...\", \"notes\": \"...\", \"project\": \"...\", \"thread\": \"...\"}}] (thread may also be null)\nPlan result: {{\"created\": [...], \"existing\": [...], \"failed\": [...]}}\n\nExit contract:\n  exit 0: every item was created or already existed\n  exit 1: one or more items were refused, retry failed only\n  exit 2: usage or parse error, nothing persisted\n  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
         ),
         stderr: String::new(),
         code: 0,
@@ -48,20 +48,32 @@ fn help_output(usage: &str) -> CliOutput {
 
 pub fn added(result: FlagAddResult, json: bool) -> CliOutput {
     let stdout = match result {
-        FlagAddResult::Created { id, title, project } if json => format!(
+        FlagAddResult::Created {
+            id,
+            number,
+            title,
+            project,
+        } if json => format!(
             "{}\n",
             serde_json::json!({
                 "outcome": "created",
                 "id": id,
+                "number": number,
                 "title": title,
                 "project": project,
             })
         ),
-        FlagAddResult::Existing { id, title, project } if json => format!(
+        FlagAddResult::Existing {
+            id,
+            number,
+            title,
+            project,
+        } if json => format!(
             "{}\n",
             serde_json::json!({
                 "outcome": "existing",
                 "id": id,
+                "number": number,
                 "title": title,
                 "project": project,
             })
@@ -113,7 +125,7 @@ pub fn list(result: ListResult, json: bool) -> CliOutput {
 
 /// The flat row array. A single-task listing with steps attaches them to its
 /// one row (`steps`: id, done, short_id, text); every other listing keeps
-/// today's exact row shape.
+/// the standard task row shape.
 fn list_json(result: &ListResult) -> String {
     let mut value = serde_json::to_value(&result.rows).expect("list rows are serializable");
     if !result.steps.is_empty() {
@@ -204,6 +216,8 @@ fn append_rows(output: &mut String, rows: &[&ListRow], indent: &str) {
     for row in rows {
         output.push_str(indent);
         output.push_str("- ");
+        output.push_str(&row.number.to_string());
+        output.push(' ');
         output.push_str(&terminal_text(&row.title));
         if let Some(thread) = row.thread.as_deref() {
             output.push_str(" #");

--- a/src/cli/steps.rs
+++ b/src/cli/steps.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use serde::Serialize;
 
 use crate::cli::add::has_c0_control;
+use crate::cli::parser::TaskAddress;
 use crate::domain::{DomainError, DomainState, Step};
 use crate::store::{default_state_dir, TaskStore};
 use uuid::Uuid;
@@ -19,7 +20,7 @@ pub enum StepsAction {
 /// A steps failure after parsing and before presenting output.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StepsError {
-    UnknownTask(Uuid),
+    UnknownTask,
     SoftDeletedTask(Uuid),
     EmptyStepText,
     InvalidStepText,
@@ -31,7 +32,7 @@ pub enum StepsError {
 impl StepsError {
     pub fn code(&self) -> &'static str {
         match self {
-            Self::UnknownTask(_) => "unknown-task",
+            Self::UnknownTask => "unknown-task",
             Self::SoftDeletedTask(_) => "soft-deleted-task",
             Self::EmptyStepText => "empty-step-text",
             Self::InvalidStepText => "invalid-step-text",
@@ -61,14 +62,21 @@ pub enum StepsResult {
 /// Refusals are resolved at the boundary under the store lock and never reach
 /// the durable write, so a refused steps command persists nothing.
 pub fn run(
-    task_id: Uuid,
+    task_address: TaskAddress,
     action: StepsAction,
     state_dir: Option<PathBuf>,
 ) -> Result<StepsResult, StepsError> {
     let store = TaskStore::new(state_dir.unwrap_or_else(default_state_dir));
     store
         .locked_transition_if_changed(|domain| {
-            let outcome = apply(domain, task_id, &action);
+            let task_id = domain
+                .tasks()
+                .iter()
+                .find(|task| task_address.matches(task))
+                .map(|task| task.id);
+            let outcome = task_id.map_or(Err(StepsError::UnknownTask), |task_id| {
+                apply(domain, task_id, &action)
+            });
             let changed = outcome.is_ok();
             Ok((outcome, changed))
         })
@@ -82,7 +90,7 @@ fn apply(
 ) -> Result<StepsResult, StepsError> {
     // A deleted task's steps are not scriptable (park/link discipline, not edit's).
     match domain.get(task_id) {
-        None => return Err(StepsError::UnknownTask(task_id)),
+        None => return Err(StepsError::UnknownTask),
         Some(task) if task.soft_deleted => return Err(StepsError::SoftDeletedTask(task_id)),
         _ => {}
     }
@@ -136,7 +144,7 @@ fn apply(
 /// Domain commands re-check what the boundary already validated; mirror the twins.
 fn map_domain_error(error: DomainError) -> StepsError {
     match error {
-        DomainError::UnknownId(id) => StepsError::UnknownTask(id),
+        DomainError::UnknownId(_) => StepsError::UnknownTask,
         DomainError::EmptyStepText => StepsError::EmptyStepText,
         DomainError::UnknownStep(_) => StepsError::UnknownStep,
         other => StepsError::Store(other.to_string()),

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -125,6 +125,9 @@ pub struct Step {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Task {
     pub id: Uuid,
+    /// Store-global human task number. Absent until the locked persistence boundary assigns it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub number: Option<u64>,
     /// Opaque semantic revision used to guard concurrent operations. Legacy tasks
     /// decode without one and receive a revision on their next mutation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -228,7 +231,7 @@ fn record_mutation(task: &mut Task, kind: TaskEventKind) {
 
 /// Document version written by this binary.
 /// Bump when an older writer cannot round-trip a newly persisted field.
-pub const STORE_FORMAT_VERSION: u32 = 1;
+pub const STORE_FORMAT_VERSION: u32 = 2;
 
 /// Version of documents written before `format_version` existed.
 /// Stay on 1 when [`STORE_FORMAT_VERSION`] is bumped.
@@ -236,6 +239,10 @@ pub const LEGACY_STORE_FORMAT_VERSION: u32 = 1;
 
 fn default_store_format_version() -> u32 {
     LEGACY_STORE_FORMAT_VERSION
+}
+
+fn default_next_task_number() -> u64 {
+    1
 }
 
 /// In-memory task set. Persistence is Task Store.
@@ -246,6 +253,9 @@ pub struct DomainState {
     /// Store document version. Missing on older files loads as [`LEGACY_STORE_FORMAT_VERSION`].
     #[serde(default = "default_store_format_version")]
     format_version: u32,
+    /// The next store-global task number, allocated only while holding the store lock.
+    #[serde(default = "default_next_task_number")]
+    pub next_task_number: u64,
     tasks: Vec<Task>,
     /// Active recovery records sharing the task store's lock and atomic replacement boundary.
     #[serde(default)]
@@ -264,6 +274,7 @@ impl DomainState {
     pub fn new() -> Self {
         Self {
             format_version: STORE_FORMAT_VERSION,
+            next_task_number: 1,
             tasks: Vec::new(),
             active_attempts: Vec::new(),
             undo_stack: Vec::new(),
@@ -426,6 +437,7 @@ impl DomainState {
         let agent_meta = agent_meta.filter(|m| !m.is_empty());
         self.tasks.push(Task {
             id,
+            number: None,
             revision: Some(Uuid::new_v4()),
             merge_base_revision: None,
             title: title.to_string(),
@@ -653,9 +665,46 @@ impl DomainState {
                 return Err(format!("task {} changed during save", local.id));
             }
         }
+        self.next_task_number = self.next_task_number.max(disk.next_task_number);
         self.merge_undo_entries(disk);
         self.merge_attempts_for_save(disk);
         Ok(())
+    }
+
+    /// Assign missing task numbers in deterministic creation order. The store calls this only
+    /// under its exclusive lock, immediately before the durable replacement.
+    pub(crate) fn assign_numbers_for_persistence(&mut self) {
+        let next_after_existing = self
+            .tasks
+            .iter()
+            .filter_map(|task| task.number)
+            .max()
+            .and_then(|number| number.checked_add(1))
+            .unwrap_or(1);
+        self.next_task_number = self.next_task_number.max(next_after_existing);
+        let mut missing: Vec<usize> = self
+            .tasks
+            .iter()
+            .enumerate()
+            .filter_map(|(index, task)| task.number.is_none().then_some(index))
+            .collect();
+        missing.sort_by_key(|&index| (self.tasks[index].created_at, self.tasks[index].id));
+        for index in missing {
+            self.tasks[index].number = Some(self.next_task_number);
+            self.next_task_number = self
+                .next_task_number
+                .checked_add(1)
+                .expect("task number exhausted");
+        }
+    }
+
+    pub(crate) fn sync_numbers_from_persisted(&mut self, persisted: &DomainState) {
+        self.next_task_number = persisted.next_task_number;
+        for task in &mut self.tasks {
+            task.number = persisted
+                .get(task.id)
+                .and_then(|persisted_task| persisted_task.number);
+        }
     }
 
     pub(crate) fn clear_merge_bases(&mut self) {
@@ -1203,6 +1252,80 @@ mod tests {
             2,
             "no journal writes for refused commands"
         );
+    }
+
+    #[test]
+    fn locked_create_assigns_number_one_then_two() {
+        let dir = std::env::temp_dir().join(format!("tsk-number-domain-{}", Uuid::new_v4()));
+        let store = crate::store::TaskStore::new(&dir);
+        let first = store
+            .locked_transition(|state| {
+                state
+                    .create(
+                        "first",
+                        None,
+                        TaskScope::Global,
+                        None,
+                        None,
+                        ProvenanceOrigin::Manual,
+                    )
+                    .map_err(|error| error.to_string())
+            })
+            .expect("persist first");
+        let second = store
+            .locked_transition(|state| {
+                state
+                    .create(
+                        "second",
+                        None,
+                        TaskScope::Global,
+                        None,
+                        None,
+                        ProvenanceOrigin::Manual,
+                    )
+                    .map_err(|error| error.to_string())
+            })
+            .expect("persist second");
+        let state = store.load().expect("load");
+        assert_eq!(state.get(first).and_then(|task| task.number), Some(1));
+        assert_eq!(state.get(second).and_then(|task| task.number), Some(2));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn edit_status_scope_thread_complete_soft_delete_leave_number_unchanged() {
+        let mut state = DomainState::new();
+        let id = create_sample(&mut state);
+        state.assign_numbers_for_persistence();
+        let number = state.get(id).and_then(|task| task.number);
+        state
+            .edit(
+                id,
+                "edited",
+                None,
+                TaskScope::Project {
+                    path: "/project".into(),
+                },
+                Some("thread".into()),
+            )
+            .expect("edit");
+        state.set_status(id, HumanStatus::Started).expect("status");
+        state.complete(id).expect("complete");
+        state.soft_delete(id).expect("delete");
+        assert_eq!(state.get(id).and_then(|task| task.number), number);
+    }
+
+    #[test]
+    fn undo_of_complete_and_of_soft_delete_keeps_the_same_number() {
+        let mut state = DomainState::new();
+        let id = create_sample(&mut state);
+        state.assign_numbers_for_persistence();
+        let number = state.get(id).and_then(|task| task.number);
+        state.complete(id).expect("complete");
+        state.undo().expect("undo complete");
+        state.soft_delete(id).expect("delete");
+        state.undo().expect("undo delete");
+        assert_eq!(state.get(id).and_then(|task| task.number), number);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -113,7 +113,7 @@ impl TaskStore {
     /// Load domain state. Missing file yields an empty state (first run).
     pub fn load(&self) -> Result<DomainState, StoreError> {
         let _guard = self.lock_exclusive()?;
-        self.load_unlocked()
+        self.load_and_upgrade_unlocked()
     }
 
     /// Persist domain state with atomic write (unique temp in same dir + rename).
@@ -123,6 +123,7 @@ impl TaskStore {
     pub fn save(&self, state: &DomainState) -> Result<(), StoreError> {
         let _guard = self.lock_exclusive()?;
         let mut durable = state.clone();
+        durable.assign_numbers_for_persistence();
         durable.clear_merge_bases();
         durable.stamp_format_version();
         self.save_unlocked(&durable)
@@ -134,8 +135,11 @@ impl TaskStore {
         transition: impl FnOnce(&mut DomainState) -> Result<T, String>,
     ) -> Result<T, String> {
         let _guard = self.lock_exclusive().map_err(|error| error.to_string())?;
-        let mut state = self.load_unlocked().map_err(|error| error.to_string())?;
+        let mut state = self
+            .load_and_upgrade_unlocked()
+            .map_err(|error| error.to_string())?;
         let result = transition(&mut state)?;
+        state.assign_numbers_for_persistence();
         state.clear_merge_bases();
         state.stamp_format_version();
         self.save_unlocked(&state)
@@ -152,9 +156,12 @@ impl TaskStore {
         transition: impl FnOnce(&mut DomainState) -> Result<(T, bool), String>,
     ) -> Result<T, String> {
         let _guard = self.lock_exclusive().map_err(|error| error.to_string())?;
-        let mut state = self.load_unlocked().map_err(|error| error.to_string())?;
+        let mut state = self
+            .load_and_upgrade_unlocked()
+            .map_err(|error| error.to_string())?;
         let (result, changed) = transition(&mut state)?;
         if changed {
+            state.assign_numbers_for_persistence();
             state.clear_merge_bases();
             state.stamp_format_version();
             self.save_unlocked(&state)
@@ -180,17 +187,29 @@ impl TaskStore {
         filesystem: &F,
     ) -> Result<(), StoreError> {
         let _guard = self.lock_exclusive()?;
-        let disk = self.load_unlocked()?;
+        let disk = self.load_and_upgrade_unlocked()?;
         check_format_version(disk.format_version())?;
         local
             .merge_for_save(&disk)
             .map_err(|message| StoreError::Io(io::Error::other(message)))?;
         let mut durable = local.clone();
+        durable.assign_numbers_for_persistence();
         durable.clear_merge_bases();
         durable.stamp_format_version();
         self.save_unlocked_with(&durable, filesystem)?;
+        local.sync_numbers_from_persisted(&durable);
         local.clear_merge_bases();
         Ok(())
+    }
+
+    fn load_and_upgrade_unlocked(&self) -> Result<DomainState, StoreError> {
+        let mut state = self.load_unlocked()?;
+        if state.format_version() < STORE_FORMAT_VERSION {
+            state.assign_numbers_for_persistence();
+            state.stamp_format_version();
+            self.save_unlocked(&state)?;
+        }
+        Ok(state)
     }
 
     fn load_unlocked(&self) -> Result<DomainState, StoreError> {
@@ -882,7 +901,7 @@ mod tests {
     }
 
     #[test]
-    fn save_stamps_format_version_one() {
+    fn save_stamps_format_version_two() {
         let dir = temp_dir("format-stamp");
         let _guard = TempDirGuard(dir.clone());
         let store = TaskStore::new(&dir);
@@ -891,7 +910,7 @@ mod tests {
         let value: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(dir.join(STATE_FILE)).expect("read"))
                 .expect("json");
-        assert_eq!(value["format_version"], 1);
+        assert_eq!(value["format_version"], 2);
     }
 
     #[test]
@@ -907,7 +926,7 @@ mod tests {
         );
 
         let loaded = TaskStore::new(&dir).load().expect("legacy store must load");
-        assert_eq!(loaded.format_version(), 1);
+        assert_eq!(loaded.format_version(), 2);
         assert!(loaded.tasks().is_empty());
     }
 
@@ -916,7 +935,7 @@ mod tests {
         let dir = temp_dir("format-load-newer");
         let _guard = TempDirGuard(dir.clone());
         let newer = serde_json::json!({
-            "format_version": 2,
+            "format_version": 3,
             "tasks": [],
             "undo_stack": []
         });
@@ -929,8 +948,8 @@ mod tests {
             matches!(
                 error,
                 StoreError::UnsupportedFormat {
-                    found: 2,
-                    supported: 1
+                    found: 3,
+                    supported: 2
                 }
             ),
             "{error}"
@@ -946,7 +965,7 @@ mod tests {
         let dir = temp_dir("format-save-newer");
         let _guard = TempDirGuard(dir.clone());
         let newer = serde_json::json!({
-            "format_version": 2,
+            "format_version": 3,
             "tasks": [],
             "undo_stack": []
         });
@@ -959,8 +978,8 @@ mod tests {
             matches!(
                 error,
                 StoreError::UnsupportedFormat {
-                    found: 2,
-                    supported: 1
+                    found: 3,
+                    supported: 2
                 }
             ),
             "{error}"

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -366,7 +366,14 @@ fn build_task_page_overlay<'a>(
         TaskScope::Global => "desk".to_string(),
     };
     let meta_scope_width = u16::try_from(render::display_width(&meta_scope)).unwrap_or(u16::MAX);
-    let mut meta = meta_scope.clone();
+    let mut meta = String::new();
+    let mut meta_scope_x = 0;
+    if let Some(number) = bound_task.and_then(|task| task.number) {
+        meta.push_str(&number.to_string());
+        meta.push_str(" · ");
+        meta_scope_x = u16::try_from(render::display_width(&meta)).unwrap_or(u16::MAX);
+    }
+    meta.push_str(&meta_scope);
     let mut thread_slot = None;
     if let Some(task) = bound_task {
         thread_slot = if let Some(thread) = task.thread.as_deref() {
@@ -421,6 +428,7 @@ fn build_task_page_overlay<'a>(
         step_marked: form.steps.delete_mark,
         step_editor,
         meta,
+        meta_scope_x,
         meta_scope_width,
         thread_slot_width,
         focus,

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -595,6 +595,7 @@ mod tests {
         let at = SystemTime::UNIX_EPOCH + Duration::from_secs(updated_secs);
         Task {
             id: Uuid::from_u128(id),
+            number: None,
             revision: Some(Uuid::from_u128(id)),
             merge_base_revision: None,
             title: format!("task-{id}"),

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -103,7 +103,8 @@ pub fn style_reverse_bold() -> Style {
 pub struct TaskRowPaint<'a> {
     pub glyph: &'a str,
     pub title: &'a str,
-    /// Trailing meta (age / project). Ignored when geometry reserves no meta column.
+    /// Trailing meta (number / age / project). At compact widths a bare number still reserves
+    /// its own small trailing run so it remains visible while the title wraps.
     pub meta: &'a str,
     pub selected: bool,
     /// Bold the title when unselected (e.g. attention emphasis).
@@ -131,12 +132,8 @@ pub fn paint_task_row_lines(
     // The title room `paint_task_row_with_indent` derives must match here, so both
     // share one computation of the prefix cells.
     let row_w = geo.row_width as usize;
-    let meta_budget = geo.meta_column_width as usize;
-    let title_budget = if meta_budget == 0 {
-        row_w
-    } else {
-        geo.title_width as usize
-    };
+    let meta_budget = task_meta_budget(row, geo);
+    let title_budget = row_w.saturating_sub(meta_budget);
     let glyph_cells = display_width(&super::terminal_text(row.glyph));
     let prefix_cells = leading_indent + 2 + glyph_cells + 1;
     let room = title_budget.saturating_sub(prefix_cells).max(1);
@@ -197,12 +194,8 @@ fn paint_task_row_with_indent(
     leading_indent: usize,
 ) -> Line<'static> {
     let row_w = geo.row_width as usize;
-    let meta_budget = geo.meta_column_width as usize;
-    let title_budget = if meta_budget == 0 {
-        row_w
-    } else {
-        geo.title_width as usize
-    };
+    let meta_budget = task_meta_budget(row, geo);
+    let title_budget = row_w.saturating_sub(meta_budget);
 
     let glyph = super::terminal_text(row.glyph);
     let prefix = format!("{}  {glyph} ", " ".repeat(leading_indent));
@@ -261,6 +254,21 @@ fn paint_task_row_with_indent(
     }
 
     bound_line(Line::from(spans), row_w)
+}
+
+/// Compact rows normally omit their age/project run, but a persisted task's bare number is
+/// still board chrome at the 40×10 floor. Reserve only that number plus the usual margin.
+fn task_meta_budget(row: &TaskRowPaint<'_>, geo: &TierGeometry) -> usize {
+    let standard = geo.meta_column_width as usize;
+    if standard > 0 {
+        standard
+    } else if !row.meta.is_empty() && row.meta.bytes().all(|byte| byte.is_ascii_digit()) {
+        display_width(row.meta)
+            .saturating_add(1)
+            .min(geo.row_width as usize)
+    } else {
+        0
+    }
 }
 
 /// Present untrusted text into a single mono-styled line bounded to `width` cells.
@@ -446,8 +454,10 @@ pub enum QueueOverlay<'a> {
         /// The page's add/rename step draft. When present it uses the shared
         /// bottom input slot, leaving the meta footer visible in the page above.
         step_editor: Option<BottomInputSlot<'a>>,
-        /// Footer: scope · thread · created · updated.
+        /// Footer: task number · scope · thread · created · updated.
         meta: String,
+        /// Display width before the scope inside `meta`. The number is chrome, not a scope hit.
+        meta_scope_x: u16,
         /// Display width of scope inside `meta`, carried separately so mouse geometry never
         /// parses user-controlled project names from rendered text.
         meta_scope_width: u16,
@@ -1133,6 +1143,7 @@ fn paint_overlay(
             step_marked,
             ref step_editor,
             ref meta,
+            meta_scope_x,
             meta_scope_width,
             thread_slot_width,
             focus,
@@ -1152,6 +1163,7 @@ fn paint_overlay(
                 *step_scroll,
                 *step_marked,
                 meta,
+                *meta_scope_x,
                 *meta_scope_width,
                 *thread_slot_width,
                 *focus,
@@ -1871,6 +1883,7 @@ fn paint_task_page(
     step_scroll: usize,
     step_marked: Option<usize>,
     meta: &str,
+    meta_scope_x: u16,
     meta_scope_width: u16,
     thread_slot_width: Option<u16>,
     focus: Option<CaptureField>,
@@ -2125,11 +2138,20 @@ fn paint_task_page(
             paint_bounded_line(&format!("  {meta}"), width, style_dim()),
         );
 
-        let thread_x = 2u16.saturating_add(meta_scope_width).min(width);
+        let scope_x = 2u16.saturating_add(meta_scope_x).min(width);
+        let thread_x = scope_x.saturating_add(meta_scope_width).min(width);
         if footer_input_open {
             return;
         }
-        hits.push(QueueHitTarget::FormScope, Rect::new(0, y, thread_x, 1));
+        hits.push(
+            QueueHitTarget::FormScope,
+            Rect::new(
+                scope_x,
+                y,
+                meta_scope_width.min(width.saturating_sub(scope_x)),
+                1,
+            ),
+        );
         if let Some(thread_slot_width) = thread_slot_width.filter(|_| thread_x < width) {
             let thread_width = thread_slot_width.min(width.saturating_sub(thread_x));
             hits.push(
@@ -2535,6 +2557,10 @@ fn detail_lines_for_task(
         format_age(now, task.created_at),
         format_age(now, task.updated_at)
     );
+    let age_text = task
+        .number
+        .map(|number| format!("{number} · {age_text}"))
+        .unwrap_or(age_text);
     push(
         &mut lines,
         paint_bounded_line(&format!("{indent}scope {scope_text}"), width, style_dim()),
@@ -2577,7 +2603,13 @@ fn build_list_rows(
             // Stale ids may outlive a snapshot refresh. Skip them without inventing a row.
             return;
         };
-        let meta = row_meta(task, model.now, in_project_section);
+        let meta = if geo.meta_column_width == 0 {
+            task.number
+                .map(|number| number.to_string())
+                .unwrap_or_default()
+        } else {
+            row_meta(task, model.now, in_project_section)
+        };
         let selected = model.selection_id == Some(task.id)
             && !matches!(model.overlay, QueueOverlay::ScopeDropdown { .. });
         // A long title wraps onto continuation lines indented under its own first
@@ -3212,13 +3244,18 @@ fn paint_verb_bar(
 
 fn row_meta(task: &Task, now: SystemTime, in_project_section: bool) -> String {
     let age = format_age(now, task.updated_at);
-    if in_project_section {
-        return age;
+    let mut parts = task
+        .number
+        .map(|number| number.to_string())
+        .into_iter()
+        .collect::<Vec<_>>();
+    if !in_project_section {
+        if let TaskScope::Project { path } = &task.scope {
+            parts.push(short_project(path).to_string());
+        }
     }
-    match &task.scope {
-        TaskScope::Project { path } => format!("{} · {age}", short_project(path)),
-        TaskScope::Global => age,
-    }
+    parts.push(age);
+    parts.join(" · ")
 }
 
 pub(crate) fn format_age(now: SystemTime, then: SystemTime) -> String {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -3244,18 +3244,43 @@ fn paint_verb_bar(
 
 fn row_meta(task: &Task, now: SystemTime, in_project_section: bool) -> String {
     let age = format_age(now, task.updated_at);
-    let mut parts = task
-        .number
-        .map(|number| number.to_string())
-        .into_iter()
-        .collect::<Vec<_>>();
-    if !in_project_section {
-        if let TaskScope::Project { path } = &task.scope {
-            parts.push(short_project(path).to_string());
+    let number = task.number.map(|number| number.to_string());
+    let project = if !in_project_section {
+        match &task.scope {
+            TaskScope::Project { path } => Some(short_project(path).to_string()),
+            TaskScope::Global => None,
         }
+    } else {
+        None
+    };
+    fit_row_meta(number, project, age)
+}
+
+/// Keep number and age intact; shrink the project basename so the standard
+/// meta column (28 cells including the trailing margin) does not clip age.
+fn fit_row_meta(number: Option<String>, project: Option<String>, age: String) -> String {
+    const CONTENT: usize = 27;
+    const SEP: &str = " · ";
+    let sep_w = display_width(SEP);
+    let mut reserved = display_width(&age);
+    if let Some(n) = number.as_deref() {
+        reserved = reserved
+            .saturating_add(display_width(n))
+            .saturating_add(sep_w);
+    }
+    let project = project.and_then(|name| {
+        let room = CONTENT.saturating_sub(reserved.saturating_add(sep_w));
+        (room > 0).then(|| present_line(&name, room))
+    });
+    let mut parts = Vec::new();
+    if let Some(n) = number {
+        parts.push(n);
+    }
+    if let Some(p) = project {
+        parts.push(p);
     }
     parts.push(age);
-    parts.join(" · ")
+    parts.join(SEP)
 }
 
 pub(crate) fn format_age(now: SystemTime, then: SystemTime) -> String {

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -1015,7 +1015,7 @@ fn plan_with_only_existing_tasks_is_a_successful_read_only_noop() {
     assert!(result["created"].as_array().expect("created").is_empty());
     assert_eq!(
         result["existing"],
-        serde_json::json!([{"i":0,"id":id,"title":"same task"}])
+        serde_json::json!([{"i":0,"id":id,"number":1,"title":"same task"}])
     );
     assert!(result["failed"].as_array().expect("failed").is_empty());
     assert_eq!(
@@ -1073,7 +1073,7 @@ fn mixed_plan_exit_1_preserves_created_and_existing_rows_for_failed_only_retry()
     assert_eq!(result["created"][0]["i"], 0);
     assert_eq!(
         result["existing"],
-        serde_json::json!([{"i":1,"id":existing_id,"title":"already exists"}])
+        serde_json::json!([{"i":1,"id":existing_id,"number":1,"title":"already exists"}])
     );
     assert_eq!(result["failed"].as_array().expect("failed").len(), 1);
     assert_eq!(result["failed"][0]["i"], 2);
@@ -1652,7 +1652,7 @@ fn flag_add_json_reports_created_and_existing_resolved_tasks() {
     assert_eq!(created["title"], "json task");
     assert_eq!(created["project"], "/projects/json");
     let id = created["id"].as_str().expect("created id").to_owned();
-    assert_eq!(created.as_object().expect("created object").len(), 4);
+    assert_eq!(created.as_object().expect("created object").len(), 5);
 
     let existing = add(&args, true);
     assert_eq!(existing.code, 0);
@@ -1663,7 +1663,7 @@ fn flag_add_json_reports_created_and_existing_resolved_tasks() {
     assert_eq!(existing["id"], id);
     assert_eq!(existing["title"], "json task");
     assert_eq!(existing["project"], "/projects/json");
-    assert_eq!(existing.as_object().expect("existing object").len(), 4);
+    assert_eq!(existing.as_object().expect("existing object").len(), 5);
 
     let global = add(
         &[
@@ -1682,6 +1682,118 @@ fn flag_add_json_reports_created_and_existing_resolved_tasks() {
     let global: serde_json::Value = serde_json::from_str(&global.stdout).expect("global JSON");
     assert_eq!(global["outcome"], "created");
     assert!(global["project"].is_null());
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn json_created_and_existing_include_number() {
+    let _env = env_lock();
+    let dir = temp_state_dir("json-number");
+    let args = [
+        "tsk".into(),
+        "add".into(),
+        "--json".into(),
+        "--desk".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+        "--title".into(),
+        "numbered task".into(),
+    ];
+
+    let created = add(&args, true);
+    assert_eq!(created.code, 0, "{}", created.stderr);
+    let created: serde_json::Value = serde_json::from_str(&created.stdout).expect("created JSON");
+    assert_eq!(created["outcome"], "created");
+    assert_eq!(created["number"], 1);
+
+    let existing = add(&args, true);
+    assert_eq!(existing.code, 0, "{}", existing.stderr);
+    let existing: serde_json::Value =
+        serde_json::from_str(&existing.stdout).expect("existing JSON");
+    assert_eq!(existing["outcome"], "existing");
+    assert_eq!(existing["number"], 1);
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn plan_created_and_existing_include_number() {
+    let _env = env_lock();
+    let dir = temp_state_dir("plan-number");
+    let run_plan = || {
+        run_with(
+            [
+                "tsk",
+                "add",
+                "--state-dir",
+                &state_dir_arg(&dir),
+                "--file",
+                "-",
+            ],
+            Cursor::new(r#"[{"title":"numbered plan task","project":null}]"#),
+            true,
+        )
+    };
+
+    let created = run_plan();
+    assert_eq!(created.code, 0, "{}", created.stderr);
+    let created: serde_json::Value = serde_json::from_str(&created.stdout).expect("created plan");
+    assert_eq!(created["created"][0]["number"], 1);
+
+    let existing = run_plan();
+    assert_eq!(existing.code, 0, "{}", existing.stderr);
+    let existing: serde_json::Value =
+        serde_json::from_str(&existing.stdout).expect("existing plan");
+    assert_eq!(existing["existing"][0]["number"], 1);
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn existing_add_does_not_advance_the_counter() {
+    let _env = env_lock();
+    let dir = temp_state_dir("existing-number-counter");
+    let existing = || {
+        add(
+            &[
+                "tsk".into(),
+                "add".into(),
+                "--desk".into(),
+                "--state-dir".into(),
+                state_dir_arg(&dir),
+                "--title".into(),
+                "first task".into(),
+            ],
+            true,
+        )
+    };
+    assert_eq!(existing().code, 0);
+    assert_eq!(existing().code, 0);
+
+    let next = add(
+        &[
+            "tsk".into(),
+            "add".into(),
+            "--json".into(),
+            "--desk".into(),
+            "--state-dir".into(),
+            state_dir_arg(&dir),
+            "--title".into(),
+            "second task".into(),
+        ],
+        true,
+    );
+    assert_eq!(next.code, 0, "{}", next.stderr);
+    let next: serde_json::Value = serde_json::from_str(&next.stdout).expect("next JSON");
+    assert_eq!(next["number"], 2);
+    assert_eq!(
+        task_store(&dir)
+            .load()
+            .expect("load state")
+            .next_task_number,
+        3
+    );
 
     let _ = std::fs::remove_dir_all(dir);
 }

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -187,7 +187,7 @@ fn list_defaults_to_invocation_project_open_tasks_in_human_and_json_group_order(
     assert!(human.stderr.is_empty());
     assert_eq!(
         human.stdout,
-        "STARTED\n - started target\n\nREADY\n - ready target\n\nBLOCKED\n - blocked target\n\nREVIEW\n - review target\n"
+        "STARTED\n - 3 started target\n\nREADY\n - 2 ready target\n\nBLOCKED\n - 4 blocked target\n\nREVIEW\n - 1 review target\n"
     );
 
     let json = list(&[
@@ -333,7 +333,7 @@ fn list_done_and_deleted_filters_are_status_and_soft_delete_specific() {
         state_dir_arg(&dir),
     ]);
     assert_eq!(done.code, 0);
-    assert_eq!(done.stdout, "DONE\n - done visible\n");
+    assert_eq!(done.stdout, "DONE\n - 1 done visible\n");
 
     let deleted = list(&[
         "tsk".into(),
@@ -366,7 +366,7 @@ fn list_done_and_deleted_filters_are_status_and_soft_delete_specific() {
     assert_eq!(deleted_human.code, 0);
     assert_eq!(
         deleted_human.stdout,
-        "DELETED\n - deleted ready\n - deleted done\n"
+        "DELETED\n - 2 deleted ready\n - 3 deleted done\n"
     );
 
     let _ = std::fs::remove_dir_all(repo);
@@ -475,7 +475,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
     assert_eq!(
         open.stdout,
         format!(
-            "STARTED\n  desk\n    - global started\n  {project_name}\n    - project started\n  other\n    - other started\n\nREADY\n  {project_name}\n    - project ready\n\nBLOCKED\n  other\n    - other blocked\n\nREVIEW\n  desk\n    - global review\n"
+            "STARTED\n  desk\n    - 1 global started\n  {project_name}\n    - 2 project started\n  other\n    - 3 other started\n\nREADY\n  {project_name}\n    - 4 project ready\n\nBLOCKED\n  other\n    - 5 other blocked\n\nREVIEW\n  desk\n    - 6 global review\n"
         )
     );
 
@@ -529,7 +529,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
                 .keys()
                 .map(String::as_str)
                 .collect::<Vec<_>>(),
-            vec!["id", "project", "status", "thread", "title"]
+            vec!["id", "number", "project", "status", "thread", "title"]
         );
     }
     let done_human = list(&[
@@ -542,7 +542,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
     ]);
     assert_eq!(
         done_human.stdout,
-        format!("DONE\n  {project_name}\n    - project done\n  desk\n    - global done\n")
+        format!("DONE\n  {project_name}\n    - 7 project done\n  desk\n    - 8 global done\n")
     );
 
     let deleted = list(&[
@@ -574,7 +574,7 @@ fn list_all_groups_each_status_by_concise_scope_for_every_filter() {
     ]);
     assert_eq!(
         deleted_human.stdout,
-        "DELETED\n  desk\n    - global deleted\n  other\n    - other deleted\n"
+        "DELETED\n  desk\n    - 9 global deleted\n  other\n    - 10 other deleted\n"
     );
 
     let _ = std::fs::remove_dir_all(repo);
@@ -645,7 +645,7 @@ fn list_all_distinguishes_global_from_project_global_and_uses_visible_scope_labe
     assert_eq!(output.code, 0);
     assert_eq!(
         output.stdout,
-        "READY\n  desk\n    - global task\n  project: global\n    - project global token\n  work/global\n    - project global path\n  work/api\n    - work api\n  personal/api\n    - personal api\n  project: <empty project 1>\n    - whitespace scope\n"
+        "READY\n  desk\n    - 1 global task\n  project: global\n    - 2 project global token\n  work/global\n    - 3 project global path\n  work/api\n    - 4 work api\n  personal/api\n    - 5 personal api\n  project: <empty project 1>\n    - 6 whitespace scope\n"
     );
 
     let _ = std::fs::remove_dir_all(dir);
@@ -706,7 +706,7 @@ fn list_all_uses_shortest_unique_trailing_scope_labels_across_statuses() {
     assert_eq!(output.code, 0);
     assert_eq!(
         output.stdout,
-        "STARTED\n  global\n    - project global\n  work/api\n    - work api\n\nREADY\n  desk\n    - global\n  project: <empty project 1>\n    - blank one\n\nBLOCKED\n  personal/api\n    - personal api\n\nREVIEW\n  project: <empty project 2>\n    - blank two\n"
+        "STARTED\n  global\n    - 1 project global\n  work/api\n    - 2 work api\n\nREADY\n  desk\n    - 3 global\n  project: <empty project 1>\n    - 4 blank one\n\nBLOCKED\n  personal/api\n    - 5 personal api\n\nREVIEW\n  project: <empty project 2>\n    - 6 blank two\n"
     );
 
     let _ = std::fs::remove_dir_all(dir);
@@ -743,7 +743,7 @@ fn list_all_preserves_raw_scope_syntax_after_trailing_segments_are_exhausted() {
     assert_eq!(output.code, 0);
     assert_eq!(
         output.stdout,
-        "READY\n  project: \"/work/api\"\n    - absolute api\n  project: \"work/api\"\n    - relative api\n  project: \"/work/api/\"\n    - trailing api\n  project: \"//work//api\"\n    - repeated api\n"
+        "READY\n  project: \"/work/api\"\n    - 1 absolute api\n  project: \"work/api\"\n    - 2 relative api\n  project: \"/work/api/\"\n    - 3 trailing api\n  project: \"//work//api\"\n    - 4 repeated api\n"
     );
     assert!(
         !output.stdout.contains("(scope "),
@@ -1074,6 +1074,7 @@ fn list_equals_project_form_accepts_dash_leading_scope() {
         serde_json::from_str::<Vec<serde_json::Value>>(&output.stdout).expect("JSON rows"),
         vec![serde_json::json!({
             "id": state.tasks()[0].id,
+            "number": 1,
             "title": "maintenance task",
             "status": "ready",
             "project": "-maintenance",
@@ -1237,7 +1238,7 @@ fn list_task_prints_step_lines_with_state_and_short_id() {
     assert!(output.stderr.is_empty());
     assert_eq!(
         output.stdout,
-        format!("READY\n - steps target\n   [x] aaa1 First step\n   [ ] aaa2 Second step\n"),
+        format!("READY\n - 1 steps target\n   [x] aaa1 First step\n   [ ] aaa2 Second step\n"),
         "one line per step with state and unambiguous short id"
     );
     assert!(
@@ -1256,7 +1257,7 @@ fn list_task_prints_step_lines_with_state_and_short_id() {
     assert_eq!(json.code, 0);
     let rows: Vec<serde_json::Value> = serde_json::from_str(&json.stdout).expect("JSON rows");
     assert_eq!(rows.len(), 1);
-    for key in ["id", "project", "status", "thread", "title"] {
+    for key in ["id", "number", "project", "status", "thread", "title"] {
         assert!(rows[0].get(key).is_some(), "single-task row keeps {key}");
     }
     assert_eq!(
@@ -1302,7 +1303,7 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
         state_dir_arg(&dir),
     ]);
     assert_eq!(plain.code, 0);
-    assert_eq!(plain.stdout, "READY\n - plain target\n");
+    assert_eq!(plain.stdout, "READY\n - 1 plain target\n");
 
     let plain_json = list(&[
         "tsk".into(),
@@ -1322,7 +1323,7 @@ fn list_task_without_steps_keeps_task_rows_and_rejects_conflicting_flags() {
             .keys()
             .map(String::as_str)
             .collect::<Vec<_>>(),
-        vec!["id", "project", "status", "thread", "title"],
+        vec!["id", "number", "project", "status", "thread", "title"],
         "a task without steps keeps today's exact JSON row shape"
     );
 
@@ -1482,6 +1483,65 @@ fn json_rows_always_carry_thread_field() {
 }
 
 #[test]
+fn json_list_rows_include_number() {
+    let _env = env_lock();
+    let dir = temp_state_dir("json-number");
+    let mut state = DomainState::new();
+    create_task(
+        &mut state,
+        "numbered task",
+        TaskScope::Global,
+        HumanStatus::Ready,
+    );
+    TaskStore::new(&dir).save(&state).expect("seed store");
+
+    let output = list(&[
+        "tsk".into(),
+        "list".into(),
+        "--desk".into(),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&output.stdout).expect("JSON rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["number"], 1);
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn human_list_rows_show_bare_digits() {
+    let _env = env_lock();
+    let dir = temp_state_dir("human-number");
+    let mut state = DomainState::new();
+    create_task(
+        &mut state,
+        "numbered task",
+        TaskScope::Global,
+        HumanStatus::Ready,
+    );
+    TaskStore::new(&dir).save(&state).expect("seed store");
+
+    let output = list(&[
+        "tsk".into(),
+        "list".into(),
+        "--desk".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    assert_eq!(output.stdout, "READY\n - 1 numbered task\n");
+    assert!(!output.stdout.contains("#1"));
+    assert!(!output.stdout.contains("T1"));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
     let _env = env_lock();
     let repo = project_repo("thread-human");
@@ -1534,7 +1594,7 @@ fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
     ]);
     assert_eq!(
         scoped.stdout,
-        "READY\n - scoped threaded #alpha\n - scoped unthreaded\n"
+        "READY\n - 1 scoped threaded #alpha\n - 2 scoped unthreaded\n"
     );
 
     let all = list(&[
@@ -1547,7 +1607,7 @@ fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
     assert_eq!(
         all.stdout,
         format!(
-            "READY\n  {project_name}\n    - scoped threaded #alpha\n    - scoped unthreaded\n  desk\n    - global threaded #ops\n"
+            "READY\n  {project_name}\n    - 1 scoped threaded #alpha\n    - 2 scoped unthreaded\n  desk\n    - 3 global threaded #ops\n"
         )
     );
 
@@ -1560,7 +1620,7 @@ fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
     ]);
     assert_eq!(
         single.stdout,
-        format!("DONE\n - step threaded #steps\n   [ ] {step_short_id} Keep this line\n")
+        format!("DONE\n - 4 step threaded #steps\n   [ ] {step_short_id} Keep this line\n")
     );
 
     let _ = std::fs::remove_dir_all(repo);

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -1542,6 +1542,184 @@ fn human_list_rows_show_bare_digits() {
 }
 
 #[test]
+fn list_bare_digits_finds_the_task_from_another_cwd() {
+    let _env = env_lock();
+    let invocation_repo = project_repo("number-invocation");
+    let _context = EnvironmentGuard::context_for(&invocation_repo);
+    let dir = temp_state_dir("number-other-cwd");
+    let mut state = DomainState::new();
+    let task = create_task_with_thread(
+        &mut state,
+        "other project task",
+        TaskScope::Project {
+            path: "/projects/other".into(),
+        },
+        HumanStatus::Ready,
+        None,
+    );
+    TaskStore::new(&dir).save(&state).expect("seed store");
+    let number = TaskStore::new(&dir)
+        .load()
+        .expect("load store")
+        .get(task)
+        .expect("task")
+        .number
+        .expect("task number");
+
+    let output = list(&[
+        "tsk".into(),
+        "list".into(),
+        number.to_string(),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&output.stdout).expect("JSON rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], task.to_string());
+    let _ = std::fs::remove_dir_all(invocation_repo);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn list_bare_digits_finds_done_and_deleted_tasks() {
+    let dir = temp_state_dir("number-done-deleted");
+    let mut state = DomainState::new();
+    let done = create_task_with_thread(
+        &mut state,
+        "done target",
+        TaskScope::Global,
+        HumanStatus::Done,
+        None,
+    );
+    let deleted = create_task_with_thread(
+        &mut state,
+        "deleted target",
+        TaskScope::Global,
+        HumanStatus::Ready,
+        None,
+    );
+    state.soft_delete(deleted).expect("soft delete task");
+    TaskStore::new(&dir).save(&state).expect("seed store");
+
+    let persisted = TaskStore::new(&dir).load().expect("load store");
+    for task in [done, deleted] {
+        let number = persisted
+            .get(task)
+            .expect("task")
+            .number
+            .expect("task number");
+        let output = list(&[
+            "tsk".into(),
+            "list".into(),
+            number.to_string(),
+            "--json".into(),
+            "--state-dir".into(),
+            state_dir_arg(&dir),
+        ]);
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&output.stdout).expect("JSON rows");
+        assert_eq!(rows[0]["id"], task.to_string());
+    }
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn list_uuid_still_finds_the_task() {
+    let dir = temp_state_dir("uuid-address");
+    let mut state = DomainState::new();
+    let task = create_task_with_thread(
+        &mut state,
+        "uuid target",
+        TaskScope::Global,
+        HumanStatus::Ready,
+        None,
+    );
+    TaskStore::new(&dir).save(&state).expect("seed store");
+
+    let output = list(&[
+        "tsk".into(),
+        "list".into(),
+        task.to_string(),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    assert_eq!(
+        serde_json::from_str::<Vec<serde_json::Value>>(&output.stdout).expect("JSON rows")[0]["id"],
+        task.to_string()
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn list_bare_digits_with_scope_or_status_flags_is_usage() {
+    let dir = temp_state_dir("number-filter-usage");
+    let mut state = DomainState::new();
+    let task = create_task_with_thread(
+        &mut state,
+        "number target",
+        TaskScope::Global,
+        HumanStatus::Ready,
+        None,
+    );
+    TaskStore::new(&dir).save(&state).expect("seed store");
+    let number = TaskStore::new(&dir)
+        .load()
+        .expect("load store")
+        .get(task)
+        .expect("task")
+        .number
+        .expect("task number")
+        .to_string();
+
+    for flag in ["--desk", "--all", "--thread=release", "--done", "--deleted"] {
+        let output = list(&[
+            "tsk".into(),
+            "list".into(),
+            number.clone(),
+            flag.into(),
+            "--state-dir".into(),
+            state_dir_arg(&dir),
+        ]);
+        assert_eq!(output.code, 2, "number with {flag}");
+        assert!(output.stdout.is_empty());
+        assert!(output.stderr.contains("usage: tsk list"));
+        assert!(output.stderr.contains("cannot be used with"));
+        assert!(!output.stderr.contains("invalid task id"));
+    }
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn list_unknown_number_matches_unknown_uuid_refusal() {
+    let dir = temp_state_dir("unknown-number");
+    let unknown_number = list(&[
+        "tsk".into(),
+        "list".into(),
+        "999".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    let unknown_uuid = list(&[
+        "tsk".into(),
+        "list".into(),
+        "00000000-0000-4000-8000-000000000001".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(unknown_number.code, unknown_uuid.code);
+    assert!(unknown_number.stdout.is_empty());
+    assert_eq!(unknown_number.stderr, unknown_uuid.stderr);
+    assert!(unknown_number.stderr.contains("unknown task"));
+    assert!(!unknown_number.stderr.contains("invalid task id"));
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn human_output_appends_thread_marker_iff_row_threaded_snapshots() {
     let _env = env_lock();
     let repo = project_repo("thread-human");

--- a/tests/cli_steps.rs
+++ b/tests/cli_steps.rs
@@ -55,6 +55,16 @@ fn steps_args(dir: &std::path::Path, task: Uuid) -> Vec<String> {
     ]
 }
 
+fn task_number(dir: &std::path::Path, task: Uuid) -> u64 {
+    TaskStore::new(dir)
+        .load()
+        .expect("load state")
+        .get(task)
+        .expect("seed task")
+        .number
+        .expect("persisted task number")
+}
+
 /// One `[state] short-id text` line from single-task list output.
 struct StepLine {
     done: bool,
@@ -341,6 +351,78 @@ fn steps_on_soft_deleted_task_refuses_without_mutation() {
         "a deleted task's steps are not scriptable"
     );
 
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn steps_bare_digits_act_on_the_task() {
+    let dir = temp_state_dir("number-address");
+    let task = seed_task(&dir, "number target");
+    let number = task_number(&dir, task);
+
+    let output = steps(&[
+        "tsk".into(),
+        "steps".into(),
+        number.to_string(),
+        "add".into(),
+        "addressed by number".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    assert_eq!(
+        TaskStore::new(&dir)
+            .load()
+            .expect("reload state")
+            .get(task)
+            .expect("task")
+            .steps[0]
+            .text,
+        "addressed by number"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn steps_uuid_still_acts_on_the_task() {
+    let dir = temp_state_dir("uuid-address");
+    let task = seed_task(&dir, "uuid target");
+
+    let mut args = steps_args(&dir, task);
+    args.extend(["add".into(), "addressed by uuid".into()]);
+    let output = steps(&args);
+
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    assert_eq!(
+        TaskStore::new(&dir)
+            .load()
+            .expect("reload state")
+            .get(task)
+            .expect("task")
+            .steps[0]
+            .text,
+        "addressed by uuid"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn steps_unknown_number_is_unknown_task() {
+    let dir = temp_state_dir("unknown-number");
+    let output = steps(&[
+        "tsk".into(),
+        "steps".into(),
+        "999".into(),
+        "add".into(),
+        "missing target".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+
+    assert_eq!(output.code, 1);
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.contains("unknown-task"));
     let _ = std::fs::remove_dir_all(dir);
 }
 

--- a/tests/fixtures/queue_board/accordion.txt
+++ b/tests/fixtures/queue_board/accordion.txt
@@ -4,15 +4,15 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                                       tsk · 3m │
+│  ▸ Smoke-test worktree dispatch                                   1 · tsk · 3m │
 │    │ no notes yet                                                              │
 │    │ scope tsk                                                                 │
-│    │ created 3m ago · updated 3m ago                                           │
-│  ▸ Edit target binding pin                                         herdr · 12m │
+│    │ 1 · created 3m ago · updated 3m ago                                       │
+│  ▸ Edit target binding pin                                     2 · herdr · 12m │
 │                                                                                │
 │ desk ────────────────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ Global backlog note                                                      2d │
+│  ○ Global backlog note                                                  7 · 2d │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/board.txt
+++ b/tests/fixtures/queue_board/board.txt
@@ -4,12 +4,12 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                                       tsk · 3m │
-│  ▸ Edit target binding pin                                         herdr · 12m │
+│  ▸ Smoke-test worktree dispatch                                   1 · tsk · 3m │
+│  ▸ Edit target binding pin                                     2 · herdr · 12m │
 │                                                                                │
 │ desk ────────────────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ Global backlog note                                                      2d │
+│  ○ Global backlog note                                                  7 · 2d │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/board_default_split_78.txt
+++ b/tests/fixtures/queue_board/board_default_split_78.txt
@@ -4,12 +4,12 @@
 │                                                                              │
 │ IN MOTION ─────────────────────────────────────────────────────────────────2 │
 │                                                                              │
-│  ▸ Smoke-test worktree dispatch                                     tsk · 3m │
-│  ▸ Edit target binding pin                                       herdr · 12m │
+│  ▸ Smoke-test worktree dispatch                                 1 · tsk · 3m │
+│  ▸ Edit target binding pin                                   2 · herdr · 12m │
 │                                                                              │
 │ desk ──────────────────────────────────────────────────────────────────────1 │
 │                                                                              │
-│  ○ Global backlog note                                                    2d │
+│  ○ Global backlog note                                                7 · 2d │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/tests/fixtures/queue_board/done_drawer.txt
+++ b/tests/fixtures/queue_board/done_drawer.txt
@@ -4,17 +4,17 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                                       tsk · 3m │
-│  ▸ Edit target binding pin                                         herdr · 12m │
+│  ▸ Smoke-test worktree dispatch                                   1 · tsk · 3m │
+│  ▸ Edit target binding pin                                     2 · herdr · 12m │
 │                                                                                │
 │ desk ────────────────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ Global backlog note                                                      2d │
+│  ○ Global backlog note                                                  7 · 2d │
 │                                                                                │
 │ DONE ────────────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ✓ Ship the queue board milestone                                     tsk · 5h │
-│  ✓ Retire classic board chrome                                              6h │
+│  ✓ Ship the queue board milestone                                 8 · tsk · 5h │
+│  ✓ Retire classic board chrome                                          9 · 6h │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/help.txt
+++ b/tests/fixtures/queue_board/help.txt
@@ -9,7 +9,7 @@
 │         │  j/k · ↑/↓ move | alt+space primary                        │         │
 │ desk ───│  alt+d done | alt+o reopen                                 │───────1 │
 │         │  alt+b block | enter open                                  │         │
-│  ○ Globa│  →/← peek | + capture                                      │      2d │
+│  ○ Globa│  →/← peek | + capture                                      │  7 · 2d │
 │         │  alt+e title | alt+x/Delete delete                         │         │
 │         │  alt+u undo | z drawer                                     │         │
 │         │  : palette | ? help                                        │         │

--- a/tests/fixtures/queue_board/palette.txt
+++ b/tests/fixtures/queue_board/palette.txt
@@ -9,7 +9,7 @@
 │         │   set status: ready                                        │         │
 │ desk ───│   set status: started                                      │───────1 │
 │         │ ▸ set status: blocked                                      │         │
-│  ○ Globa│   set status: review                                       │      2d │
+│  ○ Globa│   set status: review                                       │  7 · 2d │
 │         │                                                            │         │
 │         ├────────────────────────────────────────────────────────────┤         │
 │         │ ↑/↓ move · enter run · esc close                           │         │

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -974,11 +974,63 @@ fn task_page_footer_hits_use_display_columns_and_stay_within_the_painted_row() {
         .iter()
         .find(|hit| hit.target == QueueHitTarget::FormThread)
         .expect("thread hit");
-    assert_eq!(scope.area.width, 14, "two-space inset plus six wide glyphs");
-    assert_eq!(thread.area.x, 14, "thread starts after the painted scope");
+    assert_eq!(
+        scope.area.width, 12,
+        "six wide glyphs, with the number chrome outside the scope target"
+    );
+    assert_eq!(
+        thread.area.x, 14,
+        "thread starts after the inset and painted scope, with no number on this in-memory task"
+    );
     assert!(
         thread.area.right() <= width,
         "thread hit must not extend beyond the clipped footer: {thread:?}"
+    );
+}
+
+/// AC-25: a persisted task page paints its bare number before the footer scope, while the
+/// FormScope target starts after that non-interactive number chrome.
+#[test]
+fn ac_25_task_page_footer_number_precedes_the_form_scope_hit_target() {
+    let mut domain = DomainState::new();
+    let id = domain
+        .create(
+            "Numbered task",
+            None,
+            project(THIS_REPO),
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create");
+    let mut persisted = domain.get(id).expect("task").clone();
+    persisted.number = Some(1);
+    let mut model = BoardModel::from_tasks(vec![persisted], Some(PathBuf::from(THIS_REPO)));
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
+
+    let (width, height) = (80, 24);
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("paint task page");
+
+    let scope = board_hit_map(Rect::new(0, 0, width, height), &model)
+        .regions
+        .into_iter()
+        .find(|hit| hit.target == QueueHitTarget::FormScope)
+        .expect("scope hit");
+    let footer = row_text(&terminal, width, scope.area.y);
+    assert!(
+        footer.trim_start().starts_with("1 · app"),
+        "the painted footer must start with the persisted bare number: {footer:?}"
+    );
+    assert_eq!(
+        scope.area.x,
+        2 + "1 · ".chars().count() as u16,
+        "FormScope starts after the inset and non-interactive number chrome"
     );
 }
 

--- a/tests/queue_board_model.rs
+++ b/tests/queue_board_model.rs
@@ -25,6 +25,7 @@ fn task(id: u128, title: &str, status: HumanStatus, scope: TaskScope, updated_se
     let at = epoch_plus(updated_secs);
     Task {
         id: Uuid::from_u128(id),
+        number: None,
         revision: Some(Uuid::from_u128(id)),
         merge_base_revision: None,
         title: title.into(),

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -801,12 +801,16 @@ fn empty_thread_target_follows_a_scope_name_containing_the_thread_label() {
         .iter()
         .find(|hit| hit.target == QueueHitTarget::FormThread)
         .expect("empty thread target");
-    let expected_scope_width = 2 + "foo · thread".chars().count() as u16;
+    let expected_scope_width = "foo · thread".chars().count() as u16;
     assert_eq!(
         scope_hit.area.width, expected_scope_width,
-        "the entire project basename remains the scope target"
+        "the entire project basename remains the scope target, excluding number chrome"
     );
-    assert_eq!(thread_hit.area.x, expected_scope_width);
+    assert_eq!(
+        thread_hit.area.x,
+        2 + expected_scope_width,
+        "thread follows the footer inset and scope target, with no number on this in-memory task"
+    );
 }
 
 #[test]

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -72,7 +72,7 @@ fn project(path: &str) -> TaskScope {
 
 /// Deterministic deck-only fixture: motion, multi-project deck, blocked/review glyphs, done.
 fn fixture_tasks() -> Vec<Task> {
-    vec![
+    let mut tasks = vec![
         task(
             1,
             "Smoke-test worktree dispatch",
@@ -136,7 +136,11 @@ fn fixture_tasks() -> Vec<Task> {
             TaskScope::Global,
             6 * 3600,
         ),
-    ]
+    ];
+    for (index, task) in tasks.iter_mut().enumerate() {
+        task.number = Some((index + 1) as u64);
+    }
+    tasks
 }
 
 /// Board model matching this file's fixture: same tasks, `seed_selection` lands on the same
@@ -929,6 +933,139 @@ fn compact_77x24_and_48x19_and_40x10_paint_glyph_title_only_rows_and_leq_5_verb_
 /// status word), notes body, and meta footer. The selector row stays hidden, the base list
 /// never bleeds through, and every row is width-bounded at the 40x10 floor.
 #[test]
+fn board_row_meta_shows_bare_digits_not_hash_or_t_prefix() {
+    let mut tasks = fixture_tasks();
+    tasks[0].number = Some(12);
+    let view = fixture_view(&tasks, false);
+    let model = fixture_model(&tasks, &view);
+    let body = paint(80, 24, &model).0.join("\n");
+
+    assert!(
+        body.contains("12 · tsk · 3m"),
+        "number must lead row meta:\n{body}"
+    );
+    assert!(
+        !body.contains("#12") && !body.contains("T12"),
+        "number must be bare:\n{body}"
+    );
+}
+
+#[test]
+fn peek_shows_bare_digits() {
+    let mut tasks = fixture_tasks();
+    tasks[0].number = Some(12);
+    let view = fixture_view(&tasks, false);
+    let mut model = fixture_model(&tasks, &view);
+    model.detail_open = Some(Uuid::from_u128(1));
+    let body = paint(80, 24, &model).0.join("\n");
+
+    assert!(
+        body.contains("12 · created 3m ago"),
+        "peek must show bare number:\n{body}"
+    );
+    assert!(
+        !body.contains("#12") && !body.contains("T12"),
+        "number must be bare:\n{body}"
+    );
+}
+
+#[test]
+fn task_page_footer_shows_bare_digits() {
+    let tasks = fixture_tasks();
+    let view = fixture_view(&tasks, false);
+    let mut model = fixture_model(&tasks, &view);
+    model.overlay = QueueOverlay::TaskPage {
+        header_rows: vec!["○ numbered page".to_string()],
+        title_cursor: None,
+        status_word: "ready",
+        notes_rows: Vec::new(),
+        notes_cursor: None,
+        more_lines: 0,
+        step_views: Vec::new(),
+        step_cursor: None,
+        step_scroll: 0,
+        step_marked: None,
+        step_editor: None,
+        meta: "12 · desk · created 1m ago · updated 1m ago".to_string(),
+        meta_scope_x: 5,
+        meta_scope_width: 4,
+        thread_slot_width: None,
+        focus: None,
+        scope_dropdown: None,
+    };
+    let body = paint(80, 24, &model).0.join("\n");
+
+    assert!(
+        body.contains("12 · desk"),
+        "footer must start with the bare number:\n{body}"
+    );
+    assert!(
+        !body.contains("#12") && !body.contains("T12"),
+        "number must be bare:\n{body}"
+    );
+}
+
+#[test]
+fn done_drawer_rows_show_bare_digits() {
+    let mut tasks = fixture_tasks();
+    tasks[7].number = Some(12);
+    let view = fixture_view(&tasks, true);
+    let model = fixture_model(&tasks, &view);
+    let body = paint(80, 24, &model).0.join("\n");
+
+    assert!(
+        body.contains("12 · tsk · 5h"),
+        "done row must show bare number:\n{body}"
+    );
+    assert!(
+        !body.contains("#12") && !body.contains("T12"),
+        "number must be bare:\n{body}"
+    );
+}
+
+#[test]
+fn numbered_board_at_40x10_paints_in_bounds_wraps_titles_and_keeps_tasks_reachable() {
+    let mut tasks = (0..4)
+        .map(|index| {
+            let mut task = task(
+                500 + index,
+                &format!("item {index} title wraps across the compact forty column boundary"),
+                HumanStatus::Ready,
+                TaskScope::Global,
+                index as u64,
+            );
+            task.number = Some(1000 + index as u64);
+            task
+        })
+        .collect::<Vec<_>>();
+    let mut model = BoardModel::from_tasks(std::mem::take(&mut tasks), None);
+    let ids = model.visible_ids();
+    let mut domain = DomainState::new();
+
+    for (index, id) in ids.iter().copied().enumerate() {
+        if index > 0 {
+            apply_intent(&mut domain, &mut model, BoardIntent::SelectNext, None)
+                .expect("select next numbered task");
+        }
+        assert_eq!(model.selected_id(), Some(id));
+        let rows = board_rows(&model, 40, 10);
+        let body = rows.join("\n");
+        assert!(
+            body.contains(&format!("100{index}")),
+            "number must paint at 40x10:\n{body}"
+        );
+        assert!(
+            body.contains(&format!("item {index}")) && body.contains("boundary"),
+            "title must wrap rather than truncate:\n{body}"
+        );
+        assert!(
+            rows.iter().all(|row| row_display_width(row) == 40),
+            "row exceeded 40 columns"
+        );
+    }
+}
+
+#[test]
 fn task_page_renders_header_notes_and_meta_as_a_full_takeover_in_both_tiers() {
     let tasks = fixture_tasks();
     let view = fixture_view(&tasks, false);
@@ -949,6 +1086,7 @@ fn task_page_renders_header_notes_and_meta_as_a_full_takeover_in_both_tiers() {
         step_marked: None,
         step_editor: None,
         meta: "tsk \u{b7} created 1h ago \u{b7} updated 1h ago".to_string(),
+        meta_scope_x: 0,
         meta_scope_width: 11,
         thread_slot_width: None,
         focus: None,

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -41,6 +41,7 @@ fn task(id: u128, title: &str, status: HumanStatus, scope: TaskScope, secs_ago: 
     let at = at_secs_ago(secs_ago);
     Task {
         id: Uuid::from_u128(id),
+        number: None,
         revision: Some(Uuid::from_u128(id)),
         merge_base_revision: None,
         title: title.to_string(),

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -951,6 +951,26 @@ fn board_row_meta_shows_bare_digits_not_hash_or_t_prefix() {
 }
 
 #[test]
+fn standard_row_meta_keeps_age_when_number_and_long_project_compete() {
+    let mut tasks = fixture_tasks();
+    tasks[0].number = Some(7);
+    tasks[0].scope = project("/src/customer-portal-api");
+    tasks[0].updated_at = at_secs_ago(12 * 60);
+    let view = fixture_view(&tasks, false);
+    let model = fixture_model(&tasks, &view);
+    let rows = paint(80, 24, &model).0;
+    let row = rows
+        .iter()
+        .find(|row| row.contains("Smoke-test worktree dispatch"))
+        .expect("started fixture row");
+    assert!(row.contains('7'), "number must remain visible:\n{row}");
+    assert!(
+        row.contains("12m"),
+        "age must remain visible when number plus a long project share the meta column:\n{row}"
+    );
+}
+
+#[test]
 fn peek_shows_bare_digits() {
     let mut tasks = fixture_tasks();
     tasks[0].number = Some(12);

--- a/tests/store_persist.rs
+++ b/tests/store_persist.rs
@@ -1,8 +1,10 @@
 //! Task Store: load/save survives reload.
 //! Uses temp dirs only; never writes real plugin state.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tsk_tui::domain::{
@@ -1281,6 +1283,263 @@ fn legacy_agent_meta_without_session_and_last_observed_decode() {
         "agent_meta decodes with every subfield absent"
     );
     assert_eq!(task.last_observed, Some(ObservedStatus::Working));
+}
+
+#[test]
+fn pre_number_store_upgrades_assigning_distinct_numbers_including_done_and_deleted() {
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    let mut legacy = DomainState::new();
+    let first = legacy
+        .create(
+            "first",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("first");
+    let second = legacy
+        .create(
+            "second",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("second");
+    let third = legacy
+        .create(
+            "third",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("third");
+    legacy.complete(first).expect("done");
+    legacy.soft_delete(second).expect("deleted");
+    let mut document = serde_json::to_value(&legacy).expect("serialize legacy");
+    // Deliberately put creation times out of array order: numbers must follow these times.
+    document["tasks"][0]["created_at"] = serde_json::json!([3, 0]);
+    document["tasks"][1]["created_at"] = serde_json::json!([1, 0]);
+    document["tasks"][2]["created_at"] = serde_json::json!([2, 0]);
+    document["format_version"] = serde_json::json!(1);
+    document
+        .as_object_mut()
+        .expect("document")
+        .remove("next_task_number");
+    for task in document["tasks"].as_array_mut().expect("tasks") {
+        task.as_object_mut().expect("task").remove("number");
+    }
+    fs::write(
+        dir.join("tsk.json"),
+        serde_json::to_vec_pretty(&document).expect("json"),
+    )
+    .expect("write legacy");
+
+    let upgraded = TaskStore::new(&dir).load().expect("upgrade");
+    let on_disk: serde_json::Value =
+        serde_json::from_slice(&fs::read(dir.join("tsk.json")).expect("read upgraded store"))
+            .expect("json");
+    assert_eq!(on_disk["format_version"], 2);
+    assert_eq!(on_disk["next_task_number"], 4);
+    assert_eq!(
+        on_disk["tasks"]
+            .as_array()
+            .expect("tasks")
+            .iter()
+            .map(|task| task["number"].as_u64())
+            .collect::<Vec<_>>(),
+        vec![Some(3), Some(1), Some(2)],
+        "numbers are durably assigned in created_at order"
+    );
+    assert_eq!(upgraded.get(first).and_then(|task| task.number), Some(3));
+    assert_eq!(upgraded.get(second).and_then(|task| task.number), Some(1));
+    assert_eq!(upgraded.get(third).and_then(|task| task.number), Some(2));
+    assert_eq!(upgraded.get(first).expect("done").status, HumanStatus::Done);
+    assert!(upgraded.get(second).expect("deleted").soft_deleted);
+}
+
+#[test]
+fn upgraded_store_preserves_numbers_on_second_load() {
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    let mut legacy = DomainState::new();
+    legacy
+        .create(
+            "first",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("first");
+    let mut document = serde_json::to_value(&legacy).expect("serialize legacy");
+    document["format_version"] = serde_json::json!(1);
+    document
+        .as_object_mut()
+        .expect("document")
+        .remove("next_task_number");
+    document["tasks"][0]
+        .as_object_mut()
+        .expect("task")
+        .remove("number");
+    fs::write(
+        dir.join("tsk.json"),
+        serde_json::to_vec_pretty(&document).expect("json"),
+    )
+    .expect("write legacy");
+    let store = TaskStore::new(&dir);
+    let first = store.load().expect("first load");
+    let numbers: Vec<Option<u64>> = first.tasks().iter().map(|task| task.number).collect();
+    let second = store.load().expect("second load");
+    assert_eq!(
+        second
+            .tasks()
+            .iter()
+            .map(|task| task.number)
+            .collect::<Vec<_>>(),
+        numbers
+    );
+}
+
+#[test]
+fn reload_merge_save_keeps_numbers_and_counter_across_another_writer() {
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    let store = TaskStore::new(&dir);
+    let mut local = DomainState::new();
+    let mine = local
+        .create(
+            "mine",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create mine");
+    store.reload_merge_save(&mut local).expect("persist mine");
+    let mine_number = local
+        .get(mine)
+        .and_then(|task| task.number)
+        .expect("synced number");
+
+    store
+        .locked_transition(|state| {
+            state
+                .create(
+                    "theirs",
+                    None,
+                    TaskScope::Global,
+                    None,
+                    None,
+                    ProvenanceOrigin::Manual,
+                )
+                .map_err(|error| error.to_string())
+        })
+        .expect("another writer persists");
+    store
+        .locked_transition(|state| {
+            // Gaps are valid: a merge must retain a counter ahead of every assigned number.
+            state.next_task_number = 10;
+            Ok(())
+        })
+        .expect("advance counter");
+
+    local
+        .set_status(mine, HumanStatus::Started)
+        .expect("change mine");
+    store.reload_merge_save(&mut local).expect("persist status");
+    assert_eq!(
+        local.get(mine).and_then(|task| task.number),
+        Some(mine_number)
+    );
+    let after_status = store.load().expect("load");
+    assert_eq!(
+        after_status.get(mine).and_then(|task| task.number),
+        Some(mine_number)
+    );
+    assert_eq!(
+        after_status.next_task_number, 10,
+        "merge must retain the disk counter"
+    );
+
+    let later = local
+        .create(
+            "later",
+            None,
+            TaskScope::Global,
+            None,
+            None,
+            ProvenanceOrigin::Manual,
+        )
+        .expect("create later");
+    store.reload_merge_save(&mut local).expect("persist later");
+    assert_eq!(local.get(later).and_then(|task| task.number), Some(10));
+}
+
+#[test]
+fn overlapping_creates_under_lock_receive_distinct_numbers() {
+    const WRITERS: usize = 8;
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    let store = TaskStore::new(&dir);
+    let barrier = Arc::new(Barrier::new(WRITERS));
+    let ids = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..WRITERS)
+            .map(|writer| {
+                let store = store.clone();
+                let barrier = Arc::clone(&barrier);
+                scope.spawn(move || {
+                    barrier.wait();
+                    store.locked_transition(|state| {
+                        state
+                            .create(
+                                format!("writer {writer}"),
+                                None,
+                                TaskScope::Global,
+                                None,
+                                None,
+                                ProvenanceOrigin::Manual,
+                            )
+                            .map_err(|error| error.to_string())
+                    })
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("writer thread").expect("create"))
+            .collect::<Vec<_>>()
+    });
+    let state = store.load().expect("load");
+    let numbers: HashSet<u64> = ids
+        .iter()
+        .map(|&id| state.get(id).and_then(|task| task.number).expect("number"))
+        .collect();
+    assert_eq!(state.tasks().len(), WRITERS);
+    assert_eq!(numbers.len(), WRITERS);
+}
+
+#[test]
+fn v2_store_is_refused_when_writer_format_is_older_and_the_file_is_unwritten() {
+    let dir = temp_state_dir();
+    let _guard = TempDirGuard(dir.clone());
+    // A v2-only writer would refuse v2 just as this v2 writer refuses the next format.
+    let document = serde_json::json!({ "format_version": 3, "next_task_number": 2, "tasks": [], "undo_stack": [] });
+    let bytes = serde_json::to_vec_pretty(&document).expect("json");
+    fs::write(dir.join("tsk.json"), &bytes).expect("write newer store");
+    let error = TaskStore::new(&dir)
+        .save(&DomainState::new())
+        .expect_err("older writer refuses newer store");
+    assert!(error.to_string().contains("newer"));
+    assert_eq!(fs::read(dir.join("tsk.json")).expect("read"), bytes);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Every durably created task gets a store-global sequential number, spoken and typed as `12`. UUID stays internal identity. `tsk list 12` and `tsk steps 12` resolve that task from any cwd. The board paints bare digits in row meta, peek, the task page, and the done drawer.

## Acceptance criteria

AC-1 through AC-29 as in `docs/specs/task-numbers/task-numbers.md`. Numbers are unique, never reused, kept through edit/status/delete/undo. Direct lookup ignores cwd. JSON list/add emit `number`. Board and site show bare digits, not `#12` or `T12`.

## Coverage

| Tasks | Criteria |
| --- | --- |
| T-1 | AC-1 AC-2 AC-3 AC-4 AC-6 AC-7 AC-9 AC-10 AC-11 AC-12 AC-13 |
| T-2 | AC-5 AC-20 AC-21 AC-22 |
| T-3 | AC-8 AC-14 AC-15 AC-16 AC-17 AC-18 AC-19 AC-28 |
| T-4 | AC-23 AC-24 AC-25 AC-26 AC-27 |
| T-5 | AC-29 |

## Verification

`sdlc-check … --require ledger --require verification-report` passed (0 findings).

| Criterion | Type | Proof |
| --- | --- | --- |
| AC-1 | test-backed | locked_create_assigns_number_one_then_two |
| AC-2 | test-backed | overlapping_creates_under_lock_receive_distinct_numbers |
| AC-3 | test-backed | locked_create_assigns_number_one_then_two |
| AC-4 | test-backed | overlapping_creates_under_lock_receive_distinct_numbers |
| AC-5 | test-backed | existing_add_does_not_advance_the_counter |
| AC-6 | test-backed | edit_status_scope_thread_complete_soft_delete_leave_number_unchanged |
| AC-7 | test-backed | undo_of_complete_and_of_soft_delete_keeps_the_same_number |
| AC-8 | test-backed | list_bare_digits_finds_done_and_deleted_tasks |
| AC-9 | test-backed | reload_merge_save_keeps_numbers_and_counter_across_another_writer |
| AC-10 | test-backed | pre_number_store_upgrades_assigning_distinct_numbers_including_done_and_deleted |
| AC-11 | test-backed | pre_number_store_upgrades_assigning_distinct_numbers_including_done_and_deleted |
| AC-12 | test-backed | upgraded_store_preserves_numbers_on_second_load |
| AC-13 | test-backed | v2_store_is_refused_when_writer_format_is_older_and_the_file_is_unwritten |
| AC-14 | test-backed | list_bare_digits_finds_the_task_from_another_cwd |
| AC-15 | test-backed | list_bare_digits_with_scope_or_status_flags_is_usage |
| AC-16 | test-backed | list_uuid_still_finds_the_task |
| AC-17 | test-backed | list_unknown_number_matches_unknown_uuid_refusal |
| AC-18 | test-backed | steps_bare_digits_act_on_the_task |
| AC-19 | test-backed | steps_uuid_still_acts_on_the_task |
| AC-20 | test-backed | json_list_rows_include_number |
| AC-21 | test-backed | json_created_and_existing_include_number |
| AC-22 | test-backed | human_list_rows_show_bare_digits |
| AC-23 | test-backed | board_row_meta_shows_bare_digits_not_hash_or_t_prefix |
| AC-24 | test-backed | peek_shows_bare_digits |
| AC-25 | test-backed | ac_25_task_page_footer_number_precedes_the_form_scope_hit_target |
| AC-26 | test-backed | done_drawer_rows_show_bare_digits |
| AC-27 | test-backed | numbered_board_at_40x10_paints_in_bounds_wraps_titles_and_keeps_tasks_reachable |
| AC-28 | reviewer-checked | Pass: `skills/tsk-cli/SKILL.md` documents `tsk list 12` and `tsk steps 12`, JSON `number`, UUID still valid, cwd ignored on direct lookup, and the existing retry/exit contract. |
| AC-29 | reviewer-checked | Pass: `board.md` and `cli.md` show store-global bare digits; `board-demo.js` paints them; `keys.md` is unchanged. |

## Spec

`docs/specs/task-numbers/task-numbers.md`
ADR-0004: numbers are store-global, not per-project.
