### PR TITLE
docs: add user guide on the site and maintainer internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,169 +3,58 @@
 **A task board for your terminal.**
 
 tsk captures work and moves it through human status: ready, started, blocked,
-review, done. It ships today as a [herdr](https://herdr.dev) plugin, and the
-`tsk` binary also runs standalone against its own state directory.
+review, done. It ships as a [herdr](https://herdr.dev) plugin, and the `tsk`
+binary also runs standalone against `~/.tsk`.
+
+- Queue board with desk · projects · threads
+- Quick-add on the board, plus a herdr capture overlay
+- Task page for notes, thread, scope, and steps
+- Headless `tsk add`, `tsk list`, and `tsk steps`
 
 Park, resume, attention, linking, and dispatch are not part of this tree.
-Older engines live only on the local archive branch `archive/dark-engine-pre-v1`.
 
-The marketing page and docs live in [`site/`](site/) and deploy to
-https://tsk-gules.vercel.app. They are not packaged into the `tsk` binary.
-
-## Requirements
-
-- Rust 1.96.0 (pinned in `rust-toolchain.toml`)
-- Linux or macOS
-- herdr 0.7.5 or newer (plugin mode only)
-
-## Install
-
-Build from source:
+## Quickstart
 
 ```bash
 git clone git@github.com:smarzban/herdr-tsk.git
 cd herdr-tsk
 cargo build --release
+./target/release/tsk add -t "Draft release notes"
+./target/release/tsk
 ```
 
-The built binary is `target/release/tsk`.
+As a herdr plugin: `cargo build --release`, then `herdr plugin link "$PWD"`,
+then **Open tsk board**. Rebuild after you pull. A running board keeps the old
+binary until you quit it.
 
-### Standalone
+Full install (standalone vs plugin, env vars, quick capture):
+[Install](https://tsk-gules.vercel.app/docs/install/).
 
-Run `tsk` directly. The store is `~/.tsk`: `tsk.json` and `settings.json`
-live side by side. Override the locations with `TSK_STATE_DIR` /
-`TSK_CONFIG_DIR`.
+## Usage
 
-```bash
-tsk add -t "Draft release notes"
-tsk list
-```
+How to use the board and CLI lives on the site, not in this file:
 
-### As a herdr plugin
+- [Overview](https://tsk-gules.vercel.app/docs/)
+- [Board](https://tsk-gules.vercel.app/docs/board/)
+- [Keys](https://tsk-gules.vercel.app/docs/keys/)
+- [Capture](https://tsk-gules.vercel.app/docs/capture/)
+- [Task page](https://tsk-gules.vercel.app/docs/task-page/)
+- [Steps](https://tsk-gules.vercel.app/docs/steps/)
+- [CLI](https://tsk-gules.vercel.app/docs/cli/)
 
-The plugin pane runs `./target/release/tsk`, so build before you link:
+The store is `~/.tsk` (`tsk.json` and `settings.json`). Override with
+`TSK_STATE_DIR` / `TSK_CONFIG_DIR`. herdr's injected plugin dirs are ignored, so
+the pane and the CLI edit the same board.
 
-```bash
-herdr plugin link "$PWD"
-```
+Mutating keys need Alt (or Ctrl, flipped in the palette). Bare letters do
+nothing.
 
-`herdr plugin list` should show `herdr-tsk` enabled against that path. Rebuild
-after you pull.
+## Docs
 
-## Open the board
-
-From herdr, pick **Open tsk board**, or:
-
-```bash
-herdr plugin action invoke open-board --plugin herdr-tsk
-```
-
-It opens a **tsk** split beside the current pane. Invoking it again focuses the
-board you already have.
-
-**Quick capture** opens the capture form without the board:
-
-```bash
-herdr plugin action invoke quick-capture --plugin herdr-tsk
-```
-
-In plugin mode herdr injects `HERDR_PLUGIN_STATE_DIR` / `HERDR_PLUGIN_CONFIG_DIR`, but
-tsk deliberately ignores them: there is one store (`~/.tsk`) whether the board runs in
-herdr, another multiplexer, or a bare terminal. Herdr documents plugin state as
-plugin-owned and never touches its contents, so the pane and the CLI edit the same
-board safely.
-
-## Pane size
-
-| Pane | What you get |
+| Audience | Where |
 | --- | --- |
-| at least 78×24 | standard board: section headers, row meta, full verb legend |
-| smaller | compact: glyph and title only; help, palette, and the task page take the full pane |
-
-The board stays operable down to 40×10. A typical herdr split is 78 columns, which
-is the standard board.
-
-## Sections
-
-One urgency-ordered list. Sections are computed, not navigated.
-
-- **IN MOTION**: work you have started
-- **Home** (`P` → desk, or the default when you open the board): three tabs —
-  **desk** (`1`), **projects** (`2`), **threads** (`3`). Desk shows global in-motion
-  work and your desk ON DECK. Projects groups by repo path (collapsible; double-click
-  a header to focus that project). Threads groups by thread name across projects.
-- When scoped to one project: **ON DECK** for that project, with derived thread
-  headers above their open tasks
-- **z** opens the done drawer
-
-## Keys
-
-Mutating keys need **Alt** (or **Ctrl**, if you flip it in the palette). Bare
-letters do nothing, so typing in a focused board cannot complete or delete work.
-
-| Key | Does |
-| --- | --- |
-| `j` `k` or `↑` `↓` | move selection |
-| wheel | scroll the list |
-| `alt+space` | start the selected task, or reopen it if it is done |
-| `alt+d` | done |
-| `alt+o` | reopen |
-| `alt+b` | toggle blocked |
-| `Enter` | open the task page |
-| `→` `←` | peek notes under the row (up to five lines) |
-| `+` | capture |
-| `alt+e` | edit title |
-| `alt+x` or `alt+Delete` | delete (`alt+u` undoes) |
-| `z` | done drawer |
-| `:` | command palette |
-| `?` | help |
-| `P` | project scope (home or a project) |
-| `1` `2` `3` | home tabs: desk · projects · threads |
-| `Esc` | close the open surface |
-| `alt+q` | quit |
-
-Click a row to peek. Click it again to close. A fast double-click opens the page.
-
-`Esc` closes one layer at a time. In the palette, `q` types into the query; leave
-with `Esc`.
-
-## The task page
-
-`Enter` opens the selected task full height. It is view-first: nothing is in edit
-mode until you ask. `alt+e` edits the title, `alt+n` edits notes, `Tab` moves
-between fields. The scope footer does nothing until an edit has started.
-`Ctrl+Enter` or `Alt+Enter` saves from any field. Field `Esc` cancels that field.
-Page `Esc` closes the page.
-
-## Capture and edit
-
-| Key | Does |
-| --- | --- |
-| `Tab` / `Shift+Tab` | Title, Notes, Thread, Scope |
-| `Enter` in Title | save |
-| `Enter` in Notes | new line |
-| `Ctrl+Enter` or `Alt+Enter` | save from any field |
-| `Esc` | cancel |
-
-Title is required. Scope defaults to the repo the board was opened from, or your
-desk if there is no repo.
-
-Notes are multiline, so `Enter` inserts a line. `Ctrl+Enter` saves when the
-terminal reports it; `Alt+Enter` saves everywhere else. Both save. Neither inserts
-a line.
-
-## Delete and undo
-
-`alt+x` removes the selected task. The status line offers undo:
-
-```
-Deleted "Draft the quickstart" · u Undo
-```
-
-`alt+u` restores it. Undo also reverses the last done. It is refused if the task
-changed in between.
-
-## Site
+| Using tsk | https://tsk-gules.vercel.app/docs/ (`site/`) |
+| Changing tsk | [`docs/technical/`](docs/technical/) |
 
 ```bash
 cd site
@@ -181,4 +70,8 @@ npm run dev
 cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release
 ```
 
-Site-only: `cd site && npm ci && npm run build`.
+Site-only: `cd site && npm ci && npm test && npm run build`.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -1,0 +1,80 @@
+# Technical documentation
+
+Maintainer-grade map of **tsk**: how it works, why it is shaped this way, and a complete
+surface inventory. This tree is the internals.
+
+The **user guide** is the Starlight site (`site/src/content/docs/docs/`), published at
+https://tsk-gules.vercel.app/docs/. The repo README is the front door and points there.
+
+Crate: `tsk-tui` 0.3.0. Binary: `tsk`. Plugin: `herdr-tsk`.
+
+## Start here by need
+
+| You want | Read |
+| --- | --- |
+| Where a change belongs, and which constraints shaped the layout | [Architecture](architecture.md) |
+| Why a rule exists and what must not break | [Invariants](invariants.md) |
+| Every persisted / wire entity | [Data model](data-model.md) |
+| Trust boundaries, untrusted input, fail-open vs fail-closed | [Security model](security-model.md) |
+| How a subsystem works (mechanism + invariants) | [Subsystems](#subsystems) |
+| What a function/type does (signatures, defaults) | [Symbol reference](reference.md) (generated rustdoc) |
+| CLI, TUI, plugin, env, and script entry points | [Entry points](entry-points.md) |
+| Coverage ledger (documented vs excluded) | [Coverage](coverage.md) |
+
+## Subsystems
+
+| Subsystem | Responsibility |
+| --- | --- |
+| [Domain](domain.md) | Task lifecycle, human status, steps, threads, undo, dispatch-attempt journal |
+| [Store](store.md) | One JSON document, exclusive lock, revision merge, atomic replace |
+| [Config](config.md) | `settings.json` (verb modifier) and `walkthrough.json` |
+| [Context and scope](context.md) | Host JSON → invocation snapshot; project path / desk resolution |
+| [Capture pipeline](capture.md) | Snapshot + user fields → domain create (+ optional persist) |
+| [CLI](cli.md) | `add` / `list` / `steps` routing, parse, persist, present |
+| [App loop](app.md) | Mode select, board/capture event loops, save recovery, idle merge |
+| [Board UI](board-ui.md) | Queue query, intent reducer, chrome, paint, keys, mouse |
+| [Capture UI](capture-ui.md) | Standalone capture form (`AppMode::Capture`) |
+| [Plugin / host](plugin.md) | `herdr-plugin.toml`, pane identity, launcher scripts |
+| [Site](site.md) | Astro + Starlight marketing/docs site (not in the binary) |
+
+## Reference strategy
+
+**Hybrid.** The crate has hundreds of `pub` items (internal library used by the binary and
+integration tests, `publish = false`). Signatures and rustdoc comments are generated with
+`cargo doc`. Architecture, invariants, data model, security, and per-subsystem mechanism
+are hand-written here. Load-bearing *private* internals that rustdoc would miss are listed
+in [reference.md](reference.md#load-bearing-internals).
+
+Do not add rustdoc generation to CI or the green bar without an explicit owner decision.
+
+## File tree
+
+```
+docs/technical/
+  README.md              landing (this page)
+  architecture.md        system map, constraints, where a change belongs
+  invariants.md          rules a maintainer must not break
+  data-model.md          tsk.json, settings, CLI/host JSON
+  security-model.md      trust boundaries, fail-open / fail-closed
+  coverage.md            ledger + exclusions
+  entry-points.md        argv, env, plugin, scripts
+  reference.md           rustdoc how-to + load-bearing privates
+  domain.md
+  store.md
+  config.md
+  context.md
+  capture.md
+  cli.md
+  app.md
+  board-ui.md
+  capture-ui.md
+  plugin.md
+  site.md
+```
+
+## Related trees
+
+- User docs: [`site/src/content/docs/docs/`](../../site/src/content/docs/docs/)
+- ADRs: [`docs/specs/adr/`](../specs/adr/)
+- Glossary: [`CONTEXT.md`](../../CONTEXT.md)
+- Standing agent rules: [`AGENTS.md`](../../AGENTS.md)

--- a/docs/technical/app.md
+++ b/docs/technical/app.md
@@ -1,0 +1,106 @@
+# App loop
+
+**Responsibility.** Choose Board vs Capture, load store + snapshot + settings,
+run the crossterm/ratatui loop, persist through save recovery, idle-merge
+external writes. Does not derive queue sections (that is `ui::queue`) and does
+not own domain rules.
+
+**Public surface.** `MODE_ENV`, `AppMode`, `resolve_mode` / `resolve_mode_from`,
+`load_board` / `load_board_model`, `run`, `board_frame` / `board_idle_tick`,
+`StoreWatch`, `BoardSaveContext`, `apply_board_intent_with_save_recovery`,
+walkthrough helpers, drag autoscroll helpers. `save_recovery::{SaveRecovery, SaveFailure}`.
+Scheduler constants live in `ui::scheduler`.
+
+## How it works
+
+`app::run` is what `tsk_tui::run` calls after `main` has classified the surface as
+Board or Capture.
+
+### Mode
+
+`resolve_mode_from(mode_env, args)`: `TSK_MODE=capture` (any case) or positional
+`capture` → `AppMode::Capture`, else Board. Process-level validation of unknown
+commands is `cli::router`, not this helper.
+
+### Board loop (shape)
+
+1. Load `TaskStore`, `DomainState`, snapshot, `BoardModel`, verb modifier.
+2. Seed `StoreWatch` from the file we just loaded so the first idle tick does not
+   immediately re-merge. The launch path does **not** call
+   `open_walkthrough_for_launch` (that helper is for tests; the palette can still
+   replay the card).
+3. Enter raw mode / alternate screen; query keyboard enhancement *before* the
+   alternate screen (it can block on a round-trip).
+4. Each iteration: `board_idle_tick` → settle (`record_walkthrough_dismissal` if a
+   card just closed, expire ephemeral messages) → paint → wait
+   `board_poll_duration`.
+5. On `FramePoll::Idle`, `revalidate_board_from_store` if the watch says `tsk.json`
+   mtime/size changed **and** save recovery is not pending.
+6. On event: coalesce resize bursts (`RESIZE_DEBOUNCE` 50 ms, cap 250 ms), paint
+   at the settled size, then dispatch. Keys go through `board_keyboard_intent`.
+   Mouse through `map_board_mouse`. Paste through `map_edit_paste`.
+7. Mutating intents take a domain clone as `BoardSaveContext.baseline` *before*
+   `apply_intent` (`board_intent_needs_fresh_state` / `board_intent_may_persist`).
+8. `IntentOutcome::Persist` → `reload_merge_save`. Failure → `SaveRecovery::fail`
+   and `BoardInputMode::SaveRecovery`. Quit is allowed during recovery so a failed
+   save cannot trap the session.
+
+Wait duration: `scheduler::next_wait`. Idle base 250 ms. While text-drag
+autoscroll is armed: 33 ms floored at 25 ms.
+
+### Save recovery
+
+`SaveRecovery<DomainState>` holds baseline (last persisted) and working (intended)
+snapshots plus the error string. Only one unresolved failure (`debug_assert`).
+
+- **Retry:** persist working; on success replace the loop's `domain` and
+  `end_save_recovery(Retried)`; on failure keep both snapshots, update the error.
+- **Cancel:** restore baseline into `domain`, `sync_from_domain`,
+  `end_save_recovery(Cancelled)`. Cancel of a failed quick-add has distinct chrome
+  so “save cancelled” is not claimed for a capture that never landed.
+
+The form and its mode stay allocated through this whole window (invariant 19).
+`board_keyboard_intent` only hands keys to `map_board_form_key` when the resolved
+mode is a **form field** (`EditTitle` / `EditNotes` / `EditThread` / `EditScope` /
+`FormScopeDropdown`). `SaveRecovery` is not on that allowlist, so `r` / `c` / Esc
+reach Retry/Cancel.
+
+Confirm-edit is judged against the durable baseline *before* the reducer
+(`confirm_edit_refusal_against_the_record`) so a stale target refuses without
+mutating, and the session (mode, draft, cursor, binding) stays intact.
+
+### Idle merge
+
+`StoreWatch` stores `(modified, len)` of `tsk.json`. `poll` returns the new
+signature without recording it. `record` happens only after `store.load` and
+`merge_tasks_from_disk` succeed. A transient read error leaves `last_seen` alone
+so the next tick retries. Skipped entirely while recovery is pending.
+
+`sync_from_domain` rules: [invariants](invariants.md) §16.
+
+### Capture loop
+
+`run_capture`: load store, `CaptureModel::from_snapshot`, form loop, exit process
+on save or cancel (overlay-style). Save uses `capture_save` with `Some(&store)`
+and the same recovery type parameterized on capture's working state.
+
+## Invariants
+
+[Invariants](invariants.md) §§16, 19, 20, 29, 30.
+
+- `board_frame` owns settle-before-wait; do not move settle into the loop's
+  `continue` paths.
+- Do not clear a form before `persist` returns.
+- Walkthrough write errors stay on the message row.
+
+## Error paths
+
+Store load at launch fails `run` (binary prints `tsk: {err}`, exit 1). Mid-session
+save failures become recovery. Idle load failures are silent retries. Walkthrough
+write failures are chrome messages.
+
+## Extension points
+
+New mutating intents must be added to `board_intent_may_persist` (single list the
+loop and the chrome-row lifetime both read). New modes that can outrank a form
+must stay off the form-key allowlist if they need their own keymap.

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -1,0 +1,129 @@
+# Architecture
+
+tsk is a local-first terminal task board. One process paints a queue, another can mutate
+the same store from the CLI or a capture overlay. There is no server, no shared database,
+and no agent-driven status. Human status is the only progress authority.
+
+This page is the system map. Subsystem pages hold mechanism. [Invariants](invariants.md)
+holds the rules a change must not break.
+
+## What this tree is (and is not)
+
+This crate (`tsk-tui`) is the v1 board: capture, human-status verbs, steps, threads, and
+headless `add` / `list` / `steps`. It ships as the herdr plugin `herdr-tsk` and as a
+standalone `tsk` binary against `~/.tsk`.
+
+Park, resume, attention, linking, and dispatch *execution* are not in this tree. Their
+older engines live only on `archive/dark-engine-pre-v1`. Domain types for capsules,
+agent meta, observed status, and dispatch attempts remain on the store document so older
+files still load. The board does not apply observations to human status and does not
+start host dispatch.
+
+## Components
+
+```
+argv / TSK_MODE / --find-board-pane
+        │
+        ▼
+ src/main.rs  ── route() ──► Surface { Board, Capture, Add, Steps, List, FindBoardPane, … }
+        │
+        ├── Board / Capture ──► tsk_tui::run ──► app::{run_board, run_capture}
+        │                           │
+        │                           ├── TaskStore  (tsk.json under TSK_STATE_DIR | ~/.tsk)
+        │                           ├── SettingsRecord / WalkthroughRecord  (~/.tsk)
+        │                           ├── InvocationSnapshot  (HERDR_PLUGIN_CONTEXT_JSON)
+        │                           ├── DomainState  (in memory)
+        │                           └── BoardModel / CaptureModel  (session only)
+        │
+        ├── add / list / steps ──► cli::run_with ──► store lock → domain → presenter
+        └── --find-board-pane ──► board_pane::find_board_pane_from_stdin
+```
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| `src/main.rs` | Process routing, exit codes, stdout/stderr | Domain rules |
+| [`cli`](cli.md) | Headless parse / execute / present | TUI paint |
+| [`app`](app.md) | TUI loops, save recovery, idle store watch | Queue derivation |
+| [`domain`](domain.md) | Task lifecycle, revisions, history, undo | Filesystem |
+| [`store`](store.md) | Lock, load, atomic replace, format check | Status verbs |
+| [`ui/board`](board-ui.md) | Session model, intents, paint | Persistence |
+| [`ui/queue`](board-ui.md#queue-query) | Pure section derivation from a task snapshot | Selection, mouse |
+| [`context`](context.md) / [`scope`](context.md) | Invocation default and project tokens | Creating tasks |
+| [`capture`](capture.md) | Form/CLI create path into domain | Board chrome |
+| [`config`](config.md) | Verb modifier, walkthrough dismissal | Task document |
+| [`plugin`](plugin.md) | herdr pane + actions | Store location (deliberately ignored) |
+| [`site`](site.md) | Marketing + operator docs | Binary behavior |
+
+Chrome lives under `src/ui/` (`board/` model · apply · commands · chrome · draw, plus
+`capture`, `mouse`, `input`, `render`). That split is load-bearing: the reducer mutates
+domain + session; the query is a pure function of tasks; paint consumes both.
+
+## Main flows
+
+### Open the board
+
+1. `cli::router::route` sees no subcommand and no `--find-board-pane` / `--help` → `Surface::Board`.
+2. `app::run` → `run_board`: `TaskStore::load`, `InvocationSnapshot` from env + cwd, `BoardModel::from_domain`.
+3. Settings load the verb modifier (`alt` default). `run_board` does **not** auto-open the walkthrough; `open_walkthrough_for_launch` remains for tests, and the palette can replay it.
+4. Frame loop is **settle, paint, wait** (`app::board_frame`). Idle ticks cheaply `stat` `tsk.json` and merge if it changed (`StoreWatch` + `merge_tasks_from_disk`).
+
+### Mutating verb
+
+1. Key or mouse becomes a `BoardIntent` (`ui::input` / `ui::mouse`). Mutating letters need the configured verb modifier.
+2. `apply_board_intent_with_save_recovery` loads a persist baseline *before* the reducer when `board_intent_may_persist` is true.
+3. `apply_intent` calls `DomainState` only. Outcome `Persist` means the caller writes.
+4. `TaskStore::reload_merge_save` takes the exclusive lock, revision-guards the local mutation against disk, then atomic-replaces. Failure enters [`SaveRecovery`](app.md#save-recovery); the form and input mode stay allocated until Retry or Cancel.
+
+### Capture
+
+- Board `+` is a one-line quick-add on the status-row slot, not a form takeover.
+  After token parse it creates through `capture_save` (`store: None`); the board
+  loop persists.
+- `Tab` expands that draft onto the task page (Notes edit, because a draft has nothing to view).
+- herdr **Quick capture** launches the same binary with `TSK_MODE=capture` (`scripts/open-capture.sh`) into `AppMode::Capture`.
+- All three create through `DomainState::create` / `create_with_thread`. Empty titles never persist.
+
+### Headless add / list / steps
+
+`main` routes those surfaces to `cli::run_with`. Mutations use `TaskStore::locked_transition_if_changed` so a refused command does not rewrite the file. `list` is read-only.
+
+## Constraints that shaped the design
+
+1. **One store everywhere.** herdr injects `HERDR_PLUGIN_STATE_DIR` / `HERDR_PLUGIN_CONFIG_DIR`. tsk ignores them. Pane, overlay, and CLI all read `TSK_STATE_DIR` else `~/.tsk`. Two boards would otherwise silently diverge.
+2. **Human status is truth.** Capsule, agent meta, and `last_observed` are retained data. Completing every step never completes the task.
+3. **Local, concurrent writers.** Board + capture overlay + `tsk add` share one JSON file. The lock plus per-task revision (not wall clock) is the concurrency model. Same-task concurrent edits refuse rather than last-write-win.
+4. **Terminal as a hostile display.** Task titles and notes are untrusted. C0/C1 never reach the emulator as controls (`ui::terminal_text`). Text wraps; it does not truncate (chrome ellipsis is a different budget).
+5. **Operable in a herdr split.** Standard layout at ≥78×24 (typical split width), compact below, no panic to 40×10. Sections are computed, never navigated.
+6. **Mono modifiers only.** Bold, dim, underline, reverse. No color theme module. Markdown on notes is a styled subset of those modifiers.
+7. **Mutating keys are chording.** Bare letters do nothing on the board so a focused pane cannot complete or delete work. Nav, peek, `Enter`, `P`, `1`/`2`/`3`, `z`, `:`, `?`, `+`, `Esc` stay bare.
+8. **v1 cuts fold of dispatch.** Dispatch-attempt types persist for serde compatibility; the board has no host attention poll, park/resume, linking, or dispatch recovery.
+
+## Alternatives considered
+
+Recorded as ADRs; do not restate them here:
+
+- [ADR-0001](../specs/adr/0001-checklist-structured-field.md) — steps are a structured field, not a notes checkbox convention.
+- [ADR-0002](../specs/adr/0002-thread-tag-not-parent-task.md) — a thread is a tag on the task, not a parent task.
+- [ADR-0003](../specs/adr/0003-thread-headers-are-chrome-not-rows.md) — thread headers are renderer chrome, not selectable queue rows.
+
+Other standing rejections (from code comments and `AGENTS.md`, not a numbered ADR):
+
+- SQLite for search: in-memory filter over `DomainState` until open/save is felt-slow or the file is regularly above ~10 MB.
+- Auto-complete from agent observation: forbidden.
+- Renaming `TaskScope::Global` or the on-disk `"global"` to `"desk"`: display-only. A rename is a store migration.
+- Shared `/tmp` fallback for a missing `HOME`: refused; last resort is a *relative* `.tsk-state` / `.tsk-config` in the process cwd.
+
+## Where a change belongs
+
+| Change | First look |
+| --- | --- |
+| Status verb, create, edit, steps, undo | `src/domain/` then the board reducer or CLI |
+| Persist, lock, format version, backup | `src/store.rs` |
+| Section membership, thread blocks, tab lenses | `src/ui/queue.rs` (pure) then `src/ui/render.rs` |
+| Key chord, mouse hit, help line | `src/ui/input.rs`, `src/ui/mouse.rs` |
+| Frame loop, idle merge, save recovery | `src/app.rs`, `src/save_recovery.rs` |
+| `tsk add` / `list` / `steps` flags or JSON | `src/cli/` |
+| Invocation default, `!p` / `--project` | `src/context.rs`, `src/scope.rs` |
+| Verb modifier, walkthrough | `src/config.rs` |
+| herdr pane open/focus | `herdr-plugin.toml`, `scripts/`, `src/board_pane.rs` |
+| Operator-facing keys/board/cli text | `site/src/content/docs/docs/` *and* `site/public/board-demo.js` |

--- a/docs/technical/board-ui.md
+++ b/docs/technical/board-ui.md
@@ -1,0 +1,128 @@
+# Board UI
+
+**Responsibility.** Session presentation of the queue: derive sections, map keys and
+mouse to `BoardIntent`, reduce intents against domain + `BoardModel`, paint with
+ratatui. Persistence is [app](app.md) / [store](store.md).
+
+**Public surface.** Re-exported from `ui`: `BoardModel`, `BoardInputMode`,
+`apply_intent`, `draw_board`, `board_hit_map`, `BoardIntent`, `map_key` /
+`map_key_with`, `map_board_mouse`, queue types, render helpers, tier geometry,
+scrollbar, markdown painters, text-select. Internal split:
+`ui/board/{model,apply,commands,chrome,draw}`.
+
+## How it works
+
+### Queue query
+
+Pure function of the task snapshot + lens + done-drawer flag. Soft-deleted tasks
+are dropped before grouping.
+
+| Lens | Sections |
+| --- | --- |
+| Home **desk** | IN MOTION = every `started` task (any scope), newest `updated_at` first; ON DECK = desk (`Global`) ready/blocked/review, with thread blocks then loose; optional DONE drawer |
+| Home **projects** | One group per project path that has open work (or is `this_repo`); inside: started, review, blocked, ready; collapse is session-only |
+| Home **threads** | One group per thread name across projects; project sub-groups (desk is `project_path: None`); same status order |
+| Project focus | IN MOTION for that path; ON DECK for that path with thread headers; optional DONE |
+
+Status rank inside a group: started → review → blocked → ready → done.
+`visible_task_ids` honors collapse sets; DONE on the threads tab stays selectable
+even without a thread label.
+
+Thread blocks exist only on scoped ON DECK. Headers are renderer chrome
+(ADR-0003): they consume a list row of budget, register no hit target, and are
+not in `task_ids`. Invariant: `task_ids` = concat(blocks' ids, `loose_task_ids`)
+in paint order.
+
+`StatusCounts.need` is always 0 in this tree (field retained). Done count is the
+number of live done tasks (the `drawer_open` branches currently agree).
+
+### Model
+
+`BoardModel` is session-only: location (home tab vs project path), selection id,
+scroll, peek, collapse sets, input mode, optional `BoardForm` / `QuickAddState`,
+palette, help, save-recovery presentation, verb modifier, text selection,
+ephemeral message + delete-recovery notice.
+
+`BoardFormBinding` is `Task(id)` XOR `Capture(snapshot)` for the form's lifetime.
+Quick-add expansion (`Tab`) stashes title·notes·scope so Esc returns to the line
+and a second Tab restores what was typed.
+
+`sync_from_domain` replaces the task vec and reanchors via `ui::selection::reanchor`
+(keep id if still visible; else nearest in the *previous* visible order, preceding
+on ties). Home tab does not follow foreign creates unless the view was empty.
+
+### Intents and reducer
+
+`BoardIntent` is the single vocabulary from keyboard, mouse, and palette
+(`resolve_board_command`). `apply_intent` mutates domain only through
+`DomainState`. `board_intent_may_persist` is the one list of mutating actions;
+chrome-row lifetime (message vs delete-recovery notice) reads that same list.
+
+Chrome row: notice first, message second, legend last. Mutating actions clear
+both, then the new outcome owns the row; a *refused* mutating action puts the
+delete notice back (undo was not spent). Command surfaces cover the notice while
+open without deleting it.
+
+### Keys
+
+`map_key_with(mode, key, verb_modifier)`. Mutating letters require Alt or Ctrl.
+`1`/`2`/`3` select home tabs only in `Normal` at home without ctrl/alt/super.
+`map_board_form_key` shares `map_form_edit_key` with capture. Task-page view mode
+(`TaskPage`) keeps the board keymap so bare `e` enters edit rather than inserting
+into a hidden draft.
+
+### Mouse
+
+Row click peeks; same row again closes peek; fast double-click opens the page.
+Scrollbar track/thumb: `ListScrollTo` / `PageScrollTo` without changing
+selection. Thread headers are not in the hit map. Form fields ignore clicks until
+an edit has started. Text drag uses `text_select` + autoscroll
+(`DEFAULT_BASE_TICK` vs short tick). Copy is OSC 52, capped at 100_000 chars.
+
+### Paint
+
+`ui::tier::resolve`: **standard** when width ≥ 78 **and** height ≥ 24; else
+**compact**. Geometry is defined down to 1×1 without panic; product floor is
+40×10. Standard reserves 28 cells of trailing meta; compact is glyph + title.
+Verb-bar budgets: 7 standard, 5 compact. Project chip max 24 cells.
+
+`draw_queue_frame` paints selector, list, rule, status, verb bar, overlays
+(palette, help, save recovery, walkthrough, bottom input slot). `present_line`
+ellipsis is chrome. Task text wrapping is `edit::wrap_text`.
+
+Notes markdown: [invariants](invariants.md) §27. Peek runs the same painter then
+`dim_line`. `paint_task_row` uses `status_glyph`: ready `○`, started `▸`, blocked
+`■`, review `▲`, done `✓`.
+
+`MONO_MODIFIERS` only; `assert_buffer_mono` / `strip_color` in tests.
+
+### Selection reanchor
+
+```
+reanchor(previous, previous_visible, new_visible) -> Option<Uuid>
+```
+
+Empty new → `None`. Previous still visible → keep (even if reordered). Else scan
+outward from the old index. `previous == None` returns `None` (model seeds on
+open).
+
+## Invariants
+
+[Invariants](invariants.md) §§18–28, plus ADR-0002/0003. Selection never sits on a
+collapsed group or a header. Quick-add refusals live on the line and clear on
+close. Success create has no status message.
+
+## Error paths
+
+Domain refusals → chrome message (or the quick-add line). Persist failures →
+save-recovery mode (app). Unpresentable walkthrough → `WalkthroughOutcome::Unpresentable`,
+no dismissal write.
+
+## Extension points
+
+New section membership: `ui/queue.rs` first, then renderer row accounting (headers
+already consume budget). New keys: `BoardIntent` + mapper + reducer; if it
+persists, add it to `board_intent_may_persist`. Keymap/status/tab changes also
+need `site/src/content/docs/docs/{keys,board,capture,cli}.md` and
+`site/public/board-demo.js`. The web demo uses **bare** verb keys on purpose
+(browsers steal Alt); do not “fix” it to match the TUI.

--- a/docs/technical/capture-ui.md
+++ b/docs/technical/capture-ui.md
@@ -1,0 +1,54 @@
+# Capture UI
+
+**Responsibility.** Standalone capture form (`AppMode::Capture`): title, notes,
+thread, scope; save or cancel; process exits. Reached from herdr **Quick capture**
+(`TSK_MODE=capture`), not from board `+` (that is quick-add on the board).
+
+**Public surface.** `CaptureModel`, `CaptureField`, `CaptureOutcome`,
+`CaptureScopeChoice`, `apply_capture_intent`, `draw_capture`, `format_scope`,
+`CAPTURE_TITLE` (`"Capture"`), `CAPTURE_SCOPE_CONTROLS`, layout helpers in
+`ui::mouse`.
+
+## How it works
+
+`CaptureModel::from_snapshot` seeds title from `title_prefill` when present, scope
+from `default_scope`, empty notes/thread. Fields: Title, Notes, Thread, Scope
+(`CaptureField`). Tab / Shift-Tab cycle. Enter in Title saves; Enter in Notes is
+a newline; Ctrl+Enter / Alt+Enter save from any field. Esc cancels the process.
+
+Scope controls include desk and this-project (disabled with
+`CAPTURE_THIS_PROJECT_UNAVAILABLE` when `this_repo` is none). Thread uses
+`normalize_thread`; refusals paint on the field, not as a process error.
+
+Save calls `capture_save` with `Some(store)`. Empty title stays on the form with
+`TITLE_REQUIRED_MESSAGE` (`"Title required"`). Store failure uses the same
+`SaveRecovery` pattern as the board (`CAPTURE_SAVE_RECOVERY_HELP_LINE`:
+`r retry  ·  c cancel`).
+
+Shared editors: `EditBuffer`, `map_form_edit_key` / `map_capture_key_state`,
+`wrap_text` for Notes. Notes max painted rows in the overlay:
+`CAPTURE_NOTES_MAX_ROWS` = 3. Field label width: `CAPTURE_FIELD_LABEL_WIDTH` = 10.
+
+Mouse: `map_capture_mouse` against `capture_layout_for_model`. Tests assert
+`capture_mouse_paths_complete` so a new layout region cannot silently ignore
+clicks.
+
+## Invariants
+
+- This is a separate surface from board quick-add; do not open `AppMode::Capture`
+  from `+`.
+- Create still goes through domain; empty title does not persist.
+- Form + mode outlive a failed save (same as the board).
+- Capsule/provenance come from the snapshot even when the user picks another
+  scope.
+
+## Error paths
+
+Title required stays in-form. Domain/store errors: in-form message or save
+recovery. Cancel: no write, process exits 0 from `run_capture`'s cancel path
+(the binary treats `Ok(())` as success).
+
+## Extension points
+
+New fields belong on `CaptureField` + layout + mapper together. Prefer sharing
+`EditBuffer` rather than a third draft type.

--- a/docs/technical/capture.md
+++ b/docs/technical/capture.md
@@ -1,0 +1,46 @@
+# Capture pipeline
+
+**Responsibility.** Turn an `InvocationSnapshot` plus user fields into one domain
+create, optionally persisting. Used by Capture UI and conceptually by board
+quick-add (which calls domain create itself after token parse). Not the TUI form —
+that is [capture UI](capture-ui.md).
+
+**Public surface.** `capture_save`, `CaptureError`, `TaskId` (alias of `Uuid`).
+
+## How it works
+
+```
+capture_save(state, store, snapshot, title, notes, scope_override, thread)
+```
+
+- Scope: `scope_override` if `Some`, else `snapshot.default_scope`.
+- Capsule, agent meta, provenance: always from the snapshot (overriding scope does
+  **not** rewrite the capsule).
+- `thread` is already normalized by the caller.
+- Create goes through `DomainState::create_with_thread`. Empty title →
+  `CaptureError::Domain(EmptyTitle)`, no task.
+- If `store` is `Some`, `reload_merge_save` so a concurrent board writer is merged
+  rather than clobbered.
+
+Board quick-add parses `!p`/`!t` in the reducer, then calls `capture_save` with
+`store: None` so capsule/provenance still come from the snapshot. Persistence is
+`IntentOutcome::Persist` through the board save-recovery path — the draft is not
+discarded until that boundary confirms. The expanded Tab form uses `capture_save`
+the same way. Do not add a third create helper that skips the snapshot.
+
+## Invariants
+
+- Domain is the only creator; this module does not write JSON itself except via
+  `TaskStore`.
+- Title trim/empty rules live in domain, not here.
+- Optional persist uses merge-save, not blind `save`.
+
+## Error paths
+
+`CaptureError::Domain` / `Store`. Capture UI maps domain empty-title to the
+on-form `TITLE_REQUIRED_MESSAGE` and store errors into capture save-recovery.
+
+## Extension points
+
+New capture fields belong on the snapshot or as extra domain create arguments —
+do not persist UI-only drafts through this function.

--- a/docs/technical/cli.md
+++ b/docs/technical/cli.md
@@ -1,0 +1,91 @@
+# CLI
+
+**Responsibility.** Headless `add`, `list`, and `steps`: parse argv, optionally
+read a JSON plan, mutate or read the store under the lock, present text or JSON,
+return an exit code. No TUI.
+
+**Public surface.** `cli::run_with`, `CliOutput`, submodules `router`, `parser`,
+`add`, `list`, `steps`, `presenter`. Process routing also exposes `router::route` /
+`Surface` for `main`.
+
+## How it works
+
+`run_with(args, stdin, stdin_is_tty)` switches on `args[1]`. Stdin is consumed
+only by plan-form `add`. `stdin_is_tty` is injected so tests do not ask the live
+process (glossary: `stdin_is_tty seam`).
+
+### Router
+
+`route` is pure. Closed global-flag set before the first positional:
+`--find-board-pane`, `--help`. Two global flags, or a global flag plus anything
+else, is `Usage`. Subcommand wins over `TSK_MODE`. Unknown positional is `Usage`,
+not board.
+
+### `add`
+
+Flag form (`-t` / `--title` etc. sets `has_item_flags`): require a title, refuse
+C0 before trim (`invalid-title`), refuse empty after trim (`empty-title`). Under
+`locked_transition_if_changed`, resolve scope (`resolve_flag_scope`), look for a
+non-soft-deleted match on **title + scope + thread**, return `Existing` without
+writing, or `create_with_thread` with `ProvenanceOrigin::Capture`, no capsule, no
+agent meta.
+
+Plan form: `--file path`, `--file -`, or piped stdin when there are no item flags
+and stdin is not a TTY. JSON must be an **array**. Each object is validated first;
+valid items are applied in one durable write. Failures stay in `failed` with
+index `i`. Exit 1 if any failed, 0 if all created or existing.
+
+`--desk` cannot combine with `--project`. Item flags cannot combine with `--file`.
+Piped stdin with item flags is ignored (not read).
+
+### `list`
+
+Read-only `store.load()`. Default view: open tasks (ready/started/blocked/review)
+in the invocation project, or desk outside a repo. `--all` every scope; `--desk`
+desk only; `--done` / `--deleted` exclusive. `--thread` normalizes at argv
+(invalid name → usage exit 2). A positional UUID lists that one task and its
+steps; it cannot combine with scope/thread/status filters. Unknown well-formed
+UUID is usage (exit 2), not store failure.
+
+Human output groups STARTED / READY / BLOCKED / REVIEW (or DONE / DELETED).
+`--all` groups by status then project, with a concise trailing path or `desk`.
+JSON: flat array; single-task listing adds `steps` on the row.
+
+### `steps`
+
+Positionals: task id, `add` `<text>` or `toggle` `<short-id>`. Flags may appear
+anywhere. Refusals resolve **under the lock** and set `changed = false` so nothing
+is written. Toggle of a prefix that matches two steps is `ambiguous-step`. Empty
+short id matches nothing. Blind retry of a successful toggle flips it back —
+help text tells the caller to `list` first.
+
+Short ids are the shortest unambiguous prefix of the step UUID among siblings
+(`step_short_id`).
+
+### Presenter
+
+Maps results to `CliOutput`. Store errors → exit 3. Item refusals → exit 1 with
+the stable `code()` token on stderr for flag add/steps. Plan add prints the JSON
+object even when `failed` is non-empty (exit 1). Untrusted titles pass through
+`terminal_text` on human list output.
+
+## Invariants
+
+[Invariants](invariants.md) §§31–33. Idempotency includes thread (ADR-0002). C0
+in titles and step text is `invalid-*` before trim. `--state-dir` overrides the
+directory for that invocation only.
+
+## Error paths
+
+| Code | Meaning |
+| --- | --- |
+| 0 | listed / created-or-existing / step applied |
+| 1 | item refusal (retry the failed subset; for toggle, verify first) |
+| 2 | usage/parse; nothing persisted |
+| 3 | store I/O; commit indeterminate |
+
+## Extension points
+
+New flags go in the relevant parser with an explicit combination check. New JSON
+fields on plan items need `parse_plan_item` and a refusal code. Do not grow the
+global-flag set without updating `route` tests and `CONTEXT.md`.

--- a/docs/technical/config.md
+++ b/docs/technical/config.md
@@ -1,0 +1,59 @@
+# Config
+
+**Responsibility.** Two small documents beside the store: verb-modifier settings and
+walkthrough dismissal. Not the task document. Deliberately weaker durability than
+[store](store.md).
+
+**Public surface.** `default_config_dir`, `WalkthroughRecord`, `SettingsRecord`,
+`VerbModifier`.
+
+## How it works
+
+`default_config_dir` mirrors the store's precedence with `TSK_CONFIG_DIR` /
+`$HOME/.tsk` / `.tsk-config`, and also ignores `HERDR_PLUGIN_CONFIG_DIR`. Empty env
+values fall through — an empty `TSK_CONFIG_DIR` must not resolve to `""` (that would
+write `walkthrough.json` in whatever cwd the board was launched from). Resolution is
+split into a pure `resolve_config_dir` so tests do not `setenv` (this crate's tests
+run in threads in one process).
+
+### Settings
+
+`settings.json`: `{ "verb_modifier": "alt" | "ctrl" }`. Default `Alt`. Palette toggle
+calls `VerbModifier::toggled` and `SettingsRecord::set_verb_modifier`. Unreadable
+file → default. `prefix()` returns `"alt+"` or `"ctrl+"` for help/verb-bar labels.
+
+### Walkthrough
+
+`walkthrough.json`: `{ "dismissed": true }`. `is_dismissed` is true only when the
+file parses and `dismissed` is true. Every other failure mode is not dismissed.
+
+`record_dismissed` writes `dismissed: true` via temp+rename+file sync. It does **not**
+lock and does **not** fsync the directory. The module comment is the spec: a crash can
+lose a just-recorded dismissal (card reappears once); the payload is a constant so two
+writers are harmless.
+
+`run_board` does not call `open_walkthrough_for_launch`. That helper remains for tests:
+if the record is not dismissed it dispatches `BoardIntent::OpenWalkthrough` — the same
+intent the palette's replay uses. Dismissal write is `record_walkthrough_dismissal` —
+**presented, never propagated**. One close → one write attempt; `Unpresentable` /
+`Interrupted` write nothing.
+
+## Invariants
+
+[Invariants](invariants.md) §§17, 22, 30.
+
+- Do not reuse this write path for a varying payload (you need a lock).
+- Do not `?` a walkthrough write out of a board key handler (that tears the board
+  down on a read-only config dir).
+
+## Error paths
+
+`StoreError` (shared I/O/JSON type). Settings/walkthrough reads have no error
+channel by construction.
+
+## Extension points
+
+`WalkthroughDocument` / `SettingsDocument` use `#[serde(default)]` on fields so a
+sibling key can be added without a migration. A new setting that must not be lost
+on crash needs the store's lock + directory fsync, or its own document with those
+guarantees — not a copy of this module.

--- a/docs/technical/context.md
+++ b/docs/technical/context.md
@@ -1,0 +1,71 @@
+# Context and scope
+
+**Responsibility.** Turn host invocation JSON + process cwd into an
+`InvocationSnapshot` (default capture scope, capsule, passive agent meta), and
+resolve project tokens the same way for board `!p` and CLI `--project`.
+
+**Public surface.** `context::{CONTEXT_JSON_ENV, RawHostContext, RawWorktree,
+InvocationSnapshot, resolve_repo_root, build_snapshot, snapshot_from_env}`.
+`scope::{resolve_flag_scope, resolve_project_path}`.
+
+## How it works
+
+### Snapshot
+
+`HERDR_PLUGIN_CONTEXT_JSON` deserializes into `RawHostContext`. Unknown keys ignored.
+Missing or invalid JSON → `Default` (all none). `from_json` is the pure parser.
+
+Effective cwd: first non-empty of `focused_pane_cwd`, `workspace_cwd`, `cwd`, else
+the process cwd passed into `build_snapshot`.
+
+`resolve_repo_root` walks ancestors for a `.git` **file or directory**. No git
+library. Unresolved repo → `TaskScope::Global` (desk).
+
+Capsule fields are filled only from known values (`text::non_empty` trims). Branch
+is taken from the host hint, never invented by running git. Completely empty
+capsule / agent meta become `None`.
+
+Selected text: non-empty → `title_prefill` and `ProvenanceOrigin::Selection`; else
+no prefill and `Capture`.
+
+`this_repo` is the resolved project root; the board uses it as “this repo” for
+scope pickers and as the default when a project-scoped board opens capture.
+
+### Project tokens
+
+`resolve_project_path(token, domain, snapshot)`:
+
+- Token contains `/` → verbatim path.
+- Else unique ASCII-case-insensitive **basename** match against project paths on
+  existing tasks plus the snapshot's default / `this_repo`.
+- Missing or ambiguous → verbatim (the token is stored as the path; `tsk list --all`
+  is the recovery hatch).
+
+`resolve_flag_scope(project, global, domain, snapshot)`: `--project` wins, else
+`--desk` (`global: true`) → `TaskScope::Global`, else snapshot default. CLI flag
+`--desk` is this boolean; there is no `--global` flag.
+
+Board capture tokens (`!p` / `!t`) are parsed in the quick-add reducer with the
+same rules: bare `!p` is desk, `!p name` is basename, `!p /path` is verbatim; bare
+`!t` unthreads; `!t name` runs `normalize_thread`.
+
+## Invariants
+
+- Never invent capsule or agent fields the host did not provide.
+- Agent lifecycle is never a human-status authority.
+- Board and headless add share `resolve_project_path` so a basename that works in
+  one works in the other.
+- Desk display vs `global` storage: [invariants](invariants.md) §11.
+
+## Error paths
+
+Context parse cannot fail the board: malformed JSON is empty context. Invalid
+thread tokens refuse at the capture/CLI boundary (`ThreadError` / usage exit 2)
+before domain create. Ambiguous project basename is not an error — it stores the
+token verbatim.
+
+## Extension points
+
+New host fields: add optional keys to `RawHostContext`, map them in
+`build_snapshot` only if they should persist on the capsule. Do not start shelling
+out to git for branch; the code is explicit that branch is a host hint.

--- a/docs/technical/coverage.md
+++ b/docs/technical/coverage.md
@@ -11,8 +11,8 @@ rather than a row per function.
 
 ## Target
 
-Repo root `/Users/saeed/Workspace/herdr-tasks` (crate `tsk-tui` + `site/` + plugin
-manifest). Not a self/special docs repo.
+This repository (crate `tsk-tui` + `site/` + plugin manifest). Not a
+self/special docs repo.
 
 ## Subsystems and modules
 

--- a/docs/technical/coverage.md
+++ b/docs/technical/coverage.md
@@ -1,0 +1,115 @@
+# Coverage ledger
+
+Built from the filesystem and `Cargo.toml` / `herdr-plugin.toml` / `site/package.json`,
+not from memory. Status `done` means a hand-written page covers the item. Status
+`generated (rustdoc)` means `cargo doc --no-deps --package tsk-tui` includes every
+`pub` symbol in that module (see [reference](reference.md)).
+
+Symbol-level public items are inventoried as **723 `pub` lines** under `src/` (including
+`pub mod` / `pub use` / inherent methods). They close as a group per module via rustdoc
+rather than a row per function.
+
+## Target
+
+Repo root `/Users/saeed/Workspace/herdr-tasks` (crate `tsk-tui` + `site/` + plugin
+manifest). Not a self/special docs repo.
+
+## Subsystems and modules
+
+| Item | Kind | Doc | Status |
+| --- | --- | --- | --- |
+| System map | subsystem | [architecture.md](architecture.md) | done |
+| Cross-cutting rules | subsystem | [invariants.md](invariants.md) | done |
+| Trust / display injection | subsystem | [security-model.md](security-model.md) | done |
+| Persisted + wire shapes | data model | [data-model.md](data-model.md) | done |
+| Process surfaces | entry pts | [entry-points.md](entry-points.md) | done |
+| `src/lib.rs` (`run`, re-exports) | module | rustdoc + [architecture.md](architecture.md) | generated (rustdoc) |
+| `src/main.rs` | entry pt | [entry-points.md](entry-points.md) | done |
+| `src/domain/*` | subsystem | [domain.md](domain.md) | done |
+| `src/domain/mod.rs` | module | [domain.md](domain.md) | done |
+| `src/domain/task.rs` publics | module | rustdoc | generated (rustdoc) |
+| `src/domain/events.rs` publics | module | rustdoc | generated (rustdoc) |
+| `src/domain/thread.rs` publics | module | rustdoc | generated (rustdoc) |
+| `src/domain/undo.rs` publics | module | rustdoc | generated (rustdoc) |
+| `src/domain/dispatch_attempt.rs` publics | module | rustdoc | generated (rustdoc) |
+| `src/domain/time_serde.rs` | internal — load-bearing | [data-model.md](data-model.md), [reference.md](reference.md) | done |
+| `src/store.rs` | subsystem | [store.md](store.md) | done |
+| `src/config.rs` | subsystem | [config.md](config.md) | done |
+| `src/context.rs` | subsystem | [context.md](context.md) | done |
+| `src/scope.rs` | module | [context.md](context.md) | done |
+| `src/capture.rs` | subsystem | [capture.md](capture.md) | done |
+| `src/save_recovery.rs` | module | [app.md](app.md) | done |
+| `src/app.rs` | subsystem | [app.md](app.md) | done |
+| `src/board_pane.rs` | module | [plugin.md](plugin.md) | done |
+| `src/text.rs` | internal — load-bearing | [reference.md](reference.md) | done |
+| `src/cli/*` | subsystem | [cli.md](cli.md) | done |
+| `src/cli/mod.rs` | module | [cli.md](cli.md) | done |
+| `src/cli/router.rs` | module | [cli.md](cli.md) | done |
+| `src/cli/parser.rs` | module | [cli.md](cli.md) | done |
+| `src/cli/add.rs` | module | [cli.md](cli.md) | done |
+| `src/cli/list.rs` | module | [cli.md](cli.md) | done |
+| `src/cli/steps.rs` | module | [cli.md](cli.md) | done |
+| `src/cli/presenter.rs` | module | [cli.md](cli.md) | done |
+| `src/ui/board/*` | subsystem | [board-ui.md](board-ui.md) | done |
+| `src/ui/board/mod.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/board/model.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/board/apply.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/board/commands.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/board/chrome.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/board/draw.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/queue.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/input.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/mouse.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/render.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/edit.rs` | internal — load-bearing | [board-ui.md](board-ui.md), [reference.md](reference.md) | done |
+| `src/ui/markdown.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/selection.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/scheduler.rs` | module | [app.md](app.md) | done |
+| `src/ui/scrollbar.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/text_select.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/tier.rs` | module | [board-ui.md](board-ui.md) | done |
+| `src/ui/capture.rs` | subsystem | [capture-ui.md](capture-ui.md) | done |
+| `src/ui/mod.rs` presenters | internal — load-bearing | [security-model.md](security-model.md) | done |
+| `herdr-plugin.toml` | entry pt | [plugin.md](plugin.md) | done |
+| `scripts/open-board.sh` | entry pt | [plugin.md](plugin.md) | done |
+| `scripts/open-capture.sh` | entry pt | [plugin.md](plugin.md) | done |
+| `scripts/tsk-cli.sh` | entry pt | [entry-points.md](entry-points.md) | done |
+| `site/` Astro app | subsystem | [site.md](site.md) | done |
+
+## Data models
+
+| Item | Kind | Doc | Status |
+| --- | --- | --- | --- |
+| `DomainState` / `tsk.json` | data model | [data-model.md](data-model.md) | done |
+| `Task`, `Step`, `HumanStatus`, `TaskScope` | data model | [data-model.md](data-model.md) | done |
+| `ContextCapsule`, `AgentMeta`, `ObservedStatus` | data model | [data-model.md](data-model.md) | done |
+| `TaskEvent`, `ProvenanceOrigin` | data model | [data-model.md](data-model.md) | done |
+| `UndoEntry` | data model | [data-model.md](data-model.md) | done |
+| `DispatchAttempt` and receipts | data model | [data-model.md](data-model.md) | done |
+| `settings.json` / `VerbModifier` | data model | [data-model.md](data-model.md) | done |
+| `walkthrough.json` | data model | [data-model.md](data-model.md) | done |
+| CLI plan/flag/list JSON | data model | [data-model.md](data-model.md) | done |
+| `HERDR_PLUGIN_CONTEXT_JSON` | data model | [context.md](context.md) | done |
+
+## Exclusions (declared)
+
+| Item | Kind | Reason |
+| --- | --- | --- |
+| `target/` | excluded | generated build + rustdoc output |
+| `site/node_modules/` | excluded | vendored npm |
+| `site/dist/` | excluded | generated Astro build |
+| `#[cfg(test)]` modules and `tests/` | excluded | test-only; they *exercise* the surface, they are not product API |
+| `skills/` | excluded | operator skill docs, not crate internals |
+| `docs/specs/` (except ADRs linked from architecture) | excluded | feature-spec artifacts; ADRs are linked, not duplicated |
+| `archive/dark-engine-pre-v1` | excluded | not present in this tree; historical engines |
+| `src/host`, `src/dispatch`, `src/attention`, `src/resume` | excluded | not in this tree (stale `target/doc/herdr_tasks/` rustdoc is from an old crate name — ignore it) |
+| Adding `cargo doc` to CI / green bar | excluded | owner-approved change, not a docs-task default |
+
+## Stats
+
+- Hand-written pages: 19 under `docs/technical/` (landing, 4 spine, 11 subsystems,
+  coverage, entry-points, reference).
+- Inventoried `pub` lines under `src/`: 723, closed via rustdoc per module.
+- Inventoried crate-private / `pub(crate)` lines: 217; load-bearing subset listed in
+  [reference.md](reference.md#load-bearing-internals).
+- Exclusions: 8 rows, each with a reason.

--- a/docs/technical/data-model.md
+++ b/docs/technical/data-model.md
@@ -1,0 +1,224 @@
+# Data model
+
+Every persisted and wire shape. Ownership, lifecycle, and field semantics. Verified
+against `src/domain/task.rs`, `src/domain/events.rs`, `src/domain/undo.rs`,
+`src/domain/dispatch_attempt.rs`, `src/domain/time_serde.rs`, `src/store.rs`,
+`src/config.rs`, and `src/cli/{add,list,presenter,steps}.rs`.
+
+There is no SQL schema and no migration runner. Compatibility is serde defaults,
+aliases, and `format_version`.
+
+## Store document — `tsk.json`
+
+**Ownership.** `TaskStore` under `default_state_dir()` (`TSK_STATE_DIR` else `$HOME/.tsk`
+else `.tsk-state`). One JSON document named `tsk.json`. Sibling files: `tsk.json.lock`
+(lock, not JSON), `tsk.json.1` (previous successful live document), `.tsk.json.tmp.*`
+(in-flight, swept under the lock).
+
+**Lifecycle.** Missing file → empty `DomainState::new()`. Load holds the exclusive lock.
+Save stamps `format_version` to `STORE_FORMAT_VERSION` (1) and clears
+`merge_base_revision` on every task. A document whose `format_version` is **greater
+than** 1 is refused (`StoreError::UnsupportedFormat`); it is not rewritten.
+
+### `DomainState`
+
+| Field | Type | Semantics |
+| --- | --- | --- |
+| `format_version` | `u32` | Writer's document version. Missing field deserializes as `LEGACY_STORE_FORMAT_VERSION` (**1**, must remain 1 if the current constant is later bumped). |
+| `tasks` | `Vec<Task>` | All tasks including soft-deleted. Lookup is linear scan by id. |
+| `active_attempts` | `Vec<DispatchAttempt>` | In-flight dispatch journals. Default empty. Removed on completion or full cleanup, not retained as history. v1 board does not create these. |
+| `undo_stack` | `Vec<UndoEntry>` | LIFO. Only complete and soft-delete push. |
+
+Verified against: `src/domain/task.rs` `DomainState`.
+
+### `Task`
+
+One unit of intended work. Created by domain `create` / `create_with_thread` (status
+`ready`). Soft-deleted rows stay here until a future hard-delete that this tree does
+not implement.
+
+| Field | Type | Semantics |
+| --- | --- | --- |
+| `id` | `Uuid` | Stable identity (v4). CLI addresses the full UUID. |
+| `revision` | `Option<Uuid>` | Opaque semantic revision. Missing on legacy tasks; assigned on next mutation. |
+| `merge_base_revision` | `Option<Uuid>` | Transient save intent: revision observed before this in-memory mutation. Cleared after a successful durable write. Nil UUID means “legacy disk had no revision”. |
+| `title` | `String` | Required, trimmed, non-empty. |
+| `notes` | `Option<String>` | Free text. Stored verbatim (including CRLF). Markdown is a paint concern. |
+| `thread` | `Option<String>` | Normalized name or absent (unthreaded). Old stores without the field decode unthreaded. |
+| `status` | `HumanStatus` | Source of truth. |
+| `scope` | `TaskScope` | Desk (`Global`) or a project path. |
+| `capsule` | `Option<ContextCapsule>` | Frozen capture context. Missing fields stay `None`; never invented. |
+| `agent_meta` | `Option<AgentMeta>` | Passive host identity. Empty meta is stored as `None`. Does not affect status. |
+| `last_observed` | `Option<ObservedStatus>` | Last host observation, serde compatibility only. Absent if never observed. |
+| `provenance` | `ProvenanceOrigin` | How it was created. |
+| `history` | `Vec<TaskEvent>` | Append-only. |
+| `steps` | `Vec<Step>` | Flat ordered list. Serde alias `checklist` on read; empty omitted on write. |
+| `soft_deleted` | `bool` | Hidden from live views when true. |
+| `created_at` / `updated_at` | `SystemTime` | Wire format: `[secs, nanos]` since UNIX_EPOCH (`time_serde`). |
+
+### `HumanStatus`
+
+```
+ready | started | blocked | review | done
+```
+
+serde `snake_case`. `ready` aliases `todo`; `started` aliases `doing`. Old stores still
+load. The board never writes the old names.
+
+### `TaskScope`
+
+```
+"global" | { "project": { "path": "<string>" } }
+```
+
+Display name for `Global` is **desk**. Internal name stays `TaskScope::Global`. Path is
+the resolved project root (string), not a repo id.
+
+### `Step`
+
+| Field | Type | Semantics |
+| --- | --- | --- |
+| `id` | `Uuid` | Stable. CLI `steps toggle` uses an unambiguous prefix of this id. |
+| `text` | `String` | One line, trimmed at the domain boundary. |
+| `done` | `bool` | Progress only. Never implies task status. |
+
+### `ContextCapsule`
+
+Optional strings: `repo_path`, `worktree_path`, `branch`, `cwd`, `source_pane_id`,
+`selected_text`, `file`, and optional `line: u32` (1-based). All skipped when `None`.
+`is_empty` is true when every field is absent. Capsule is a snapshot of the *invocation*,
+not of the task's current `scope` — overriding scope at capture still stores the original
+capsule.
+
+### `AgentMeta` / `AgentSessionIdentity`
+
+`agent_id`, `pane_id`, `agent_session: { source, value }`. Empty meta is omitted.
+v1 board does not link or unlink agents (`TaskEventKind::AgentLinked` exists for old
+history).
+
+### `ObservedStatus`
+
+`working | blocked | idle | done | unknown`. Retained. Board code does not apply it.
+
+### `ProvenanceOrigin`
+
+`manual | capture | selection`. Board quick-add and headless add use `capture`.
+Selected-text invocation uses `selection`.
+
+### `TaskEvent` / `TaskEventKind`
+
+`{ kind, at }` with the same time tuple. Kinds:
+
+`created`, `edited`, `status_set`, `completed`, `reopened`, `soft_deleted`, `restored`,
+`parked`, `agent_linked`, `agent_unlinked`, `dispatched`, `step_added`, `step_checked`,
+`step_unchecked`, `step_renamed`, `step_removed`.
+
+Step kinds alias the old `checklist_item_*` names on read. Park / link / dispatch kinds
+are historical; this tree does not append them.
+
+### `UndoEntry`
+
+```
+{ "soft_delete": { "id", "expected_revision"? } }
+{ "complete":    { "id", "expected_revision"? } }
+```
+
+Missing `expected_revision` is a legacy entry and fails `undo` as stale without popping.
+
+### Dispatch-attempt journal (retained, unused by v1 board)
+
+Still part of the document so older files load. Fields on `DispatchAttempt`: `id`,
+`task_id`, `mode` (`here` \| `new_worktree`), `kind` (string), `steps`
+(`create_worktree` / `open_pane` / `start_agent` / `send_prompt` with `completed`),
+`owned_resources` (worktree / pane / agent receipts), `phase`
+(`dispatching` \| `failed` \| `cleaning`), `last_error`, `revision`, `updated_at`.
+
+Transitions are revision-guarded. Do not invent receipts from ambient paths.
+
+**Relations.** `DispatchAttempt.task_id` → `Task.id`. A task may have at most one active
+attempt. Attempts do not have a foreign-key cascade; removing a task is not implemented.
+
+## Config directory — `settings.json` / `walkthrough.json`
+
+Same directory as the store by default (`TSK_CONFIG_DIR` else `$HOME/.tsk`). Distinct
+files so a task-document bump does not disturb settings.
+
+### `settings.json`
+
+```json
+{ "verb_modifier": "alt" }
+```
+
+`verb_modifier`: `alt` (default) or `ctrl`. Missing / unreadable / malformed → `Alt`.
+Written pretty-printed via temp+rename (no lock, no directory fsync). See
+[config](config.md).
+
+### `walkthrough.json`
+
+```json
+{ "dismissed": true }
+```
+
+The only durable fact: the walkthrough was completed or skipped. Missing, empty,
+malformed, unreadable, or `dismissed: false` → not dismissed. Field is
+`#[serde(default)]` so siblings can be added without a migration.
+
+## Headless wire formats
+
+Not stored. Produced/consumed by [`cli`](cli.md).
+
+### Flag add `--json` (one object)
+
+```json
+{ "outcome": "created" | "existing", "id": "<uuid>", "title": "<string>", "project": "<path>" | null }
+```
+
+`project` is null for desk.
+
+### Plan add (stdin or `--file`)
+
+Input: a JSON **array** of objects. Fields: `title` (required string), optional `notes`,
+`project` (string, JSON null = desk, omitted = invocation default), `thread` (string or
+null; missing/null = unthreaded).
+
+Output:
+
+```json
+{
+  "created":  [{ "i": 0, "id": "<uuid>", "title": "..." }],
+  "existing": [{ "i": 1, "id": "<uuid>", "title": "..." }],
+  "failed":   [{ "i": 2, "title": "..." | null, "code": "empty-title", "error": "..." }]
+}
+```
+
+`i` is the input index. Notes are not echoed. Error `code` is the machine contract;
+`error` is not.
+
+Stable refusal codes: `empty-title`, `invalid-title`, `invalid-item`, plus `store-error`
+on I/O.
+
+### `list --json`
+
+A JSON array of `{ id, title, status, project, thread }`. `project` / `thread` are
+`null` when absent. Single-task listing (`tsk list <uuid>`) attaches `steps`:
+`[{ id, done, short_id, text }, ...]` in stored order on that one row. Other listings
+keep the row shape without `steps`.
+
+### herdr pane list (stdin to `--find-board-pane`)
+
+Expected: `{ "result": { "panes": [ { "pane_id", "label", ... } ] } }`. Match
+`label == "tsk"`. First flag-safe `pane_id` wins. Invalid JSON → no match (the binary
+exits 1 for none, stderr only on I/O / parse errors of stdin read — unparseable JSON
+is `Ok(None)` from `find_board_pane_id`).
+
+### `HERDR_PLUGIN_CONTEXT_JSON`
+
+See [context](context.md). Unknown keys ignored. Missing/malformed → empty
+`RawHostContext` (no invented fields).
+
+## What is not a data model
+
+- Queue sections, thread blocks, collapse sets, selection, peek, forms: session-only
+  (`BoardModel`). Collapse does not persist.
+- Search: in-memory filter, no index.
+- Site content and the web demo: not the store.

--- a/docs/technical/domain.md
+++ b/docs/technical/domain.md
@@ -1,0 +1,74 @@
+# Domain
+
+**Responsibility.** Task lifecycle and the in-memory document: create, human-status
+verbs, edit, soft-delete/restore, undo, steps, thread normalization, and (retained)
+dispatch-attempt journaling. Persistence is [store](store.md). Presentation is
+[board UI](board-ui.md) / [CLI](cli.md). This layer does not talk to the filesystem
+or the terminal.
+
+**Public surface.** `src/domain/` re-exports task, events, thread, undo, and
+dispatch_attempt. `time_serde` is private. Callers typically hold a `DomainState` and
+pass `&mut` into `create`, `set_status`, `complete`, `reopen`, `soft_delete`,
+`restore`, `edit`, `undo`, `add_step` / `toggle_step` / `rename_step` / `remove_step`.
+Signatures: generated [rustdoc](reference.md).
+
+## How it works
+
+`DomainState` is a `Vec<Task>` plus `undo_stack` and `active_attempts`. Lookup is a
+scan by id (`SHORTCUT` in source: fine until the store is large). Soft-deleted tasks
+remain gettable.
+
+Create trims the title, assigns v4 `id` and `revision`, status `ready`, and a single
+`Created` event. `create_with_thread` is the path that can set an already-normalized
+thread in that same mutation; `create` is the unthreaded compatibility wrapper.
+
+Mutations other than create go through `record_mutation`: set `merge_base_revision`
+to the previous revision (or nil for legacy), mint a new v4 revision, stamp
+`updated_at`, append history. That merge base is what [store](store.md) uses to
+detect a concurrent writer on the same task.
+
+Status verbs are explicit. `complete` / `soft_delete` also push `UndoEntry`. `undo`
+inspects the top entry's `expected_revision`, refuses stale/legacy without popping,
+then `restore` or `reopen`. Empty stack is `Ok(())`.
+
+Steps are appended, toggled, renamed, or removed. None of those commands touch
+`status`, `scope`, or `notes`. Old event names `checklist_item_*` still deserialize.
+
+`normalize_thread` is a pure function (see [data model](data-model.md)). The domain
+does not call it on `edit` — callers (board reducer, CLI parser, capture tokens)
+normalize first and pass `Option<String>`.
+
+Dispatch attempts are a durable journal with revision-guarded transitions and owned
+resource receipts. v1 board never starts one. Merge rules still matter: disk owns
+attempt *existence*, so a local copy must not resurrect an attempt disk already
+removed.
+
+Idle merge (`merge_tasks_from_disk`) is for “another process wrote the file”: on
+revision mismatch, disk wins. There is no mutation baseline, so wall-clock is not
+used. Save merge (`merge_for_save`) is the opposite situation: this process has
+uncommitted mutations that must apply only if disk still has the revision they
+started from.
+
+## Invariants
+
+Owned subset of [invariants](invariants.md) §§1–12, plus:
+
+- `get` finds soft-deleted tasks; views filter them.
+- `active_attempt_for_task` is unique.
+- History is append-only; do not rewrite past events.
+- Do not auto-complete from `ObservedStatus` or from `steps` all-done.
+
+## Error paths
+
+`DomainError`: `EmptyTitle`, `UnknownId`, `SoftDeleted`, `StaleUndo`,
+`UnknownDispatchAttempt`, `EmptyStepText`, `UnknownStep`, `ActiveDispatchAttempt`,
+wrapped `DispatchAttempt`. CLI maps a subset to stable codes; the board paints
+`Display` on the chrome row (stale-undo is reordered reason-first so a clipped row
+keeps the meaning).
+
+## Extension points
+
+New human-status values need serde aliases if old names exist, queue `status_rank`,
+glyphs in `render::status_glyph`, CLI list groups, and site/demo updates. New
+event kinds need a `TaskEventKind` variant. Bumping `STORE_FORMAT_VERSION` is a
+store concern: keep `LEGACY_STORE_FORMAT_VERSION` at 1.

--- a/docs/technical/entry-points.md
+++ b/docs/technical/entry-points.md
@@ -1,0 +1,97 @@
+# Entry points
+
+Every way a process starts, plus env vars and herdr hooks. Verified against
+`src/main.rs`, `src/cli/router.rs`, `src/app.rs`, `src/store.rs`, `src/config.rs`,
+`src/context.rs`, `herdr-plugin.toml`, and `scripts/`.
+
+## Binary: `tsk`
+
+`[[bin]] name = "tsk"` → `src/main.rs`. After argv0, `cli::router::route(args, TSK_MODE)`
+selects a `Surface`.
+
+| Surface | How selected | Behavior |
+| --- | --- | --- |
+| `Board` | default (no subcommand, no global flag, `TSK_MODE` unset) | TUI board (`tsk_tui::run`) |
+| `Capture` | positional `capture`, or `TSK_MODE=capture` with no subcommand | TUI capture form; exits after save/cancel |
+| `Add` | positional `add` | `cli::run_with` |
+| `Steps` | positional `steps` | `cli::run_with` |
+| `List` | positional `list` | `cli::run_with` |
+| `FindBoardPane` | `--find-board-pane` before any positional | read stdin pane-list JSON, print pane id |
+| `GlobalHelp` | `--help` before any positional | usage + command list, exit 0 |
+| `Usage` | unknown positional, unknown flag, or global flag combined with anything else | stderr usage, exit 2 |
+
+Global flags are a **closed set**: `--find-board-pane` and `--help`, and only before
+the first positional. `tsk add -t capture` stays `Add`. A second global flag is usage.
+
+Library entry used by the TUI surfaces: `tsk_tui::run` → `app::run`
+(`src/lib.rs`, `src/app.rs`). `--find-board-pane` is handled in `main` before that.
+
+Headless stdout/stderr/exit are `CliOutput { stdout, stderr, code }` written by `main`.
+A TUI error prints `tsk: {err}` and exits 1.
+
+## CLI commands
+
+Full mechanism: [cli](cli.md). Help text in `src/cli/presenter.rs` is the user-facing
+contract; this table is the maintainer index.
+
+| Command | Mutations | Notable flags |
+| --- | --- | --- |
+| `tsk add` | yes, unless idempotent existing | `-t/--title`, `-n/--notes`, `-p/--project`, `--desk`, `--thread`, `--json`, `--file`, `--state-dir`, `--help` |
+| `tsk list` | no | optional task UUID, `-p/--project`, `--desk`, `--all`, `--thread`, `--done`, `--deleted`, `--json`, `--state-dir`, `--help` |
+| `tsk steps` | yes on success | `<task-id> add <text>` \| `toggle <step-short-id>`, `--state-dir`, `--help` |
+
+`--desk` is the flag (not `--global`). `--project` / `--state-dir` / `--file` values
+that start with `-` need `--flag=value`.
+
+Exit codes: [invariants](invariants.md#cli) and `CONTEXT.md` (“exit contract”).
+
+## Environment
+
+| Variable | Read by | Default / fallback |
+| --- | --- | --- |
+| `TSK_STATE_DIR` | `store::default_state_dir` | `$HOME/.tsk`; empty falls through; last resort `.tsk-state` (relative) |
+| `TSK_CONFIG_DIR` | `config::default_config_dir` | `$HOME/.tsk`; empty falls through; last resort `.tsk-config` |
+| `TSK_MODE` | `cli::router` (as `capture_env`) and `app::MODE_ENV` | unset → board. `capture` (case-insensitive) → capture TUI when no subcommand |
+| `HERDR_PLUGIN_CONTEXT_JSON` | `context::RawHostContext::from_env` | missing/malformed → empty snapshot |
+| `HERDR_PLUGIN_STATE_DIR` | **ignored** | — |
+| `HERDR_PLUGIN_CONFIG_DIR` | **ignored** | — |
+| `HOME` | state/config dir resolution | if empty/missing, relative last-resort dirs |
+| `TSK_BIN` | `scripts/open-board.sh` only | `$script_dir/../target/release/tsk`. `open-capture.sh` does not read it. |
+| `HERDR_BIN_PATH` | launcher scripts | `herdr` on PATH |
+
+`HERDR_ENV=1` is an operator convention for live herdr smoke (`AGENTS.md`); the binary
+does not read it.
+
+## herdr plugin
+
+`herdr-plugin.toml`:
+
+- id / name `herdr-tsk`, version `0.3.0`, `min_herdr_version = "0.7.5"`, platforms
+  linux + macos
+- `[[build]]` `cargo build --release`
+- `[[panes]]` id `board`, title `tsk` (**must** equal `BOARD_PANE_LABEL`), placement
+  `split`, command `./target/release/tsk`
+- actions: `open-board` → `scripts/open-board.sh`; `quick-capture` →
+  `scripts/open-capture.sh`
+
+A running pane keeps the old binary until it is quit.
+
+## Scripts
+
+| Script | Role |
+| --- | --- |
+| `scripts/open-board.sh` | Idempotent open-or-focus: `pane list` → `tsk --find-board-pane` → `plugin pane focus` or `plugin pane open --entrypoint board --placement split --focus` |
+| `scripts/open-capture.sh` | Overlay the board entrypoint with `--env TSK_MODE=capture` |
+| `scripts/tsk-cli.sh` | Operator helper around the CLI (not the TUI loop) |
+
+## Site (separate process)
+
+Astro app in `site/`. Production: `https://tsk-gules.vercel.app` (Vercel root
+directory `site`). Dev: `npm run dev` in `site/`. Not loaded by `tsk`. See
+[site](site.md).
+
+## Tests as drivers (not product entry points)
+
+Integration tests under `tests/` construct `TaskStore` / `BoardModel` / `cli::run_with`
+directly. Golden fixtures: `tests/fixtures/queue_board/*.txt`, regenerated with
+`cargo test --test queue_board_render regenerate_golden_fixtures -- --ignored`.

--- a/docs/technical/invariants.md
+++ b/docs/technical/invariants.md
@@ -1,0 +1,182 @@
+# Invariants
+
+Rules a maintainer must not break. Each rule names why it holds, what enforces it, and
+what fails if it is violated. Subsystem pages restate the subset they own.
+
+## Domain
+
+1. **Human status is the only progress authority.** `HumanStatus` on `Task` is what the
+   board and CLI show. `last_observed`, capsule, and agent meta never drive `set_status`,
+   `complete`, or `reopen`. Completing every step never completes the task
+   (`DomainState::toggle_step` journals `StepChecked` / `StepUnchecked` only).
+   *Breaks:* an agent observation or a full checklist silently marks work done.
+
+2. **Create and edit refuse empty titles.** Title is trimmed; whitespace-only is
+   `DomainError::EmptyTitle` and adds no task. CLI additionally refuses any C0 control
+   (`invalid-title`) *before* trim, including a control-only title.
+   *Enforced by:* `DomainState::create` / `edit`; `cli::add::has_c0_control`.
+
+3. **Soft-delete keeps the row in the store.** `get` still finds it. Views and `list`
+   (without `--deleted`) hide it. Undo of soft-delete is `restore`.
+   *Breaks:* a hard delete that drops history, or a view that paints deleted rows as live.
+
+4. **Every semantic mutation refreshes `revision` and appends history.** `record_mutation`
+   stamps a new v4 revision, `updated_at`, and a `TaskEvent`. Create is the one path that
+   writes `Created` without going through `record_mutation` (it still assigns a revision).
+   *Breaks:* two writers can no longer revision-guard the same task.
+
+5. **`merge_base_revision` is save intent, never durable.** It is set on mutation, used
+   under the store lock, and cleared after a successful replace (`clear_merge_bases`).
+   Serde keeps the field so an in-memory clone can round-trip during a failed save; a
+   successful write must not retain it.
+   *Enforced by:* `TaskStore::save` / `reload_merge_save` / `locked_transition*`.
+
+6. **Legacy missing revision is a nil UUID base, not a real revision.**
+   `LEGACY_MERGE_BASE_REVISION = Uuid::nil()`. UUID v4 revisions never equal nil. A
+   first mutation of a pre-revision task is accepted against a disk copy that still has
+   `revision: null`.
+   *Breaks:* first edit of an old task spuriously conflicts, or a nil revision is
+   persisted as if it were assigned.
+
+7. **Undo is LIFO, revision-guarded, and a no-op on an empty stack.** Only `complete` and
+   `soft_delete` push. A stale or legacy (no `expected_revision`) entry is *retained* and
+   returns `StaleUndo` — a refused undo must not expose an older entry.
+   *Enforced by:* `DomainState::undo` in `src/domain/undo.rs`.
+
+8. **A task owns at most one active dispatch attempt.** `start_dispatch_attempt` refuses
+   `ActiveDispatchAttempt`. Completed / fully-cleaned attempts are removed from
+   `DomainState`, not kept as history. Disk owns attempt lifecycle under the lock: a
+   stale in-memory copy must not recreate an attempt disk already dropped
+   (`merge_attempts_for_save` retains only ids still on disk).
+
+9. **Steps are a flat ordered list.** One level, stable ids, no reordering by a verb.
+   Old stores name the field `checklist`; new writes use `steps` only. Notes markdown
+   `- [ ]` stays literal text (ADR-0001).
+
+10. **A thread is a normalized name, not an entity.** No thread id, status, or lifecycle.
+    Identity is the name. The field persists on the task regardless of status (ADR-0002).
+    **Threads tab** groups any non-done, non-deleted task that carries the name
+    (including `started`). **Scoped ON DECK headers** group *open* tasks only
+    (ready / blocked / review): a thread whose remaining work is all started has
+    no ON DECK header (those rows live in IN MOTION).
+    `normalize_thread`: ASCII alphanumerics and hyphens, first char alphanumeric, ≤32
+    chars, stored lowercase.
+
+11. **`TaskScope::Global` serializes as `"global"` and displays as desk.** Do not rename
+    either without a store migration.
+
+12. **`STORE_FORMAT_VERSION` is 1.** Missing `format_version` loads as
+    `LEGACY_STORE_FORMAT_VERSION` (also 1). That legacy constant **must stay 1** when
+    the current constant is later bumped, so old files still decode. Newer documents
+    are refused, not rewritten (`StoreError::UnsupportedFormat`).
+
+## Persistence
+
+13. **One board directory.** `TSK_STATE_DIR` else `$HOME/.tsk` else relative `.tsk-state`.
+    Empty env values fall through. `HERDR_PLUGIN_STATE_DIR` is ignored. Config mirrors
+    this with `TSK_CONFIG_DIR` / `.tsk-config`. Never fall back to `std::env::temp_dir()`.
+
+14. **Exclusive lock on `tsk.json.lock` covers load-modify-save.** `File::lock` / unlock
+    on drop. Orphan `.tsk.json.tmp.*` sweep runs only under that lock.
+
+15. **Atomic replace is temp + fsync + rename + directory fsync.** Unique temp
+    (`.tsk.json.tmp.{pid}.{nanos}`). Success retains the previous live file as
+    `tsk.json.1` via hard-link *before* replace. A corrupt live JSON must not overwrite
+    that backup.
+
+16. **Idle merge is disk-wins on revision mismatch, and must not move the user's place.**
+    `merge_tasks_from_disk` replaces a task when revisions differ (no wall-clock).
+    `BoardModel::sync_from_domain` never changes the home tab or selection for tasks
+    merged in from disk, except an otherwise-empty view surfacing the first arriving
+    task. A save this surface just made pins selection only when the current lens
+    paints that task; otherwise it reanchors near the saved task's old position.
+
+17. **Config writes are not the store.** Walkthrough and settings copy the temp+rename
+    shape but **do not** lock or fsync the directory. A crash can lose a just-recorded
+    dismissal (walkthrough reappears once). The walkthrough payload is a constant, so
+    two writers producing the same bytes are harmless. Do not reuse this code for a
+    varying payload.
+
+## Board session
+
+18. **Selection rests only on a row the current lens paints.** Collapse counts as
+    invisibility. `seed_selection` and reanchor fallbacks must never pin a collapsed
+    or out-of-lens task. Thread headers consume row budget but are not selectable or
+    hit-testable (ADR-0003). `task_ids` in a deck section is the concatenation of
+    thread blocks then loose unthreaded ids, in paint order.
+
+19. **A form and its input mode outlive the save call.** Never clear the form or switch
+    mode before the persistence boundary confirms. A cancelled failed save otherwise
+    leaves an edit mode with no form, which no key can escape.
+
+20. **Save-recovery keys reach Retry/Cancel even if a form is allocated.**
+    `board_keyboard_intent` is an *allowlist* of form-field modes. `SaveRecovery`,
+    palette, help, and other surfaces that outrank the form must not be swallowed by
+    `map_board_form_key`. `r` / `c` / Esc are the recovery chords.
+
+21. **Anything painted on the status-row slot hides `status_message` while it is up.**
+    Quick-add owns its refusals and clears them on close. Otherwise the message is
+    invisible during the overlay and leaks onto the board afterwards.
+
+22. **Mutating verbs need the configured modifier** (`VerbModifier::Alt` default, `Ctrl`
+    if flipped in the palette / `settings.json`). Bare `space` `d` `o` `b` `e` `n` `x`
+    `u` `q` do nothing. Nav, peek, `Enter`, `P`, `1`/`2`/`3`, `z`, `:`, `?`, `+`, `Esc`
+    stay bare.
+
+23. **Quick-add is the only board create path.** There is no inline board capture form.
+    Success has no status message; the row flash is the feedback. `!p` / `!t` tokens
+    are stripped from the saved title.
+
+24. **Task page is view-first.** Only modifier `e` / `n` / Tab enter edit, except a
+    quick-add draft expanded with `Tab`, which opens straight into Notes edit. The
+    scope footer is inert until an edit has started. Field regions are inert to click
+    in `TaskPage` until an edit state is already open.
+
+25. **Text wraps, never truncates.** One engine (`ui::edit::wrap_text`, word-boundary,
+    display-cell measured) feeds notes, task-page titles, list rows, quick-add, capture
+    Notes, and peek. Task-page notes wrap at `row_width - 6`. The capped task-page
+    header and the verb bar's tier-budget ellipsis are chrome limits, not task text.
+    `escaped_draft_rows` remains only for single-line Title/Thread editors.
+
+26. **One definition of a line break:** `\r\n`, lone `\n`, or lone `\r`
+    (`ui::split_line_breaks`). Presenters, paste flattening, and line movement must
+    agree. A CRLF paste is stored verbatim; a presenter that only knew `\n` would
+    leave `\u{000d}` on every line.
+
+27. **Control characters never paint as controls.** `ui::terminal_text` turns C0/C1
+    into `\u{00xx}` escapes. Notes markdown is view/peek only; edit is raw source.
+    Peek paints the same markers then dims every span.
+
+28. **Mono modifiers only.** `ui::render::MONO_MODIFIERS`. No color theme module.
+    Tests assert buffers have no SGR color.
+
+29. **Frame loop is settle → paint → wait.** `board_frame` owns that order so an idle
+    poll cannot skip settle. Idle merge is skipped while save recovery is pending
+    (reloading disk would replace the working snapshot being retried). A failed
+    `store.load` during watch must *not* advance `StoreWatch::last_seen`.
+
+30. **Walkthrough dismissal is presented, never propagated.** A write failure stays on
+    the chrome row; the board stays open. Unreadable `walkthrough.json` reads as not
+    dismissed (fail toward showing the card, never toward keeping the board shut).
+
+## CLI
+
+31. **Closed global-flag set.** Only `--find-board-pane` and `--help`, and only before
+    the first positional. Anything else before a subcommand is usage (exit 2).
+
+32. **Exit contract.** `0` success (add: every item created or already existed). `1`
+    item refusal (retry only the failed subset). `2` usage/parse (nothing persisted).
+    `3` store I/O (commit indeterminate; verify with `list` before retry). Flag-add
+    idempotency key is trimmed title + resolved scope + normalized thread among
+    non-soft-deleted tasks.
+
+33. **`--state-dir` is the test/ops override** for a single invocation; it does not
+    change the process-wide default used by the TUI unless `TSK_STATE_DIR` is set.
+
+## Plugin
+
+34. **Pane identity is the label `tsk`, exact.** `board_pane::BOARD_PANE_LABEL` must
+    equal `herdr-plugin.toml` `[[panes]] title`. Terminal title is not identity (a
+    standalone `tsk` in some other pane can show the same title). Pane ids passed to
+    `plugin pane focus` must be flag-safe: non-empty, not start with `-`,
+    `[A-Za-z0-9_.:-]+`.

--- a/docs/technical/plugin.md
+++ b/docs/technical/plugin.md
@@ -1,0 +1,84 @@
+# Plugin / host
+
+**Responsibility.** Ship tsk as herdr plugin `herdr-tsk`: manifest, pane identity,
+idempotent open-or-focus, overlay capture. The plugin does **not** own the store
+location.
+
+**Public surface.** `herdr-plugin.toml`; `scripts/open-board.sh`,
+`open-capture.sh`, `tsk-cli.sh`; `board_pane::{BOARD_PANE_LABEL,
+find_board_pane_from_stdin, find_board_pane_id}`.
+
+## How it works
+
+Manifest (`herdr-plugin.toml`):
+
+- `id` / `name`: `herdr-tsk`, version `0.3.0` (same as crate `tsk-tui`)
+- `min_herdr_version`: `0.7.5`
+- platforms: linux, macos
+- build: `cargo build --release`
+- pane: id `board`, title `tsk`, placement `split`, command
+  `./target/release/tsk`
+- actions: `open-board` → `scripts/open-board.sh`; `quick-capture` →
+  `scripts/open-capture.sh`
+
+Pane **title** `tsk` is the identity string. It must equal
+`board_pane::BOARD_PANE_LABEL` (`"tsk"`). The painted board heading
+`BOARD_TITLE` is `"Tasks"` — a different string. Matching on terminal title would
+false-positive a standalone `tsk` in some other pane.
+
+### Open-or-focus
+
+`open-board.sh`:
+
+1. `$HERDR_BIN_PATH` else `herdr`; board binary `$TSK_BIN` else
+   `scripts/../target/release/tsk` (`open-capture.sh` does not read `TSK_BIN`).
+2. `pane list` JSON piped to `tsk --find-board-pane`.
+3. If a flag-safe id comes back, `plugin pane focus`; on failure (stale list),
+   fall through so the keypress is never a silent no-op.
+4. Else `plugin pane open --plugin herdr-tsk --entrypoint board --placement split --focus`.
+
+`--find-board-pane` is Rust so the launcher does not depend on python3. Pane ids
+must be non-empty, not start with `-`, and match `[A-Za-z0-9_.:-]+`.
+
+### Quick capture
+
+`open-capture.sh` opens the **same** `board` entrypoint as an **overlay** with
+`--env TSK_MODE=capture`. Short-lived; board focus idempotency is not this
+script's job.
+
+### `tsk-cli.sh`
+
+Looks up the enabled `herdr-tsk` `plugin_root` from `herdr plugin list --json`
+(via python3) and execs `$plugin_root/target/release/tsk` with the remaining
+argv. Missing binary → exit 127. Agents get the same `~/.tsk` as the pane with
+no extra state plumbing.
+
+### Context injection
+
+herdr injects `HERDR_PLUGIN_CONTEXT_JSON` (used) and `HERDR_PLUGIN_STATE_DIR` /
+`HERDR_PLUGIN_CONFIG_DIR` (ignored). One board everywhere: [store](store.md),
+[context](context.md).
+
+This tree has no host attention poll, no pane-link verbs, and no dispatch
+recovery. `HostPorts` / dispatch modules in stale `target/doc/herdr_tasks/` are
+from a previous crate name; they are not in `src/` now.
+
+## Invariants
+
+[Invariants](invariants.md) §34. Rebuild `target/release/tsk` before live smoke;
+a running pane keeps the old binary until quit. Do not `herdr plugin link` a
+worktree over the owner's daily Tasks link unless asked (`AGENTS.local.md`).
+
+## Error paths
+
+- No matching pane: `find_board_pane_id` → `None`; binary `--find-board-pane`
+  exits 1 with no stdout. The shell script then opens a new pane.
+- Unparseable pane-list JSON: `None` (not a panic).
+- Unsafe pane ids skipped until a safe one, or none.
+- `tsk-cli.sh` without an enabled plugin: python `SystemExit`.
+
+## Extension points
+
+New actions: a `[[actions]]` row plus a script. New panes: title must match a
+label constant if `--find-board-pane` should see them. Do not parse pane-list
+JSON in bash.

--- a/docs/technical/reference.md
+++ b/docs/technical/reference.md
@@ -1,0 +1,80 @@
+# Symbol reference
+
+## Strategy
+
+**Generated rustdoc for every `pub` item. Hand-written pages for why, invariants, and
+load-bearing privates.**
+
+The crate is an unpublished library (`publish = false`) plus a binary. Integration
+tests and `src/main.rs` consume `pub` modules. There are hundreds of public items
+(types, functions, consts). Hand-transcribing signatures would drift; rustdoc will not
+write architecture.
+
+Public-symbol rows in [coverage.md](coverage.md) close as **generated (rustdoc)**.
+
+### Generate
+
+From the repo root, with the pinned toolchain (`rust-toolchain.toml` → 1.96.0):
+
+```bash
+cargo doc --no-deps --package tsk-tui
+```
+
+Output: `target/doc/tsk_tui/index.html` (gitignored). Open with
+`cargo doc --no-deps --package tsk-tui --open`.
+
+`--document-private-items` additionally emits `pub(crate)` / private items. The
+load-bearing subset of those is listed below so a maintainer does not have to generate
+privates to learn the rules.
+
+This command is **not** on the green bar and **not** in CI. Adding it is an
+owner-approved change, not a docs default.
+
+Crate-level rustdoc lives on `src/lib.rs` (`//! tsk library root.`) and module `//!`
+comments. Prefer deepening those comments when a public item's *signature* docs are
+thin; do not fork a second hand-written API book.
+
+## Load-bearing internals
+
+Private or `pub(crate)` items that carry an invariant rustdoc-on-publics would miss.
+Mechanism belongs on the subsystem page; this is the index.
+
+| Item | Visibility | Why it is load-bearing | Page |
+| --- | --- | --- | --- |
+| `ui::terminal_text` | `pub(crate)` | C0/C1 never paint as controls | [security](security-model.md), [board UI](board-ui.md) |
+| `ui::split_line_breaks` | `pub(crate)` | One definition of `\r\n` / `\n` / `\r` | [invariants](invariants.md) §26 |
+| `ui::present_line` / `present_lines` | `pub(crate)` | Width-bounded paint + overflow marker | [board UI](board-ui.md) |
+| `ui::edit::wrap_text` | `pub(crate)` | The one wrap engine (word-boundary, display cells) | [invariants](invariants.md) §25 |
+| `ui::edit::EditBuffer` | `pub(crate)` | Cursor in Unicode scalars; shared Title/Notes/Thread/step drafts | [board UI](board-ui.md) |
+| `ui::edit::flatten_line_breaks` | `pub(crate)` | Paste flattening uses the same break definition | [board UI](board-ui.md) |
+| `ui::edit::escaped_draft_rows` | `pub(crate)` | Single-line editors only; do not reuse for wrapping notes | [invariants](invariants.md) §25 |
+| `BoardForm` / `BoardFormBinding` | `pub(super)` | Task id XOR capture snapshot for the form's lifetime | [board UI](board-ui.md) |
+| `board_keyboard_intent` form allowlist | private in `app` | Save-recovery `r`/`c`/Esc must outrank an allocated form | [app](app.md) |
+| `DomainState::merge_for_save` | `pub(crate)` | Revision guard under the store lock | [domain](domain.md), [store](store.md) |
+| `LEGACY_MERGE_BASE_REVISION` | private | Nil UUID base for pre-revision tasks | [invariants](invariants.md) §6 |
+| `DomainState::stamp_format_version` / `clear_merge_bases` | `pub(crate)` | Must run on every successful replace | [store](store.md) |
+| `time_serde` | private module | Wire times as `[secs, nanos]` | [data model](data-model.md) |
+| `text::non_empty` | `pub(crate)` | Trim + reject empty host strings without allocating | [context](context.md) |
+| `StoreWatch::{poll,record}` | private | Failed idle load must not mark the watch caught up | [app](app.md) |
+| `config::resolve_config_dir` | private | Empty `TSK_CONFIG_DIR` must not resolve to `""` | [config](config.md) |
+| `AtomicFilesystem` | private trait | Lets tests fail a write stage without weakening production | [store](store.md) |
+
+### `wrap_text`
+
+```text
+ui::edit::wrap_text(value: &str, width: usize) -> Vec<WrappedRow>
+```
+
+Splits on `split_line_breaks` first, then wraps each logical line to at most `width`
+**display cells** (ratatui `Line::width`), preferring the last whitespace on the row.
+A run with no whitespace (or a single character wider than the allocation) hard-breaks
+at the cell edge. `width == 0` yields no rows. This is the engine named in
+`AGENTS.md`; list rows, notes, peek, capture Notes, and task-page titles all go through
+it.
+
+### Form binding
+
+`BoardFormBinding::Task(Uuid)` and `BoardFormBinding::Capture(Box<Option<InvocationSnapshot>>)`
+are mutually exclusive by construction. A capture form cannot acquire a selected-task
+id; a task form cannot reload invocation snapshot under its drafts. Clearing the form
+before `reload_merge_save` returns is the failure mode invariant 19 exists to prevent.

--- a/docs/technical/security-model.md
+++ b/docs/technical/security-model.md
@@ -1,0 +1,89 @@
+# Security model
+
+tsk is a single-user local tool. There is no authentication, no network API, and no
+multi-tenant boundary. The trust questions that remain are: what input is untrusted,
+what the process will execute, and what fails open vs closed.
+
+## Trust boundaries
+
+| Surface | Trust | Enforcement |
+| --- | --- | --- |
+| `tsk.json` on disk | Trusted as the user's own file, untrusted as *terminal content* | JSON parse; newer `format_version` refused; titles/notes escaped at paint |
+| `settings.json` / `walkthrough.json` | Same | Malformed → safe defaults (Alt modifier / not dismissed) |
+| `HERDR_PLUGIN_CONTEXT_JSON` | Untrusted structured input from the host | serde; unknown keys ignored; missing/malformed → empty snapshot; no field invented |
+| herdr `pane list` JSON on stdin | Untrusted | Must parse; label must equal `tsk`; pane id must be flag-safe before it is passed to another CLI |
+| Task title, notes, thread, step text, project path | Untrusted display strings | `ui::terminal_text` (C0/C1 → `\u{00xx}`); wrap rather than clip; markdown is a styled subset with no color and no raw control passthrough |
+| CLI argv and plan JSON | Untrusted | Closed flag sets; plan must be an array of objects; C0 in titles/step text refused |
+| OSC 52 clipboard (`copy_to_clipboard`) | Local terminal | Payload capped (`COPY_MAX_CHARS` = 100_000); still a terminal feature, not a sandbox |
+
+The host (herdr) is trusted to spawn the binary and inject context, **not** to choose
+the state directory. Injected `HERDR_PLUGIN_STATE_DIR` / `HERDR_PLUGIN_CONFIG_DIR` are
+ignored so a host cannot silently point the plugin at a different board than the CLI.
+
+## What is not trusted to change status
+
+Agent identity (`AgentMeta`), host observations (`ObservedStatus`), and dispatch-attempt
+phase are **not** authorities. Human verbs (and the CLI commands that wrap the same
+domain functions) are. Auto-complete from agent status is forbidden.
+
+## Fail closed
+
+- Newer store `format_version` than this binary: refuse load/save
+  (`StoreError::UnsupportedFormat`). Do not rewrite the file.
+- Concurrent same-task mutation: `merge_for_save` returns a typed failure; disk is not
+  overwritten.
+- Empty / whitespace title, empty step text, invalid thread shape: no durable write.
+- CLI usage/parse errors: exit 2, nothing persisted.
+- `--find-board-pane`: pane ids that start with `-`, contain spaces, or fall outside
+  `[A-Za-z0-9_.:-]+` are skipped so they cannot be parsed as flags by
+  `herdr plugin pane focus`.
+- Unknown global flags: usage, not a best-effort board open.
+
+## Fail open (deliberate)
+
+- Missing `tsk.json`: empty board (first run).
+- Unreadable / malformed `walkthrough.json`: treat as not dismissed. A broken config
+  location must not keep the board shut (and must not pretend the card was skipped).
+- Walkthrough / settings write failure: present on the chrome row, keep the board
+  running.
+- Malformed `HERDR_PLUGIN_CONTEXT_JSON`: empty snapshot, default scope from cwd-walk
+  or desk.
+- Failed idle `store.load`: do not advance `StoreWatch`; retry next tick. Do not treat
+  the failed read as “caught up”.
+- `HERDR_PLUGIN_CONTEXT_JSON` selected text used as title prefill: still escaped at
+  paint; provenance becomes `selection`.
+
+Config's lack of lock/directory-fsync is a durability trade, not an access-control
+trade. Anyone who can write `~/.tsk` can change the board; that is the single-user
+model.
+
+## Process and host
+
+- Plugin actions are explicit (`open-board`, `quick-capture`). No background host
+  poll in this tree.
+- `scripts/open-board.sh` shells out to `$HERDR_BIN_PATH` (else `herdr` on PATH) and
+  `./target/release/tsk` (override `TSK_BIN`). It does not eval pane-list JSON in the
+  shell; it pipes JSON to `tsk --find-board-pane`.
+- Capture overlay sets `TSK_MODE=capture` via herdr `--env`; it does not inherit a
+  second state dir.
+
+## Display injection
+
+The terminal is the dangerous output. Two layers:
+
+1. **Escape.** `terminal_text` / `present_line` / `present_lines` so a title containing
+   ESC, BEL, or C1 cannot drive the emulator. Line breaks are the only control
+   consumed rather than escaped, and only through `split_line_breaks`.
+2. **Markdown subset** (view/peek only): `**bold**`, `*em*`/`_em_` (underline),
+   `` `code` `` (dim, ticks kept), `#`–`######`, `-`/`*` lists, fenced ` ``` `
+   (no inline inside). Unmatched `*` and word-internal `_` stay literal. No HTML, no
+   links-as-commands, no color.
+
+Clipboard copy uses OSC 52 (`ui::text_select::osc52_clipboard`). Treat that as “user
+copied from their own board”, not as a network exfil boundary.
+
+## Secrets
+
+tsk does not handle API keys or credentials. Do not add a path that logs
+`HERDR_PLUGIN_CONTEXT_JSON` (it may contain selected source) or that writes store
+contents to a shared temp directory.

--- a/docs/technical/site.md
+++ b/docs/technical/site.md
@@ -1,0 +1,55 @@
+# Site
+
+**Responsibility.** Marketing landing page and operator docs. Astro 7 + Starlight
+0.41 in `site/`. **Not** packaged into the `tsk` binary. `cargo build` ignores it.
+
+**Public surface (product, not rustdoc).** Production
+https://tsk-gules.vercel.app. Vercel root directory `site`. `site/vercel.json`
+pins `npm ci`, `npm run build`, output `dist`, framework `astro`, and
+`ignoreCommand` so a commit that does not touch `site/**` skips the deploy.
+
+## How it works
+
+| Path | Role |
+| --- | --- |
+| `src/pages/index.astro` | Custom homepage (not the Starlight index) |
+| `src/pages/privacy.astro`, `terms.astro` | Legal pages |
+| `src/content/docs/docs/` | User guide (Starlight): install, board, keys, capture, task page, steps, CLI |
+| `src/content/docs/404.md` | Docs 404 |
+| `public/board-demo.js`, `capture.js`, `landing.js`, `theme.js` | Interactive demo + chrome |
+| `src/styles/landing.css`, `starlight.css` | Page styles |
+| `src/components/ThemeSelect.astro` | Starlight `ThemeSelect` slot (`astro.config.mjs`) |
+| `src/components/Wordmark.astro` | Landing/legal pages only (not a Starlight override) |
+| `scripts/generate-apple-touch.mjs` | Apple touch icons; run before `dev`/`build` |
+| `test/site.test.mjs` | `node --test` |
+
+Site config (`astro.config.mjs`): `site: 'https://tsk-gules.vercel.app'`, sitemap,
+Starlight title `tsk`, GitHub edit links under `.../edit/main/site/`, sidebar
+Overview / Install / Board / Keys / Capture / CLI. Default theme script prefers
+dark (`tsk-theme` / `starlight-theme` in localStorage).
+
+CI: `.github/workflows/site.yml` runs `npm ci && npm test && npm run build` in
+`site/`. The Rust workflow `paths-ignore`s `site/**`.
+
+The web board demo uses **bare** verb keys. Browsers steal Alt-chords; matching
+the TUI's modifier requirement would make the demo inoperable. When keymap,
+status verbs, or tab/section semantics change, update
+`site/src/content/docs/docs/{keys,board,capture,cli}.md` **and**
+`public/board-demo.js` together.
+
+## Invariants
+
+- Do not fold this tree into the Rust crate or the green-bar `cargo test`.
+- Do not “fix” demo keys to require Alt.
+- `node_modules/` and `dist/` are generated (excluded from the coverage ledger).
+
+## Error paths
+
+Site tests fail the site workflow only. A docs typo cannot break `tsk`. A missed
+`board-demo.js` update ships a demo that lies about the board.
+
+## Extension points
+
+New operator pages: add a Starlight markdown file and a sidebar entry. New
+landing sections: `index.astro` + `landing.css` + `landing.js`. Keep the binary
+and the site's claims aligned by the dual update rule above.

--- a/docs/technical/store.md
+++ b/docs/technical/store.md
@@ -21,9 +21,11 @@ Lock: `tsk.json.lock` (`OpenOptions` create/read/write, `File::lock()`, unlock o
 else peek `format_version` (missing → 1), refuse if `found > STORE_FORMAT_VERSION`,
 then serde.
 
-**Save.** Lock, clone, `clear_merge_bases`, `stamp_format_version`, then unlocked
-write. Prefer `reload_merge_save` when another process may have written since this
-snapshot was loaded (board + capture).
+**Save.** Takes the exclusive lock, clones, `clear_merge_bases`,
+`stamp_format_version`, then writes while that lock is still held
+(`save_unlocked` is the helper that assumes the caller already locked). Prefer
+`reload_merge_save` when another process may have written since this snapshot
+was loaded (board + capture).
 
 **`reload_merge_save`.** Lock, load disk, `check_format_version`, `merge_for_save`
 (local mutations kept only if disk still has their merge base; siblings merged in;

--- a/docs/technical/store.md
+++ b/docs/technical/store.md
@@ -1,0 +1,69 @@
+# Store
+
+**Responsibility.** Durable `DomainState` as pretty-printed JSON in one directory.
+Atomic replace, exclusive inter-process lock, format-version gate, last-good backup.
+Does not interpret human status.
+
+**Public surface.** `TaskStore`, `TaskStateStore`, `StoreError`, `default_state_dir`.
+The trait exists so dispatch-era tests could inject save failures; production is
+`TaskStore`.
+
+## How it works
+
+`TaskStore::new` takes the **directory**, not the file. Live document: `tsk.json`.
+Lock: `tsk.json.lock` (`OpenOptions` create/read/write, `File::lock()`, unlock on
+`Drop`). Backup: `tsk.json.1`.
+
+`default_state_dir`: non-empty `TSK_STATE_DIR`, else non-empty `$HOME/.tsk`, else
+`.tsk-state`. Empty strings fall through. `HERDR_PLUGIN_STATE_DIR` is not read.
+
+**Load.** Lock, sweep orphan `.tsk.json.tmp.*`, missing file → `DomainState::new()`,
+else peek `format_version` (missing → 1), refuse if `found > STORE_FORMAT_VERSION`,
+then serde.
+
+**Save.** Lock, clone, `clear_merge_bases`, `stamp_format_version`, then unlocked
+write. Prefer `reload_merge_save` when another process may have written since this
+snapshot was loaded (board + capture).
+
+**`reload_merge_save`.** Lock, load disk, `check_format_version`, `merge_for_save`
+(local mutations kept only if disk still has their merge base; siblings merged in;
+attempts that vanished on disk are dropped), write a clone with bases cleared, then
+clear bases on the caller's state. On any write-stage failure the caller's merge
+bases stay set so [save recovery](app.md#save-recovery) retries the same intent.
+
+**`locked_transition` / `locked_transition_if_changed`.** Load → closure → optional
+save under one lock. CLI add/steps use `if_changed` so an idempotent existing match
+does not rewrite the file.
+
+**Atomic write.** Unique temp `.tsk.json.tmp.{pid}.{nanos}` in the same directory
+(so rename is atomic on the same filesystem). Write, `sync_file`, rename over
+`tsk.json`, `sync_directory` (Linux/macOS; other OS: no-op). Failure unlinks the
+temp. Before replacing a *valid* live file, `retain_last_good` hard-links it to
+`tsk.json.1` (remove old backup first). A live file that fails JSON parse is
+replaced without touching the backup — a corrupt live document must not clobber
+last-good.
+
+`AtomicFilesystem` is a private trait so tests can fail create/write/sync/rename
+independently. Production is `StdFilesystem`.
+
+## Invariants
+
+[Invariants](invariants.md) §§12–16. Additional:
+
+- Sweep temps only under the exclusive lock (a concurrent writer's in-flight temp
+  must not be deleted).
+- Never fall back to `std::env::temp_dir()` for the state directory.
+- Peek format version before full serde so an unsupported newer document is a typed
+  error, not a confusing serde failure.
+
+## Error paths
+
+`StoreError::Io`, `StoreError::Json`, `StoreError::UnsupportedFormat { found, supported }`.
+CLI maps store errors to exit 3. Board save maps them into `SaveRecovery`.
+
+## Extension points
+
+A format bump: increment `STORE_FORMAT_VERSION`, keep `LEGACY_STORE_FORMAT_VERSION`
+at 1, teach serde defaults/aliases for new fields, never rewrite a newer file. A
+second document (index, attachments) is a new filename beside `tsk.json`, not a
+silent new meaning for this one.

--- a/site/README.md
+++ b/site/README.md
@@ -1,8 +1,10 @@
 # tsk site
 
-Marketing page and docs for tsk. Lives in this repo as `site/` — same split as
-[herdr's `website/`](https://github.com/herdrdev/herdr/tree/master/website).
+Marketing page and **user guide** for tsk. Lives in this repo as `site/` — same
+split as [herdr's `website/`](https://github.com/herdrdev/herdr/tree/master/website).
 Astro + Starlight; the homepage is a custom page, not the Starlight index.
+How-to pages are `src/content/docs/docs/`. Maintainer internals stay in
+`docs/technical/` at the repo root.
 
 This directory is **not** part of the `tsk` binary. `cargo build` ignores it.
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -41,6 +41,8 @@ export default defineConfig({
             { label: 'Board', slug: 'docs/board' },
             { label: 'Keys', slug: 'docs/keys' },
             { label: 'Capture', slug: 'docs/capture' },
+            { label: 'Task page', slug: 'docs/task-page' },
+            { label: 'Steps', slug: 'docs/steps' },
             { label: 'CLI', slug: 'docs/cli' },
           ],
         },

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,0 +1,17 @@
+# tsk
+
+> A task board for your terminal. Capture work and move it through ready, started, blocked, review, done.
+
+User guide: https://tsk-gules.vercel.app/docs/
+
+- [Overview](https://tsk-gules.vercel.app/docs/)
+- [Install](https://tsk-gules.vercel.app/docs/install/)
+- [Board](https://tsk-gules.vercel.app/docs/board/)
+- [Keys](https://tsk-gules.vercel.app/docs/keys/)
+- [Capture](https://tsk-gules.vercel.app/docs/capture/)
+- [Task page](https://tsk-gules.vercel.app/docs/task-page/)
+- [Steps](https://tsk-gules.vercel.app/docs/steps/)
+- [CLI](https://tsk-gules.vercel.app/docs/cli/)
+
+Source: https://github.com/smarzban/herdr-tsk
+Maintainer internals: https://github.com/smarzban/herdr-tsk/tree/main/docs/technical

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -1,35 +1,78 @@
 ---
 title: Board
-description: Home tabs, sections, and how the list is ordered.
+description: Tabs, sections, status, peek, and the done drawer.
 ---
 
-Home is a tabbed board: **desk** · **projects** · **threads** (`1` / `2` / `3`).
+Home is a tabbed board: **desk** · **projects** · **threads**. Tabs show only at
+home (`1` / `2` / `3`). `P` opens the project picker from the keyboard.
 
-- **desk**: global IN MOTION plus desk/global ON DECK
-- **projects**: one collapsible group per project
-- **threads**: cross-project thread names with project sub-groups
+## Tabs
 
-Project focus (`P` → project) hides the tabs and paints the project name chip.
-Collapse state is session-only. Each row's dim meta includes its store-global task number as bare digits, alongside its age and project when shown.
+- **desk**: IN MOTION is every started task, from any project. ON DECK is desk
+  work that is ready, blocked, or review. Thread headers sit above those open
+  desk tasks.
+- **projects**: one collapsible group per project. Single-click a header to
+  collapse it. Double-click a header to focus that project. Inside a group:
+  started, then review, blocked, ready.
+- **threads**: thread names across projects, with collapsible project sub-groups
+  under each name. Same status order.
+
+Project focus (`P` → a project) hides the tabs and paints the project name chip
+on the right (`P ▾`). At home the chip is hidden. Collapse state is session-only.
+It does not persist.
+
+Each row's dim meta includes its store-global task number as bare digits,
+alongside its age and project when shown.
 
 ## Sections
 
 One urgency-ordered list. Sections are computed, not navigated.
 
 - **IN MOTION**: work you have started
-- **ON DECK** when project-scoped
+- **ON DECK** when you are on a project board: that project's ready, blocked, and
+  review tasks, with thread headers above their open rows
 - **z** opens the done drawer
 
-## Pane size
+Thread headers on a scoped deck show `#name` and an open count. They take a list
+row of space. They are not selectable and clicks do not land on them.
 
-| Pane | What you get |
-| --- | --- |
-| at least 78×24 | standard board |
-| smaller | compact: glyph, bare task number, and title |
-| down to 40×10 | still operable |
+Unthreaded tasks list after thread groups in the same deck.
 
 ## Human status
 
 `ready` · `started` · `blocked` · `review` · `done`
 
-Human status is the source of truth. Agents do not auto-complete tasks.
+Human status is the source of truth. Completing every step does not complete the
+task. Agents do not auto-complete work.
+
+`alt+space` starts a ready task, or reopens a done one. `alt+d` marks done.
+`alt+o` reopens. `alt+b` toggles blocked. **review** is set from the command
+palette (`:` → `set status: review`), not from a dedicated letter.
+
+## Peek and mouse
+
+`→` peeks notes under the selected row (up to five wrapped lines). `←` closes
+the peek.
+
+Click a row to peek. Click the same row again to close. A fast double-click opens
+the [task page](/docs/task-page/). The wheel scrolls the list.
+
+## Pane size
+
+| Pane | What you get |
+| --- | --- |
+| at least 78×24 | standard board: section headers, row meta, full verb legend |
+| smaller | compact: glyph, bare task number, and title; help, palette, and the task page take the full pane |
+| down to 40×10 | still operable |
+
+A typical herdr split is 78 columns, which is the standard board.
+
+## Palette and help
+
+`:` opens a searchable command palette. Type to filter. `q` is a query character
+here, not quit. Leave with `Esc`.
+
+The palette is also how you flip mutating keys from Alt to Ctrl (`verb keys: use
+ctrl`). That choice is stored in `~/.tsk/settings.json`.
+
+`?` opens the help card. Any key closes it.

--- a/site/src/content/docs/docs/capture.md
+++ b/site/src/content/docs/docs/capture.md
@@ -1,16 +1,23 @@
 ---
 title: Capture
-description: Quick-add bar and title tokens for project and thread.
+description: Quick-add on the board, title tokens, and the capture overlay.
 ---
 
 Press `+` for a one-line title on the status-row slot. The list stays visible.
 
 - `Enter` saves and closes
 - `Ctrl+Enter` saves and stays open
-- `Tab` expands onto the task page (title · notes · scope)
+- `Tab` expands onto the [task page](/docs/task-page/) (title · notes · scope)
 
 A project board defaults the draft to that project. A project-less board defaults
-to your desk. Home keeps the cwd-derived default.
+to your desk. Home keeps the cwd-derived default (the repo you opened from, or
+desk if there is no repo).
+
+A saved task becomes the selection. Success has no status message. The row flash
+is the feedback. Refusals (empty title, bad thread) paint while the line is open
+and clear when it closes.
+
+Title is required.
 
 ## Title tokens
 
@@ -23,7 +30,28 @@ from the saved title.
 | `!p name` | project by basename (case-insensitive) |
 | `!p /path` | that path verbatim |
 | `!t` | unthread |
-| `!t name` | normalized thread (lowercase ASCII alphanumerics and hyphens, ≤32 chars) |
+| `!t name` | normalized thread (lowercase ASCII alphanumerics and hyphens, first character alphanumeric, at most 32 characters) |
 
-A saved task becomes the selection. Success has no status message: the row flash
-is the feedback.
+An ambiguous project basename is stored as typed. `tsk list --all --json` is how
+you find a typo scope later.
+
+## Quick capture (herdr)
+
+**Quick capture** opens the capture form as a short-lived overlay, without first
+opening a split board:
+
+```bash
+herdr plugin action invoke quick-capture --plugin herdr-tsk
+```
+
+Tab through Title, Notes, Thread, Scope. `Enter` in Title saves. `Enter` in Notes
+inserts a line. `Ctrl+Enter` or `Alt+Enter` save from any field. `Esc` cancels
+and leaves.
+
+An idle board watching the same `~/.tsk` picks up the new task on the next tick.
+
+## Expanded form
+
+From the `+` line, `Tab` opens the task page in notes edit because a draft has
+nothing to view yet. `Esc` returns to the line. A second `Tab` restores what you
+typed.

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -76,8 +76,8 @@ To recover a typo scope: `tsk list --all --json`.
 ## steps
 
 ```
-tsk steps <task-id> add <text> [--state-dir <dir>]
-tsk steps <task-id> toggle <step-short-id> [--state-dir <dir>]
+tsk steps <task> add <text> [--state-dir <dir>]
+tsk steps <task> toggle <step-short-id> [--state-dir <dir>]
 ```
 
 See [steps](/docs/steps/) for the board side. `toggle` is not idempotent. Verify

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -1,24 +1,100 @@
 ---
 title: CLI
-description: Headless tsk add and tsk list.
+description: Headless tsk add, list, and steps.
 ---
 
-For scriptable board work:
+The same `~/.tsk` store backs the board, herdr, and these commands.
 
 ```bash
 tsk add -t "Draft release notes"
 tsk list
 ```
 
-`add` creates tasks without opening the TUI. `list` prints tasks from the store
-without changing them.
+## add
 
-Task numbers are store-global, so `tsk list 12` finds task `12` regardless of
-your current directory. JSON output exposes that value as `number`; UUID lookup
-continues to work too.
+Create one task, or apply a JSON plan.
 
-State is still `~/.tsk` whether you use the board, herdr, or the CLI.
+```
+tsk add -t <title> [-n <notes>] [-p <project> | --desk] [--thread <name>] [--json] [--state-dir <dir>]
+tsk add [--file <path|->] [--state-dir <dir>]
+```
 
-See the app README and `skills/tsk-cli/SKILL.md` in
-[herdr-tsk](https://github.com/smarzban/herdr-tsk) for exit codes, plan-shaped
-bulk add, and retry rules.
+`--desk` is your desk (stored as scope `global`). `-p` / `--project` uses the
+same basename-or-path rules as capture `!p`. `--thread` normalizes like `!t`.
+
+An add whose trimmed title, resolved project, and normalized thread already
+exist succeeds without changing the task.
+
+Values that start with `-` need `--title=…`, `--notes=…`, `--project=…`,
+`--state-dir=…`, or `--file=…`. Item flags plus `--file` is usage (exit 2,
+nothing persists). Piped stdin with item flags is ignored and not read.
+
+`--json` on a flag add prints one object: `outcome` (`created` or `existing`),
+`id`, `number`, `title`, and `project` (or `null`).
+
+Plan JSON is an array:
+
+```json
+[{"title": "...", "notes": "...", "project": "...", "thread": "..."}]
+```
+
+`thread` may be `null`. The result is `{ "created": [...], "existing": [...], "failed": [...] }`.
+Notes are not echoed.
+
+```bash
+tsk add --file plan.json
+cat plan.json | tsk add
+```
+
+## list
+
+Prints tasks. It does not change them.
+
+```
+tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]
+```
+
+Default: ready, started, blocked, and review in the invocation project, or your
+desk outside a repository.
+
+- `--desk` selects desk
+- `--all` every scope
+- `--done` done only
+- `--deleted` soft-deleted only
+- `--thread` filters within the selected scope
+
+A store-global task number (bare digits, like `12`) or a task UUID lists that
+one task and its steps (`[x]` / `[ ]` plus the step short id). Direct lookup
+ignores cwd. A task operand cannot combine with scope, thread, or status
+filters.
+
+`--json` is a flat array of `id`, `number`, `title`, `status`, `project`, and
+`thread`. Single-task JSON also attaches `steps`.
+
+To recover a typo scope: `tsk list --all --json`.
+
+## steps
+
+```
+tsk steps <task-id> add <text> [--state-dir <dir>]
+tsk steps <task-id> toggle <step-short-id> [--state-dir <dir>]
+```
+
+See [steps](/docs/steps/) for the board side. `toggle` is not idempotent. Verify
+with `tsk list <task>` before a retry.
+
+## Exit contract
+
+| Exit | Meaning |
+| --- | --- |
+| 0 | listed, or every add item created/existed, or the step applied |
+| 1 | one or more item refusals (add/steps). Retry only the failed subset. For toggle, list first. |
+| 2 | usage or parse error. Nothing persisted. |
+| 3 | store I/O. Commit is indeterminate. `tsk list` before retrying. |
+
+Add refusal codes include `empty-title`, `invalid-title`, `invalid-item`. Any C0
+control in a title or step text is `invalid-title` / `invalid-step-text` before
+trimming.
+
+Steps refusals (exit 1): `empty-step-text`, `invalid-step-text`, `unknown-task`,
+`soft-deleted-task`, `unknown-step`, `ambiguous-step`.

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -1,27 +1,31 @@
 ---
 title: Overview
-description: What tsk is and how the board works.
+description: What tsk is and where to read how to use it.
 ---
 
-**tsk** is a task board for your terminal. It captures work and moves it through
-human status: ready, started, blocked, review, done.
+**tsk** is a task board for your terminal. Capture work, then move it through human
+status: ready, started, blocked, review, done.
 
-It ships as the herdr plugin `herdr-tsk`, and the `tsk` binary also runs
-standalone against `~/.tsk`.
+It ships as the herdr plugin `herdr-tsk`. The `tsk` binary also runs standalone
+against `~/.tsk`. The pane, the capture overlay, and the CLI edit the same board.
 
-## What is in scope
+This site is the user guide. Maintainer internals live in the repo under
+[`docs/technical/`](https://github.com/smarzban/herdr-tsk/tree/main/docs/technical).
 
-- Queue board with desk · projects · threads
-- Quick-add capture on the board
-- Task page for title, notes, thread, and scope
-- Headless `tsk add` and `tsk list`
+## What you can do
 
-Park, resume, attention, linking, and dispatch are not part of this tree.
+- Keep a queue with **desk**, **projects**, and **threads**
+- Capture with `+` on the board, or a herdr overlay
+- Open a task page for title, notes, thread, scope, and steps
+- Script the same store with `tsk add`, `tsk list`, and `tsk steps`
 
-## Next
+Park, resume, attention, linking, and dispatch are not in this product.
 
-- [Install](/docs/install/)
-- [Board](/docs/board/)
-- [Keys](/docs/keys/)
-- [Capture](/docs/capture/)
-- [CLI](/docs/cli/)
+## Start here
+
+1. [Install](/docs/install/) and open the board
+2. [Board](/docs/board/) for tabs, sections, and status
+3. [Keys](/docs/keys/) for the keymap
+4. [Capture](/docs/capture/) to add work
+5. [Task page](/docs/task-page/) and [steps](/docs/steps/) for detail
+6. [CLI](/docs/cli/) when you want the board without the TUI

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -1,13 +1,13 @@
 ---
 title: Install
-description: Build tsk from source and open the board.
+description: Build tsk and open the board.
 ---
 
 ## Requirements
 
 - Rust 1.96.0 (pinned in `rust-toolchain.toml`)
 - Linux or macOS
-- herdr 0.7.5 or newer (plugin mode only)
+- herdr 0.7.5 or newer, for plugin mode only
 
 ## Build
 
@@ -25,7 +25,7 @@ The binary is `target/release/tsk`.
 ./target/release/tsk
 ```
 
-State lives in `~/.tsk` (`tsk.json` and `settings.json`). Override with
+State lives in `~/.tsk`: `tsk.json` next to `settings.json`. Override with
 `TSK_STATE_DIR` / `TSK_CONFIG_DIR`.
 
 ```bash
@@ -35,9 +35,13 @@ tsk list
 
 ## As a herdr plugin
 
+The pane runs `./target/release/tsk`, so build before you link:
+
 ```bash
 herdr plugin link "$PWD"
 ```
+
+`herdr plugin list` should show `herdr-tsk` enabled against that path.
 
 Then **Open tsk board**, or:
 
@@ -45,4 +49,21 @@ Then **Open tsk board**, or:
 herdr plugin action invoke open-board --plugin herdr-tsk
 ```
 
+It opens a **tsk** split beside the current pane. Invoke it again to focus the
+board you already have.
+
+**Quick capture** opens the capture form without a persistent board:
+
+```bash
+herdr plugin action invoke quick-capture --plugin herdr-tsk
+```
+
 Rebuild after you pull. A running board keeps the old binary until you quit it.
+
+herdr injects `HERDR_PLUGIN_STATE_DIR` / `HERDR_PLUGIN_CONFIG_DIR`. tsk ignores
+them on purpose: one store (`~/.tsk`) whether you are in herdr, another
+multiplexer, or a bare terminal.
+
+## Next
+
+[Board](/docs/board/) · [Keys](/docs/keys/) · [Capture](/docs/capture/)

--- a/site/src/content/docs/docs/keys.md
+++ b/site/src/content/docs/docs/keys.md
@@ -1,29 +1,73 @@
 ---
 title: Keys
-description: Navigation and verb modifier keys on the board.
+description: Board, task page, and capture key chords.
 ---
 
 Mutating keys need **Alt** (or **Ctrl**, if you flip it in the palette). Bare
 letters do nothing, so typing in a focused board cannot complete or delete work.
 
+Nav, peek, `Enter`, `P`, `1` / `2` / `3`, `z`, `:`, `?`, `+`, and `Esc` stay
+bare.
+
+The web demo on the landing page uses bare verb letters on purpose. Browsers
+steal Alt-chords.
+
+## Board
+
 | Key | Does |
 | --- | --- |
-| `j` `k` or `↑` `↓` | move |
-| `alt+space` | start, or reopen if done |
+| `j` `k` or `↑` `↓` | move selection |
+| wheel | scroll the list |
+| `alt+space` | start the selected task, or reopen it if it is done |
 | `alt+d` | done |
 | `alt+o` | reopen |
 | `alt+b` | toggle blocked |
-| `Enter` | open the task page |
-| `→` `←` | peek notes |
-| `+` | capture |
+| `Enter` | open the [task page](/docs/task-page/) |
+| `→` `←` | peek notes under the row (up to five lines) |
+| `+` | [capture](/docs/capture/) |
 | `alt+e` | edit title |
-| `alt+x` | delete (`alt+u` undoes) |
+| `alt+x` or `alt+Delete` | delete (`alt+u` undoes) |
 | `z` | done drawer |
 | `:` | command palette |
 | `?` | help |
-| `P` | project scope |
-| `1` `2` `3` | desk · projects · threads |
+| `P` | project picker |
+| `1` `2` `3` | home tabs: desk · projects · threads |
 | `Esc` | close one layer |
 | `alt+q` | quit |
 
-Click a row to peek. Click again to close. Fast double-click opens the page.
+Click a row to peek. Click it again to close. A fast double-click opens the page.
+
+`Esc` closes one layer at a time.
+
+## Task page
+
+The page is view-first. Verbs still need the modifier, except Tab and arrows.
+
+| Key | Does |
+| --- | --- |
+| `alt+e` | edit title (or rename the highlighted step) |
+| `alt+n` | edit notes |
+| `Tab` / `Shift+Tab` | move between title, notes, thread, scope |
+| `alt+a` | add a [step](/docs/steps/) |
+| `↓` | activate the step cursor, then move it |
+| `↑` | move the step cursor; from the first step, deactivates it |
+| `alt+space` | toggle the highlighted step, or start/reopen the task |
+| `alt+x` | mark, then remove, the highlighted step; otherwise delete the task |
+| `Ctrl+Enter` or `Alt+Enter` | save from any field |
+| `Esc` | cancel the field, or close the page |
+
+The scope footer does nothing until an edit has started. Field clicks are inert
+until then too.
+
+## Capture line and form
+
+| Key | Does |
+| --- | --- |
+| `Tab` / `Shift+Tab` | Title, Notes, Thread, Scope |
+| `Enter` in Title | save |
+| `Enter` in Notes | new line |
+| `Ctrl+Enter` or `Alt+Enter` | save from any field |
+| `Esc` | cancel |
+
+On the board `+` line: `Enter` saves and closes, `Ctrl+Enter` saves and stays
+open, `Tab` expands onto the task page.

--- a/site/src/content/docs/docs/steps.md
+++ b/site/src/content/docs/docs/steps.md
@@ -1,0 +1,57 @@
+---
+title: Steps
+description: Flat checklists on a task, from the page and from the CLI.
+---
+
+A task can carry a flat, ordered list of steps. One level. No nesting. Each step
+has a stable id, one line of text, and a done flag.
+
+Checking every step does **not** mark the task done. Steps are progress on the
+page, not a second status.
+
+Markdown `- [ ]` in notes is ordinary text. Use steps for checklists.
+
+## On the task page
+
+Open the task with `Enter`. The step cursor starts inactive.
+
+- Bare `↓` activates it on the first step (again after you deactivate it)
+- `↑` / `↓` move it while it is active
+- `↑` from the first step deactivates it
+- A click on a step row moves the cursor there
+
+With the cursor active, the usual verbs act on that step:
+
+| Key | Does |
+| --- | --- |
+| `alt+a` | add a step (footer line) |
+| `alt+space` | toggle done |
+| `alt+e` | rename the highlighted step |
+| `alt+x` | mark, then a second press removes |
+
+The add/rename line is a one-line draft. `Enter` applies it. `Ctrl+Enter` adds
+and leaves the line open empty. `Esc` cancels. A failed save keeps the line
+until you retry or cancel.
+
+Wheel still scrolls the page. Arrows belong to the step cursor while it is
+active.
+
+## From the CLI
+
+```bash
+tsk steps <task-id> add "Write the failing test"
+tsk steps <task-id> toggle <step-short-id>
+tsk list <task-id>
+```
+
+The task id is a task UUID from `tsk add --json` or `tsk list --json`.
+
+A step short id is the shortest unambiguous prefix of that step's id, as printed
+by `tsk list <task-id>`.
+
+`toggle` flips the flag. A blind retry after an unseen success flips it back.
+Verify with `tsk list <task-id>` before retrying.
+
+Soft-deleted tasks refuse step changes.
+
+Full flags and exit codes: [CLI](/docs/cli/).

--- a/site/src/content/docs/docs/steps.md
+++ b/site/src/content/docs/docs/steps.md
@@ -39,18 +39,19 @@ active.
 ## From the CLI
 
 ```bash
-tsk steps <task-id> add "Write the failing test"
-tsk steps <task-id> toggle <step-short-id>
-tsk list <task-id>
+tsk steps <task> add "Write the failing test"
+tsk steps <task> toggle <step-short-id>
+tsk list <task>
 ```
 
-The task id is a task UUID from `tsk add --json` or `tsk list --json`.
+The task is a store-global number (bare digits) or a UUID from `tsk add --json`
+or `tsk list --json`. Direct lookup ignores cwd.
 
 A step short id is the shortest unambiguous prefix of that step's id, as printed
-by `tsk list <task-id>`.
+by `tsk list <task>`.
 
 `toggle` flips the flag. A blind retry after an unseen success flips it back.
-Verify with `tsk list <task-id>` before retrying.
+Verify with `tsk list <task>` before retrying.
 
 Soft-deleted tasks refuse step changes.
 

--- a/site/src/content/docs/docs/task-page.md
+++ b/site/src/content/docs/docs/task-page.md
@@ -1,0 +1,47 @@
+---
+title: Task page
+description: "View and edit one task: title, notes, thread, and scope."
+---
+
+`Enter` opens the selected task full height.
+
+It is view-first. Nothing is in edit mode until you ask. `alt+e` edits the title,
+`alt+n` edits notes, `Tab` moves between title, notes, thread, and scope. The
+scope footer does nothing until an edit has started.
+
+`Ctrl+Enter` or `Alt+Enter` saves from any field. Field `Esc` cancels that field.
+Page `Esc` closes the page.
+
+Notes are multiline, so `Enter` inserts a line. `Ctrl+Enter` saves when the
+terminal reports it. `Alt+Enter` saves everywhere else. Both save. Neither
+inserts a line.
+
+Thread uses the same name rules as capture `!t`. The field is optional.
+
+## Notes markdown
+
+View and peek style a small markdown subset. Edit is always the raw source. No
+color.
+
+| Marker | Paint |
+| --- | --- |
+| `**bold**` | bold |
+| `*em*` or `_em_` | underline |
+| `` `code` `` | dim, ticks kept |
+| `#` … `######` | bold + underline, dim hashes |
+| `-` or `*` lists | dim bullet |
+| fenced ` ``` ` | dim fence and body, no inline inside |
+
+Unmatched `*` and word-internal `_` stay literal. `- [ ]` stays text.
+[Steps](/docs/steps/) own checklists.
+
+Peek paints the same markers, then dims every span, with a `│` gutter.
+
+## Peek vs page
+
+On the list, `→` or a row click peeks up to five wrapped note lines. Open the
+page when you want the full notes, thread, scope, and steps.
+
+Text on the page wraps. It does not truncate.
+
+See [keys](/docs/keys/) for the full chord table.


### PR DESCRIPTION
## Summary

Adds the dedicated user guide on the Starlight site and maintainer internals under `docs/technical/`.

- Site docs cover install, board, keys, capture, task page, steps, and CLI.
- README is the front door and links to the site for usage.
- `docs/technical/` is architecture, data model, invariants, security, and subsystem pages. Public symbols stay on rustdoc (`cargo doc --no-deps --package tsk-tui`).

Unrelated local landing/WIP files were left out of this PR.

## Test plan

- [x] `cd site && npm test && npm run build`
- [x] Previewed `/docs/`, `/docs/task-page/`, `/docs/steps/`, `/docs/cli/`, landing → Read the docs
- [ ] `cargo fmt --check` (docs-only; CI still runs because README and `docs/` are in the diff)
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test`
- [ ] Manual herdr open-board smoke (if host paths changed) — not needed
- [ ] `cd site && npm ci && npm run build` (if `site/` changed)