### PR TITLE
feat: add copyable task identifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,9 +39,9 @@ For scriptable board work, use `tsk add` and `tsk list`; read
   project-scoped · done drawer (`z`). Scoped ON DECK thread blocks paint dim `#name`
   headers with open counts; headers consume row budget but are not selectable or
   hit-testable.
-- Standard ≥78×24, compact below, operable to 40×10. Persisted task rows paint their
-  bare task number as dim meta chrome, including peek, task page, and done drawer; drafts
-  without a number paint none.
+- Standard ≥78×24, compact below, operable to 40×10. Persisted task rows paint an
+  dim `T<number>` prefix before the title, including task page and done drawer; clicking
+  that prefix copies it. Peek relies on its parent row's prefix. Drafts without a number paint none.
 - Human status: `ready` · `started` · `blocked` · `review` · `done`. The store
   still reads old `todo`/`doing` values.
 - Mutating verbs (`space` `d` `o` `b` `e` `n` `x` `u` `q`) need Alt, or Ctrl

--- a/site/public/board-demo.js
+++ b/site/public/board-demo.js
@@ -347,16 +347,27 @@ import { parseCapture } from "./capture.js";
     return bits.join(" · ");
   }
 
-  function copyTaskIdentifier(task) {
-    const identifier = `T${task.number}`;
-    navigator.clipboard?.writeText(identifier).catch(() => {});
-    state.copyNotice = `copy sent: ${identifier}`;
+  function showCopyNotice(message) {
+    state.copyNotice = message;
     setTimeout(() => {
-      if (state.copyNotice === `copy sent: ${identifier}`) {
+      if (state.copyNotice === message) {
         state.copyNotice = "";
         render();
       }
     }, 2000);
+    render();
+  }
+
+  function copyTaskIdentifier(task) {
+    const identifier = `T${task.number}`;
+    if (!navigator.clipboard?.writeText) {
+      showCopyNotice("copy unavailable");
+      return;
+    }
+    navigator.clipboard
+      .writeText(identifier)
+      .then(() => showCopyNotice(`copied ${identifier}`))
+      .catch(() => showCopyNotice("copy failed"));
   }
 
   function verbItems(task) {

--- a/site/public/board-demo.js
+++ b/site/public/board-demo.js
@@ -121,6 +121,7 @@ import { parseCapture } from "./capture.js";
     selectedId: "t1",
     peekId: null,
     flashId: null,
+    copyNotice: "",
     drawer: false,
     overlay: null,
     draft: "",
@@ -341,10 +342,21 @@ import { parseCapture } from "./capture.js";
 
   function metaFor(task) {
     const bits = [];
-    bits.push(String(task.number));
     if (state.tab === "desk" && task.project) bits.push(task.project);
     bits.push(age(task.updatedAt));
     return bits.join(" · ");
+  }
+
+  function copyTaskIdentifier(task) {
+    const identifier = `T${task.number}`;
+    navigator.clipboard?.writeText(identifier).catch(() => {});
+    state.copyNotice = `copy sent: ${identifier}`;
+    setTimeout(() => {
+      if (state.copyNotice === `copy sent: ${identifier}`) {
+        state.copyNotice = "";
+        render();
+      }
+    }, 2000);
   }
 
   function verbItems(task) {
@@ -454,6 +466,7 @@ import { parseCapture } from "./capture.js";
     state.overlay = null;
     state.draft = "";
     state.refuse = "";
+    state.copyNotice = "";
     state.undo = null;
   }
 
@@ -589,7 +602,7 @@ import { parseCapture } from "./capture.js";
     const title =
       editing === "title"
         ? `<input class="tsk-field" id="tsk-edit" value="${esc(state.editDraft)}" />`
-        : `<div class="tsk-page-title">${esc(task.title)}</div>`;
+        : `<div class="tsk-page-title"><span class="tsk-task-id" data-copy-task="${esc(task.id)}" title="copy T${task.number}">T${task.number}</span> ${esc(task.title)}</div>`;
     const notes =
       editing === "notes"
         ? `<textarea class="tsk-field tsk-notes" id="tsk-edit">${esc(state.editDraft)}</textarea>`
@@ -599,7 +612,7 @@ import { parseCapture } from "./capture.js";
         ${title}
         <div class="dim">${esc(task.status)} · ${esc(projectName(task))}${task.thread ? ` · #${esc(task.thread)}` : ""}</div>
         ${notes}
-        <div class="foot dim">${task.number} · esc close · alt+e title · alt+n notes · alt+d done · alt+b block</div>
+        <div class="foot dim">esc close · alt+e title · alt+n notes · alt+d done · alt+b block</div>
       </div>`;
   }
 
@@ -636,7 +649,7 @@ import { parseCapture } from "./capture.js";
                 .join("")
             : "";
         return `<button type="button" class="tsk-row ${selected ? "is-sel" : ""} ${flash ? "is-flash" : ""}" data-task="${task.id}">
-          <span class="tsk-row-main">${indent}  <span class="${selected ? "sel" : "glyph"}">${glyph}</span> <span class="${selected ? "sel-text" : ""}">${esc(task.title)}</span></span>
+          <span class="tsk-row-main">${indent}  <span class="${selected ? "sel" : "glyph"}">${glyph}</span> <span class="tsk-task-id ${selected ? "sel-text" : ""}" data-copy-task="${esc(task.id)}" title="copy T${task.number}">T${task.number}</span> <span class="${selected ? "sel-text" : ""}">${esc(task.title)}</span></span>
           <span class="meta">${esc(metaFor(task))}</span>
         </button>${peek}`;
       })
@@ -651,7 +664,8 @@ import { parseCapture } from "./capture.js";
         : `<button type="button" class="tsk-done-count foot" data-drawer="1">${doneN} done</button>
            <div class="foot dim tsk-verbs">${verbItems(task)
              .map((v) => `<button type="button" class="tsk-verb" data-verb="${esc(v.id)}">${esc(v.label)}</button>`)
-             .join("<span> · </span>")}</div>`;
+             .join("<span> · </span>")}</div>
+           ${state.copyNotice ? `<div class="foot dim">${esc(state.copyNotice)}</div>` : ""}`;
 
     return `
       <div class="tsk-tabs">${state.focusProject ? chip : tabs}</div>
@@ -1004,6 +1018,13 @@ import { parseCapture } from "./capture.js";
   let lastClick = { id: null, at: 0 };
 
   root.addEventListener("click", (e) => {
+    const copy = e.target.closest("[data-copy-task]");
+    if (copy) {
+      const task = state.tasks.find((item) => item.id === copy.getAttribute("data-copy-task"));
+      if (task) copyTaskIdentifier(task);
+      render();
+      return;
+    }
     const tab = e.target.closest("[data-tab]");
     if (tab) {
       goTab(tab.getAttribute("data-tab"));

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -21,8 +21,8 @@ Project focus (`P` → a project) hides the tabs and paints the project name chi
 on the right (`P ▾`). At home the chip is hidden. Collapse state is session-only.
 It does not persist.
 
-Each row's dim meta includes its store-global task number as bare digits,
-alongside its age and project when shown.
+Each persisted row begins with a dim store-global identifier such as
+`T30`. Click the identifier to copy it. Age and project remain trailing meta when shown.
 
 ## Sections
 
@@ -54,15 +54,16 @@ palette (`:` → `set status: review`), not from a dedicated letter.
 `→` peeks notes under the selected row (up to five wrapped lines). `←` closes
 the peek.
 
-Click a row to peek. Click the same row again to close. A fast double-click opens
-the [task page](/docs/task-page/). The wheel scrolls the list.
+Click a dim task identifier to copy it. Click elsewhere on a row to peek.
+Click the same row again to close. A fast double-click opens the
+[task page](/docs/task-page/). The wheel scrolls the list.
 
 ## Pane size
 
 | Pane | What you get |
 | --- | --- |
 | at least 78×24 | standard board: section headers, row meta, full verb legend |
-| smaller | compact: glyph, bare task number, and title; help, palette, and the task page take the full pane |
+| smaller | compact: glyph, `T` identifier, and title; help, palette, and the task page take the full pane |
 | down to 40×10 | still operable |
 
 A typical herdr split is 78 columns, which is the standard board.

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -63,8 +63,8 @@ desk outside a repository.
 - `--deleted` soft-deleted only
 - `--thread` filters within the selected scope
 
-A store-global task number (bare digits, like `12`) or a task UUID lists that
-one task and its steps (`[x]` / `[ ]` plus the step short id). Direct lookup
+A store-global task number (`T12`, `t12`, or bare `12`) or a task UUID lists
+that one task and its steps (`[x]` / `[ ]` plus the step short id). Direct lookup
 ignores cwd. A task operand cannot combine with scope, thread, or status
 filters.
 

--- a/site/src/content/docs/docs/keys.md
+++ b/site/src/content/docs/docs/keys.md
@@ -35,7 +35,7 @@ steal Alt-chords.
 | `Esc` | close one layer |
 | `alt+q` | quit |
 
-Click a row to peek. Click it again to close. A fast double-click opens the page.
+Click a dim task identifier (`T30`) to copy it. Click elsewhere on a row to peek, click it again to close, and fast double-click to open the page.
 
 `Esc` closes one layer at a time.
 

--- a/site/src/content/docs/docs/steps.md
+++ b/site/src/content/docs/docs/steps.md
@@ -44,8 +44,8 @@ tsk steps <task> toggle <step-short-id>
 tsk list <task>
 ```
 
-The task is a store-global number (bare digits) or a UUID from `tsk add --json`
-or `tsk list --json`. Direct lookup ignores cwd.
+The task is a store-global number (`T12`, `t12`, or bare `12`) or a UUID from
+`tsk add --json` or `tsk list --json`. Direct lookup ignores cwd.
 
 A step short id is the shortest unambiguous prefix of that step's id, as printed
 by `tsk list <task>`.

--- a/site/src/content/docs/docs/task-page.md
+++ b/site/src/content/docs/docs/task-page.md
@@ -3,7 +3,8 @@ title: Task page
 description: "View and edit one task: title, notes, thread, and scope."
 ---
 
-`Enter` opens the selected task full height.
+`Enter` opens the selected task full height. The dim `T30` prefix in the
+header copies that task identifier when clicked.
 
 It is view-first. Nothing is in edit mode until you ask. `alt+e` edits the title,
 `alt+n` edits notes, `Tab` moves between title, notes, thread, and scope. The

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -454,6 +454,11 @@ html[data-theme="light"] .theme-toggle .icon-moon {
   white-space: nowrap;
 }
 
+.tsk-task-id {
+  color: var(--terminal-dim);
+  cursor: copy;
+}
+
 .tsk-row.is-sel .sel-text {
   color: #ffffff;
   background: color-mix(in srgb, var(--terminal-sel) 14%, transparent);

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -26,11 +26,12 @@ test("the shared theme script is loaded once from the Starlight head", async () 
   assert.doesNotMatch(themeSelect, /theme\.js/);
 });
 
-test("demo rows paint bare task numbers", async () => {
+test("demo rows lead with copyable T task identifiers", async () => {
   const demo = await read("../public/board-demo.js");
   assert.match(demo, /let n = 12;/);
   assert.match(demo, /number: n\+\+,/);
-  assert.match(demo, /bits\.push\(String\(task\.number\)\)/);
+  assert.doesNotMatch(demo, /bits\.push\(String\(task\.number\)\)/);
+  assert.match(demo, /data-copy-task=/);
+  assert.match(demo, /T\$\{task\.number\}/);
   assert.doesNotMatch(demo, /#\$\{task\.number\}/);
-  assert.doesNotMatch(demo, /T\$\{task\.number\}/);
 });

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -64,9 +64,9 @@ A typo in a project name silently files the task under a new scope. Use
 
 ## Direct task lookup and steps
 
-A task number is the human handle: resolve “task 12” with `tsk list 12`.
-Bare digits and UUIDs are both valid task operands. Direct lookup ignores cwd,
-invocation default, and task scope: `tsk list 12` finds its one task even in
+A task number is the human handle: resolve `T12` with `tsk list T12`.
+`T12`, `t12`, bare digits, and UUIDs are valid task operands. Direct lookup ignores cwd,
+invocation default, and task scope: `tsk list T12` finds its one task even in
 another project, including done and soft-deleted tasks. JSON list rows include
 numeric `number` beside `id`. Do not combine a direct task operand with scope,
 thread, or status filters.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1201,11 +1201,20 @@ pub fn refresh_before_mutation(
 
 /// Copy a visible task identifier without changing selection, page state, or persistence.
 fn copy_task_number(domain: &DomainState, model: &mut BoardModel, id: uuid::Uuid) {
+    copy_task_number_with(domain, model, id, copy_to_clipboard);
+}
+
+fn copy_task_number_with(
+    domain: &DomainState,
+    model: &mut BoardModel,
+    id: uuid::Uuid,
+    copy: impl FnOnce(&str) -> bool,
+) {
     let Some(number) = domain.get(id).and_then(|task| task.number) else {
         return;
     };
     let identifier = format!("T{number}");
-    let message = if copy_to_clipboard(&identifier) {
+    let message = if copy(&identifier) {
         format!("copy sent: {identifier}")
     } else {
         "copy failed".to_string()
@@ -2374,6 +2383,34 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.dir);
         }
+    }
+
+    #[test]
+    fn copy_task_number_sends_the_exact_displayed_identifier() {
+        let temp = TempStore::new("copy-task-number-payload");
+        let mut domain = DomainState::new();
+        let id = domain
+            .create(
+                "Copy me",
+                None,
+                TaskScope::Global,
+                None,
+                None,
+                ProvenanceOrigin::Manual,
+            )
+            .expect("seed task");
+        temp.store.save(&domain).expect("persist numbered task");
+        let domain = temp.store.load().expect("reload numbered task");
+        let mut model = BoardModel::from_domain(&domain, None);
+        let mut copied = None;
+
+        copy_task_number_with(&domain, &mut model, id, |text| {
+            copied = Some(text.to_string());
+            true
+        });
+
+        assert_eq!(copied.as_deref(), Some("T1"));
+        assert_eq!(model.message(), Some("copy sent: T1"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1199,6 +1199,20 @@ pub fn refresh_before_mutation(
     true
 }
 
+/// Copy a visible task identifier without changing selection, page state, or persistence.
+fn copy_task_number(domain: &DomainState, model: &mut BoardModel, id: uuid::Uuid) {
+    let Some(number) = domain.get(id).and_then(|task| task.number) else {
+        return;
+    };
+    let identifier = format!("T{number}");
+    let message = if copy_to_clipboard(&identifier) {
+        format!("copy sent: {identifier}")
+    } else {
+        "copy failed".to_string()
+    };
+    model.set_ephemeral_message(message, Duration::from_secs(2));
+}
+
 /// Apply a board intent. Returns `true` when the board loop should quit.
 fn handle_board_intent(
     store: &TaskStore,
@@ -1207,6 +1221,11 @@ fn handle_board_intent(
     intent: BoardIntent,
     save_recovery: &mut SaveRecovery<DomainState>,
 ) -> io::Result<bool> {
+    if let BoardIntent::CopyTaskNumber(id) = intent {
+        copy_task_number(domain, model, id);
+        return Ok(false);
+    }
+
     let baseline = if save_recovery.is_pending() || !board_intent_may_persist(&intent) {
         DomainState::new()
     } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2377,6 +2377,47 @@ mod tests {
     }
 
     #[test]
+    fn copy_task_number_intent_uses_the_app_loop_handoff_without_mutating() {
+        let temp = TempStore::new("copy-task-number");
+        let mut domain = DomainState::new();
+        let id = domain
+            .create(
+                "Copy me",
+                None,
+                TaskScope::Global,
+                None,
+                None,
+                ProvenanceOrigin::Manual,
+            )
+            .expect("seed task");
+        temp.store.save(&domain).expect("persist numbered task");
+        let mut domain = temp.store.load().expect("reload numbered task");
+        let number = domain.get(id).expect("task").number.expect("task number");
+        let mut model = BoardModel::from_domain(&domain, None);
+        let selection = model.selected_id();
+        let mut recovery = SaveRecovery::new();
+
+        let quit = handle_board_intent(
+            &temp.store,
+            &mut domain,
+            &mut model,
+            BoardIntent::CopyTaskNumber(id),
+            &mut recovery,
+        )
+        .expect("copy intent");
+
+        assert!(!quit);
+        assert_eq!(
+            model.selected_id(),
+            selection,
+            "copy must not move selection"
+        );
+        assert_eq!(domain.get(id).expect("task").number, Some(number));
+        let message = format!("copy sent: T{number}");
+        assert_eq!(model.message(), Some(message.as_str()));
+    }
+
+    #[test]
     fn ctrl_enter_step_save_uses_the_real_app_save_boundary() {
         let temp = TempStore::new("ctrl-enter-step");
         let mut domain = DomainState::new();

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -23,10 +23,14 @@ impl TaskAddress {
     }
 }
 
-/// Parse a task UUID or its bare-decimal human number.
+/// Parse a task UUID, bare-decimal human number, or the displayed `T<number>` form.
 pub fn parse_task_address(value: &str) -> Result<TaskAddress, String> {
-    if value.bytes().all(|byte| byte.is_ascii_digit()) {
-        return value
+    let number = value
+        .strip_prefix('T')
+        .or_else(|| value.strip_prefix('t'))
+        .unwrap_or(value);
+    if !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit()) {
+        return number
             .parse::<u64>()
             .map(TaskAddress::Number)
             .map_err(|_| format!("invalid task id {value}"));
@@ -34,6 +38,19 @@ pub fn parse_task_address(value: &str) -> Result<TaskAddress, String> {
     Uuid::parse_str(value)
         .map(TaskAddress::Id)
         .map_err(|_| format!("invalid task id {value}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_task_address, TaskAddress};
+
+    #[test]
+    fn task_addresses_accept_the_displayed_identifier_case_insensitively() {
+        assert_eq!(parse_task_address("T30"), Ok(TaskAddress::Number(30)));
+        assert_eq!(parse_task_address("t30"), Ok(TaskAddress::Number(30)));
+        assert_eq!(parse_task_address("30"), Ok(TaskAddress::Number(30)));
+        assert!(parse_task_address("T-30").is_err());
+    }
 }
 
 /// Parsed add input. A plan source is selected by `file` or piped stdin.

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -254,6 +254,8 @@ fn apply_board_intent(
             return Ok(IntentOutcome::None);
         }
         BoardIntent::CloseCommandSurface => return Ok(IntentOutcome::None),
+        // The app loop performs the OSC 52 write so pure reducer tests stay terminal-free.
+        BoardIntent::CopyTaskNumber(_) => return Ok(IntentOutcome::None),
         BoardIntent::OpenWalkthrough => return Ok(IntentOutcome::None),
         BoardIntent::ConfirmCommand | BoardIntent::SelectCommand(_) => {
             // Resolve to the existing intent, then run that exact route. `SelectCommand`

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -240,7 +240,20 @@ fn build_task_page_overlay<'a>(
     // glyph instead of truncating; edit mode wraps the draft with its cursor.
     // The uniform budget keeps every row's wrap identical.
     let word_cells = status_word.chars().count() + 1;
-    let title_avail = width.saturating_sub(4 + word_cells);
+    let editing_title = model.input_mode() == BoardInputMode::EditTitle;
+    let header_identifier = (!editing_title)
+        .then(|| {
+            bound_task
+                .and_then(|task| task.number)
+                .map(|number| format!("T{number}"))
+        })
+        .flatten();
+    let identifier_cells = header_identifier
+        .as_deref()
+        .map(render::display_width)
+        .unwrap_or(0);
+    let title_avail =
+        width.saturating_sub(4 + word_cells + identifier_cells + usize::from(identifier_cells > 0));
     // The header may grow only inside the page body: it must stop one row short
     // of the lowest chrome row with one note row still living under it, or a
     // pathological title would eat the page (and the painter's chrome).
@@ -250,7 +263,6 @@ fn build_task_page_overlay<'a>(
         .min()
         .unwrap_or(page_geo.height);
     let header_cap = page_bottom.saturating_sub(3).max(1) as usize;
-    let editing_title = model.input_mode() == BoardInputMode::EditTitle;
     let mut header_rows: Vec<String> = Vec::new();
     let mut title_cursor = None;
     if editing_title {
@@ -357,20 +369,14 @@ fn build_task_page_overlay<'a>(
     form.notes_width.set(notes_width);
 
     // Meta footer: scope · thread · created · updated (ages only while the bound task is
-    // present). Keep its clickable pieces separate from the painted string: a project basename
-    // is user-controlled and may contain the same separator or label text.
+    // present). The identifier belongs in the header, so it never competes with scope hits.
     let meta_scope = match &form.scope {
         TaskScope::Project { path } => render::short_project(path).to_string(),
         TaskScope::Global => "desk".to_string(),
     };
     let meta_scope_width = u16::try_from(render::display_width(&meta_scope)).unwrap_or(u16::MAX);
     let mut meta = String::new();
-    let mut meta_scope_x = 0;
-    if let Some(number) = bound_task.and_then(|task| task.number) {
-        meta.push_str(&number.to_string());
-        meta.push_str(" · ");
-        meta_scope_x = u16::try_from(render::display_width(&meta)).unwrap_or(u16::MAX);
-    }
+    let meta_scope_x = 0;
     meta.push_str(&meta_scope);
     let mut thread_slot = None;
     if let Some(task) = bound_task {
@@ -415,6 +421,8 @@ fn build_task_page_overlay<'a>(
 
     QueueOverlay::TaskPage {
         header_rows,
+        header_identifier,
+        header_identifier_task: (!editing_title).then(|| form.task_id()).flatten(),
         title_cursor,
         status_word,
         notes_rows,

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -118,6 +118,8 @@ pub enum BoardIntent {
     SelectPrev,
     /// Select visible list row by index (mouse row click).
     SelectIndex(usize),
+    /// Copy the presentation-only `T<number>` identifier for one persisted task.
+    CopyTaskNumber(uuid::Uuid),
     /// Jump the list viewport to a content offset without changing selection or peek
     /// (list scrollbar track click / thumb drag).
     ListScrollTo(usize),
@@ -813,6 +815,7 @@ pub fn intent_primary_action(intent: &BoardIntent) -> Option<PrimaryBoardAction>
         | BoardIntent::ExpandQuickAdd
         | BoardIntent::CancelQuickAdd
         | BoardIntent::QuickAddSelectIndex(_)
+        | BoardIntent::CopyTaskNumber(_)
         | BoardIntent::FormFocusNext
         | BoardIntent::FormFocusPrev
         | BoardIntent::FocusFormField(_)

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -539,6 +539,7 @@ pub fn map_board_mouse(
         BoardInputMode::QuickAdd => match hit_at(hits, pos) {
             // The line already owns keyboard focus, so its click is intentionally inert.
             Some(QueueHitTarget::QuickAddInput) => None,
+            Some(QueueHitTarget::TaskNumber(id)) => Some(BoardIntent::CopyTaskNumber(id)),
             Some(QueueHitTarget::Task(id)) => model
                 .visible_ids()
                 .iter()

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -567,6 +567,7 @@ pub fn map_board_mouse(
             _ => None,
         },
         BoardInputMode::TaskPage => match hit_at(hits, pos) {
+            Some(QueueHitTarget::TaskNumber(id)) => Some(BoardIntent::CopyTaskNumber(id)),
             Some(QueueHitTarget::FormScope) | Some(QueueHitTarget::FormThread) => None,
             // A click on an step row selects it (AC-21) — the board's click
             // convention: a click selects, never mutates.
@@ -603,6 +604,7 @@ pub fn map_board_mouse(
                 subgroup_idx,
             }),
             Some(QueueHitTarget::Drawer) => Some(BoardIntent::ToggleDoneDrawer),
+            Some(QueueHitTarget::TaskNumber(id)) => Some(BoardIntent::CopyTaskNumber(id)),
             Some(QueueHitTarget::Task(id)) => model
                 .visible_ids()
                 .iter()

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -102,9 +102,10 @@ pub fn style_reverse_bold() -> Style {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TaskRowPaint<'a> {
     pub glyph: &'a str,
+    /// Presentation-only task identifier, for example `T30`. Drafts have none.
+    pub identifier: Option<&'a str>,
     pub title: &'a str,
-    /// Trailing meta (number / age / project). At compact widths a bare number still reserves
-    /// its own small trailing run so it remains visible while the title wraps.
+    /// Trailing age / project metadata. The task identifier belongs with the title, not here.
     pub meta: &'a str,
     pub selected: bool,
     /// Bold the title when unselected (e.g. attention emphasis).
@@ -112,53 +113,63 @@ pub struct TaskRowPaint<'a> {
 }
 
 /// One painted task-row line plus the title-content cells a text selection may copy.
-///
-/// `content_x` / `content_width` skip the leading indent, status glyph, and (on the
-/// first line) the right-aligned meta column — chrome the clipboard must not see.
 pub struct TaskRowLine {
     pub line: Line<'static>,
     pub content_x: u16,
     pub content_width: u16,
+    /// The leading identifier's exact cells, on the first line only.
+    pub identifier: Option<(u16, u16)>,
 }
 
-/// Paint one task as ONE OR MORE list lines: the first is the classic glyph + title +
-/// right-aligned meta row; a title too wide for its budget wraps at word boundaries onto
-/// continuation lines indented into its own column, with no meta. Nothing is cut.
+/// Paint one task as ONE OR MORE list lines. Persisted tasks lead with a dim,
+/// presentation-only identifier; wrapped title continuations align under the title text.
 pub fn paint_task_row_lines(
     row: &TaskRowPaint<'_>,
     geo: &TierGeometry,
     leading_indent: usize,
 ) -> Vec<TaskRowLine> {
-    // The title room `paint_task_row_with_indent` derives must match here, so both
-    // share one computation of the prefix cells.
     let row_w = geo.row_width as usize;
     let meta_budget = task_meta_budget(row, geo);
     let title_budget = row_w.saturating_sub(meta_budget);
     let glyph_cells = display_width(&super::terminal_text(row.glyph));
     let prefix_cells = leading_indent + 2 + glyph_cells + 1;
-    let room = title_budget.saturating_sub(prefix_cells).max(1);
-    let content_x = u16::try_from(prefix_cells).unwrap_or(u16::MAX);
-    let content_width = u16::try_from(room).unwrap_or(1).max(1);
+    let identifier_width = row.identifier.map(display_width).unwrap_or(0);
+    let identifier_gap = usize::from(identifier_width > 0);
+    let title_x = prefix_cells.saturating_add(identifier_width + identifier_gap);
+    let room = title_budget.saturating_sub(title_x).max(1);
+    let head_content_x = u16::try_from(prefix_cells).unwrap_or(u16::MAX);
+    let head_content_width = u16::try_from(identifier_width + identifier_gap + room)
+        .unwrap_or(u16::MAX)
+        .max(1);
+    let title_content_x = u16::try_from(title_x).unwrap_or(u16::MAX);
+    let title_content_width = u16::try_from(room).unwrap_or(1).max(1);
+    let identifier = row.identifier.map(|_| {
+        (
+            head_content_x,
+            u16::try_from(identifier_width).unwrap_or(u16::MAX),
+        )
+    });
     let segments: Vec<String> = crate::ui::edit::wrap_text(row.title, room)
         .into_iter()
         .map(|wrapped| wrapped.text)
         .collect();
 
     let mut lines = Vec::with_capacity(segments.len());
-    // The first line reuses the classic painter verbatim with segment 0.
     let head = TaskRowPaint {
         title: &segments[0],
         ..*row
     };
     lines.push(TaskRowLine {
         line: paint_task_row_with_indent(&head, geo, leading_indent),
-        content_x,
-        content_width,
+        content_x: head_content_x,
+        content_width: head_content_width,
+        identifier,
     });
-    // Continuations indent into the title column (past glyph and space).
-    let indent = " ".repeat(prefix_cells);
+    let indent = " ".repeat(title_x);
     let continuation_style = if row.selected {
         style_reverse()
+    } else if row.title_bold {
+        style_bold()
     } else {
         style_plain()
     };
@@ -171,8 +182,9 @@ pub fn paint_task_row_lines(
                 )),
                 row_w,
             ),
-            content_x,
-            content_width,
+            content_x: title_content_x,
+            content_width: title_content_width,
+            identifier: None,
         });
     }
     lines
@@ -199,27 +211,26 @@ fn paint_task_row_with_indent(
 
     let glyph = super::terminal_text(row.glyph);
     let prefix = format!("{}  {glyph} ", " ".repeat(leading_indent));
-    let title_room = title_budget.saturating_sub(display_width(&prefix));
+    let identifier = row.identifier.unwrap_or_default();
+    let identifier_gap = if identifier.is_empty() { "" } else { " " };
+    let title_room = title_budget
+        .saturating_sub(display_width(&prefix))
+        .saturating_sub(display_width(identifier))
+        .saturating_sub(display_width(identifier_gap));
     let title = present_line(row.title, title_room);
-    let left = fit_left(&format!("{prefix}{title}"), title_budget);
-    let left_w = display_width(&left);
+    let left_w = display_width(&prefix)
+        .saturating_add(display_width(identifier))
+        .saturating_add(display_width(identifier_gap))
+        .saturating_add(display_width(&title));
 
-    // The prototype leaves one trailing column past the meta text (matched by section
-    // headers' own trailing-space right budget); reserve it here so task rows agree with
-    // the rest of the frame instead of running meta flush to the frame edge.
     let margin_w = if meta_budget == 0 { 0 } else { 1 };
     let meta_content_budget = meta_budget.saturating_sub(margin_w);
-
-    // Compact (or empty meta): title zone only, padded out to the row width.
     let meta = if meta_budget == 0 || row.meta.is_empty() {
         String::new()
     } else {
         present_line(row.meta, meta_content_budget)
     };
     let meta_w = display_width(&meta);
-
-    // Leader = pad title zone to `title_budget` + right-align pad inside the meta column.
-    // When meta is absent the leader simply fills through the end of the row.
     let leader_w = if meta.is_empty() {
         row_w.saturating_sub(left_w)
     } else {
@@ -229,19 +240,33 @@ fn paint_task_row_with_indent(
     };
     let leader = " ".repeat(leader_w);
 
-    let (left_style, leader_style, meta_style) = if row.selected {
-        (style_reverse(), style_reverse_dim(), style_reverse_dim())
+    let (title_style, identifier_style, leader_style, meta_style) = if row.selected {
+        (
+            style_reverse(),
+            style_reverse_dim(),
+            style_reverse_dim(),
+            style_reverse_dim(),
+        )
     } else {
-        let title_style = if row.title_bold {
-            style_bold()
-        } else {
-            style_plain()
-        };
-        (title_style, style_dim(), style_dim())
+        (
+            if row.title_bold {
+                style_bold()
+            } else {
+                style_plain()
+            },
+            style_dim(),
+            style_dim(),
+            style_dim(),
+        )
     };
 
-    let mut spans: Vec<Span<'static>> = Vec::with_capacity(3);
-    spans.push(Span::styled(left, left_style));
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(5);
+    spans.push(Span::styled(prefix, title_style));
+    if !identifier.is_empty() {
+        spans.push(Span::styled(identifier.to_string(), identifier_style));
+        spans.push(Span::styled(identifier_gap.to_string(), title_style));
+    }
+    spans.push(Span::styled(title, title_style));
     if !leader.is_empty() {
         spans.push(Span::styled(leader, leader_style));
     }
@@ -256,19 +281,8 @@ fn paint_task_row_with_indent(
     bound_line(Line::from(spans), row_w)
 }
 
-/// Compact rows normally omit their age/project run, but a persisted task's bare number is
-/// still board chrome at the 40×10 floor. Reserve only that number plus the usual margin.
-fn task_meta_budget(row: &TaskRowPaint<'_>, geo: &TierGeometry) -> usize {
-    let standard = geo.meta_column_width as usize;
-    if standard > 0 {
-        standard
-    } else if !row.meta.is_empty() && row.meta.bytes().all(|byte| byte.is_ascii_digit()) {
-        display_width(row.meta)
-            .saturating_add(1)
-            .min(geo.row_width as usize)
-    } else {
-        0
-    }
+fn task_meta_budget(_row: &TaskRowPaint<'_>, geo: &TierGeometry) -> usize {
+    geo.meta_column_width as usize
 }
 
 /// Present untrusted text into a single mono-styled line bounded to `width` cells.
@@ -429,6 +443,10 @@ pub enum QueueOverlay<'a> {
         /// bare segments the painter indents under it. View mode wraps the stored
         /// title; edit mode wraps the draft.
         header_rows: Vec<String>,
+        /// Underlined leading identifier on a persisted task page in view mode only.
+        header_identifier: Option<String>,
+        /// Task the header identifier refers to, kept separate from paint text for hit testing.
+        header_identifier_task: Option<Uuid>,
         /// Terminal cursor (row, col) inside `header_rows` while the title is edited.
         title_cursor: Option<(u16, u16)>,
         /// The task's status word, dim and right-aligned on the header row.
@@ -531,6 +549,8 @@ pub enum QueueHitTarget {
     /// The quick-add input row. Clicking it keeps the already-focused line focused.
     QuickAddInput,
     Task(Uuid),
+    /// Underlined presentation-only identifier on a persisted task.
+    TaskNumber(Uuid),
     Verb(usize),
     /// The DONE section header (painted only while the drawer is open): toggles it shut,
     /// the mouse path onto the same [`BoardIntent::ToggleDoneDrawer`] `z` dispatches
@@ -1132,6 +1152,8 @@ fn paint_overlay(
         QueueOverlay::QuickAdd { .. } => {}
         QueueOverlay::TaskPage {
             ref header_rows,
+            ref header_identifier,
+            header_identifier_task,
             ref title_cursor,
             status_word,
             ref notes_rows,
@@ -1153,6 +1175,8 @@ fn paint_overlay(
                 frame,
                 geo,
                 header_rows,
+                header_identifier.as_deref(),
+                *header_identifier_task,
                 *title_cursor,
                 status_word,
                 notes_rows,
@@ -1872,6 +1896,8 @@ fn paint_task_page(
     frame: &mut Frame<'_>,
     geo: &TierGeometry,
     header_rows: &[String],
+    header_identifier: Option<&str>,
+    header_identifier_task: Option<Uuid>,
     title_cursor: Option<(u16, u16)>,
     status_word: &str,
     notes_rows: &[String],
@@ -1922,17 +1948,35 @@ fn paint_task_page(
             break;
         }
         let line = if offset == 0 {
-            let header = format!("  {row_text}");
-            let mut line = Line::from(Span::styled(header.clone(), style_bold()));
-            let used = display_width(&header);
-            if used + word < header_width as usize {
-                line.spans
-                    .push(Span::raw(" ".repeat(header_width as usize - used - word)));
-                line.spans
-                    .push(Span::styled(status_word.to_string(), style_dim()));
+            let (glyph, title) = row_text.split_once(' ').unwrap_or((row_text, ""));
+            let prefix = format!("  {glyph} ");
+            let identifier = header_identifier.unwrap_or_default();
+            let identifier_gap = if identifier.is_empty() { "" } else { " " };
+            let used = display_width(&prefix)
+                .saturating_add(display_width(identifier))
+                .saturating_add(display_width(identifier_gap))
+                .saturating_add(display_width(title));
+            let mut spans = vec![Span::styled(prefix, style_bold())];
+            if !identifier.is_empty() {
+                spans.push(Span::styled(identifier.to_string(), style_dim()));
+                spans.push(Span::styled(identifier_gap.to_string(), style_bold()));
+                if let Some(task) = header_identifier_task {
+                    hits.push(
+                        QueueHitTarget::TaskNumber(task),
+                        Rect::new(
+                            4,
+                            y,
+                            u16::try_from(display_width(identifier)).unwrap_or(u16::MAX),
+                            1,
+                        ),
+                    );
+                }
             }
-            // `  {glyph} {title}` — title words start at column 4; the glyph and the
-            // right-aligned status word are chrome and stay out of the copy.
+            spans.push(Span::styled(title.to_string(), style_bold()));
+            if used + word < header_width as usize {
+                spans.push(Span::raw(" ".repeat(header_width as usize - used - word)));
+                spans.push(Span::styled(status_word.to_string(), style_dim()));
+            }
             let title_cells = used.saturating_sub(4);
             if title_cells > 0 {
                 hits.push_copyable(Rect::new(
@@ -1942,7 +1986,7 @@ fn paint_task_page(
                     1,
                 ));
             }
-            line
+            Line::from(spans)
         } else {
             let painted = format!("    {row_text}");
             let title_cells = display_width(&painted).saturating_sub(4);
@@ -2348,9 +2392,11 @@ enum ListRow {
     Task {
         id: Uuid,
         line: Line<'static>,
-        /// First column of the title text (past indent + glyph).
+        /// Exact first-line identifier cells, if this persisted task has one.
+        identifier: Option<(u16, u16)>,
+        /// First copyable content column, past indent + glyph.
         content_x: u16,
-        /// Title-zone width (excludes right-aligned meta).
+        /// Content width (identifier + title on the first line, title only on continuations).
         content_width: u16,
     },
     /// Read-only accordion content under a task, full-width and un-hit-tested.
@@ -2457,12 +2503,16 @@ fn paint_list_row(
         ListRow::Task {
             id,
             line,
+            identifier,
             content_x,
             content_width: copy_w,
         } => {
             put_line(frame, y, content_width, line.clone());
             if base_list_interactive {
                 hits.push(QueueHitTarget::Task(*id), Rect::new(0, y, content_width, 1));
+                if let Some((x, width)) = identifier {
+                    hits.push(QueueHitTarget::TaskNumber(*id), Rect::new(*x, y, *width, 1));
+                }
             }
             hits.push_copyable(Rect::new(*content_x, y, *copy_w, 1));
         }
@@ -2555,10 +2605,6 @@ fn detail_lines_for_task(
         format_age(now, task.created_at),
         format_age(now, task.updated_at)
     );
-    let age_text = task
-        .number
-        .map(|number| format!("{number} · {age_text}"))
-        .unwrap_or(age_text);
     push(
         &mut lines,
         paint_bounded_line(&format!("{indent}scope {scope_text}"), width, style_dim()),
@@ -2601,13 +2647,7 @@ fn build_list_rows(
             // Stale ids may outlive a snapshot refresh. Skip them without inventing a row.
             return;
         };
-        let meta = if geo.meta_column_width == 0 {
-            task.number
-                .map(|number| number.to_string())
-                .unwrap_or_default()
-        } else {
-            row_meta(task, model.now, in_project_section)
-        };
+        let meta = row_meta(task, model.now, in_project_section);
         let selected = model.selection_id == Some(task.id)
             && !matches!(model.overlay, QueueOverlay::ScopeDropdown { .. });
         // A long title wraps onto continuation lines indented under its own first
@@ -2615,6 +2655,7 @@ fn build_list_rows(
         let lines = paint_task_row_lines(
             &TaskRowPaint {
                 glyph: status_glyph(task.status),
+                identifier: task.number.map(|number| format!("T{number}")).as_deref(),
                 title: &task.title,
                 meta: &meta,
                 selected,
@@ -2630,6 +2671,7 @@ fn build_list_rows(
             out.push(ListRow::Task {
                 id: task.id,
                 line: painted.line,
+                identifier: painted.identifier,
                 content_x: painted.content_x,
                 content_width: painted.content_width,
             });
@@ -3242,7 +3284,6 @@ fn paint_verb_bar(
 
 fn row_meta(task: &Task, now: SystemTime, in_project_section: bool) -> String {
     let age = format_age(now, task.updated_at);
-    let number = task.number.map(|number| number.to_string());
     let project = if !in_project_section {
         match &task.scope {
             TaskScope::Project { path } => Some(short_project(path).to_string()),
@@ -3251,34 +3292,22 @@ fn row_meta(task: &Task, now: SystemTime, in_project_section: bool) -> String {
     } else {
         None
     };
-    fit_row_meta(number, project, age)
+    fit_row_meta(project, age)
 }
 
-/// Keep number and age intact; shrink the project basename so the standard
-/// meta column (28 cells including the trailing margin) does not clip age.
-fn fit_row_meta(number: Option<String>, project: Option<String>, age: String) -> String {
+/// Keep the age intact and shrink the project basename inside the standard meta column.
+fn fit_row_meta(project: Option<String>, age: String) -> String {
     const CONTENT: usize = 27;
     const SEP: &str = " · ";
-    let sep_w = display_width(SEP);
-    let mut reserved = display_width(&age);
-    if let Some(n) = number.as_deref() {
-        reserved = reserved
-            .saturating_add(display_width(n))
-            .saturating_add(sep_w);
-    }
     let project = project.and_then(|name| {
-        let room = CONTENT.saturating_sub(reserved.saturating_add(sep_w));
+        let room = CONTENT.saturating_sub(display_width(&age).saturating_add(display_width(SEP)));
         (room > 0).then(|| present_line(&name, room))
     });
-    let mut parts = Vec::new();
-    if let Some(n) = number {
-        parts.push(n);
-    }
-    if let Some(p) = project {
-        parts.push(p);
-    }
-    parts.push(age);
-    parts.join(SEP)
+    [project, Some(age)]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(SEP)
 }
 
 pub(crate) fn format_age(now: SystemTime, then: SystemTime) -> String {
@@ -3326,14 +3355,6 @@ fn put_line_at(frame: &mut Frame<'_>, rect: Rect, line: Line<'static>) {
 
 pub(crate) fn display_width(s: &str) -> usize {
     Line::from(s).width()
-}
-
-fn fit_left(raw: &str, budget: usize) -> String {
-    if display_width(raw) <= budget {
-        return raw.to_string();
-    }
-    // present_line already applied to the title; this only guards prefix edge cases.
-    present_line(raw, budget)
 }
 
 fn bound_line(line: Line<'static>, max_width: usize) -> Line<'static> {
@@ -3447,6 +3468,7 @@ mod tests {
         let line = paint_task_row(
             &TaskRowPaint {
                 glyph: "○",
+                identifier: None,
                 title: &long_title,
                 meta: long_meta,
                 selected: false,
@@ -3492,6 +3514,7 @@ mod tests {
         let title_only = paint_task_row(
             &TaskRowPaint {
                 glyph: "○",
+                identifier: None,
                 title: &long_title,
                 meta: "1h",
                 selected: false,
@@ -3507,6 +3530,7 @@ mod tests {
         let meta_only = paint_task_row(
             &TaskRowPaint {
                 glyph: "○",
+                identifier: None,
                 title: "short",
                 meta: long_meta,
                 selected: false,
@@ -3553,6 +3577,7 @@ mod tests {
                         let line = paint_task_row(
                             &TaskRowPaint {
                                 glyph: "◓",
+                                identifier: None,
                                 title,
                                 meta,
                                 selected,
@@ -3596,6 +3621,49 @@ mod tests {
     }
 
     #[test]
+    fn task_identifier_is_dimmed_without_underline() {
+        let geo = tier::resolve(80, 24);
+        let line = paint_task_row(
+            &TaskRowPaint {
+                glyph: "○",
+                identifier: Some("T30"),
+                title: "copy this",
+                meta: "1m",
+                selected: false,
+                title_bold: false,
+            },
+            &geo,
+        );
+        let identifier = line
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == "T30")
+            .expect("identifier span");
+        assert!(identifier.style.add_modifier.contains(Modifier::DIM));
+        assert!(!identifier.style.add_modifier.contains(Modifier::UNDERLINED));
+
+        let selected = paint_task_row(
+            &TaskRowPaint {
+                glyph: "○",
+                identifier: Some("T30"),
+                title: "copy this",
+                meta: "1m",
+                selected: true,
+                title_bold: false,
+            },
+            &geo,
+        );
+        let identifier = selected
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == "T30")
+            .expect("selected identifier span");
+        assert!(identifier.style.add_modifier.contains(Modifier::DIM));
+        assert!(identifier.style.add_modifier.contains(Modifier::REVERSED));
+        assert!(!identifier.style.add_modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
     fn frame_escape_scan_finds_no_sgr_color_codes_only_bold_dim_underline_reverse() {
         // Scanner accepts mono SGR and rejects color SGR.
         assert_no_color_sgr("plain text");
@@ -3625,6 +3693,7 @@ mod tests {
         let variants = [
             TaskRowPaint {
                 glyph: "○",
+                identifier: None,
                 title: "plain row",
                 meta: "1h",
                 selected: false,
@@ -3632,6 +3701,7 @@ mod tests {
             },
             TaskRowPaint {
                 glyph: "▲",
+                identifier: None,
                 title: "bold title",
                 meta: "tsk · 2m",
                 selected: false,
@@ -3639,6 +3709,7 @@ mod tests {
             },
             TaskRowPaint {
                 glyph: "◓",
+                identifier: None,
                 title: "selected row",
                 meta: "3d",
                 selected: true,

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -443,7 +443,7 @@ pub enum QueueOverlay<'a> {
         /// bare segments the painter indents under it. View mode wraps the stored
         /// title; edit mode wraps the draft.
         header_rows: Vec<String>,
-        /// Underlined leading identifier on a persisted task page in view mode only.
+        /// Dim leading identifier on a persisted task page in view mode only.
         header_identifier: Option<String>,
         /// Task the header identifier refers to, kept separate from paint text for hit testing.
         header_identifier_task: Option<Uuid>,
@@ -549,7 +549,7 @@ pub enum QueueHitTarget {
     /// The quick-add input row. Clicking it keeps the already-focused line focused.
     QuickAddInput,
     Task(Uuid),
-    /// Underlined presentation-only identifier on a persisted task.
+    /// Dim presentation-only identifier on a persisted task.
     TaskNumber(Uuid),
     Verb(usize),
     /// The DONE section header (painted only while the drawer is open): toggles it shut,
@@ -1939,6 +1939,12 @@ fn paint_task_page(
     // to the content viewport below.
     let header_width = width.saturating_sub(2);
     let word = display_width(status_word);
+    // The broad title region sits beneath the identifier hit so a view-mode header can
+    // reserve the prefix for copy without making the rest of the title interactive.
+    hits.push(
+        QueueHitTarget::FormTitle,
+        Rect::new(0, lay.title_y, width, title_row_count),
+    );
     for (offset, row_text) in header_rows.iter().enumerate() {
         let y = lay.title_y.saturating_add(offset as u16);
         // The builder caps `header_rows` to the page body; this clamp holds even
@@ -1988,11 +1994,15 @@ fn paint_task_page(
             }
             Line::from(spans)
         } else {
-            let painted = format!("    {row_text}");
-            let title_cells = display_width(&painted).saturating_sub(4);
+            let has_identifier = header_identifier.is_some_and(|identifier| !identifier.is_empty());
+            let title_indent = 4usize
+                .saturating_add(header_identifier.map(display_width).unwrap_or(0))
+                .saturating_add(usize::from(has_identifier));
+            let painted = format!("{}{row_text}", " ".repeat(title_indent));
+            let title_cells = display_width(&painted).saturating_sub(title_indent);
             if title_cells > 0 {
                 hits.push_copyable(Rect::new(
-                    4,
+                    u16::try_from(title_indent).unwrap_or(u16::MAX),
                     y,
                     u16::try_from(title_cells).unwrap_or(u16::MAX),
                     1,
@@ -2002,10 +2012,6 @@ fn paint_task_page(
         };
         put_line(frame, y, header_width, line);
     }
-    hits.push(
-        QueueHitTarget::FormTitle,
-        Rect::new(0, lay.title_y, width, title_row_count),
-    );
     if let Some((cursor_row, cursor_col)) = title_cursor {
         // Every title row shares the four-cell gutter (two leading blanks plus
         // glyph and space), so the wrapped field starts at column 4 on all of them.

--- a/tests/cli_list.rs
+++ b/tests/cli_list.rs
@@ -1542,7 +1542,7 @@ fn human_list_rows_show_bare_digits() {
 }
 
 #[test]
-fn list_bare_digits_finds_the_task_from_another_cwd() {
+fn list_displayed_or_bare_number_finds_the_task_from_another_cwd() {
     let _env = env_lock();
     let invocation_repo = project_repo("number-invocation");
     let _context = EnvironmentGuard::context_for(&invocation_repo);
@@ -1566,19 +1566,25 @@ fn list_bare_digits_finds_the_task_from_another_cwd() {
         .number
         .expect("task number");
 
-    let output = list(&[
-        "tsk".into(),
-        "list".into(),
+    for operand in [
         number.to_string(),
-        "--json".into(),
-        "--state-dir".into(),
-        state_dir_arg(&dir),
-    ]);
+        format!("T{number}"),
+        format!("t{number}"),
+    ] {
+        let output = list(&[
+            "tsk".into(),
+            "list".into(),
+            operand,
+            "--json".into(),
+            "--state-dir".into(),
+            state_dir_arg(&dir),
+        ]);
 
-    assert_eq!(output.code, 0, "{}", output.stderr);
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&output.stdout).expect("JSON rows");
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0]["id"], task.to_string());
+        assert_eq!(output.code, 0, "{}", output.stderr);
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&output.stdout).expect("JSON rows");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["id"], task.to_string());
+    }
     let _ = std::fs::remove_dir_all(invocation_repo);
     let _ = std::fs::remove_dir_all(dir);
 }

--- a/tests/fixtures/queue_board/accordion.txt
+++ b/tests/fixtures/queue_board/accordion.txt
@@ -4,15 +4,15 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                                   1 · tsk · 3m │
+│  ▸ T1 Smoke-test worktree dispatch                                    tsk · 3m │
 │    │ no notes yet                                                              │
 │    │ scope tsk                                                                 │
-│    │ 1 · created 3m ago · updated 3m ago                                       │
-│  ▸ Edit target binding pin                                     2 · herdr · 12m │
+│    │ created 3m ago · updated 3m ago                                           │
+│  ▸ T2 Edit target binding pin                                      herdr · 12m │
 │                                                                                │
 │ desk ────────────────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ Global backlog note                                                  7 · 2d │
+│  ○ T7 Global backlog note                                                   2d │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/board.txt
+++ b/tests/fixtures/queue_board/board.txt
@@ -4,12 +4,12 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                                   1 · tsk · 3m │
-│  ▸ Edit target binding pin                                     2 · herdr · 12m │
+│  ▸ T1 Smoke-test worktree dispatch                                    tsk · 3m │
+│  ▸ T2 Edit target binding pin                                      herdr · 12m │
 │                                                                                │
 │ desk ────────────────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ Global backlog note                                                  7 · 2d │
+│  ○ T7 Global backlog note                                                   2d │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/board_default_split_78.txt
+++ b/tests/fixtures/queue_board/board_default_split_78.txt
@@ -4,12 +4,12 @@
 │                                                                              │
 │ IN MOTION ─────────────────────────────────────────────────────────────────2 │
 │                                                                              │
-│  ▸ Smoke-test worktree dispatch                                 1 · tsk · 3m │
-│  ▸ Edit target binding pin                                   2 · herdr · 12m │
+│  ▸ T1 Smoke-test worktree dispatch                                  tsk · 3m │
+│  ▸ T2 Edit target binding pin                                    herdr · 12m │
 │                                                                              │
 │ desk ──────────────────────────────────────────────────────────────────────1 │
 │                                                                              │
-│  ○ Global backlog note                                                7 · 2d │
+│  ○ T7 Global backlog note                                                 2d │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/tests/fixtures/queue_board/done_drawer.txt
+++ b/tests/fixtures/queue_board/done_drawer.txt
@@ -4,17 +4,17 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke-test worktree dispatch                                   1 · tsk · 3m │
-│  ▸ Edit target binding pin                                     2 · herdr · 12m │
+│  ▸ T1 Smoke-test worktree dispatch                                    tsk · 3m │
+│  ▸ T2 Edit target binding pin                                      herdr · 12m │
 │                                                                                │
 │ desk ────────────────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ Global backlog note                                                  7 · 2d │
+│  ○ T7 Global backlog note                                                   2d │
 │                                                                                │
 │ DONE ────────────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ✓ Ship the queue board milestone                                 8 · tsk · 5h │
-│  ✓ Retire classic board chrome                                          9 · 6h │
+│  ✓ T8 Ship the queue board milestone                                  tsk · 5h │
+│  ✓ T9 Retire classic board chrome                                           6h │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/help.txt
+++ b/tests/fixtures/queue_board/help.txt
@@ -4,12 +4,12 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │         ┌─ help ──────────────────────────────────────────────── [x]─┐         │
-│  ▸ Smoke│                                                            │tsk · 3m │
-│  ▸ Edit │  alt+q quit | Esc close                                    │dr · 12m │
+│  ▸ T1 Sm│                                                            │tsk · 3m │
+│  ▸ T2 Ed│  alt+q quit | Esc close                                    │dr · 12m │
 │         │  j/k · ↑/↓ move | alt+space primary                        │         │
 │ desk ───│  alt+d done | alt+o reopen                                 │───────1 │
 │         │  alt+b block | enter open                                  │         │
-│  ○ Globa│  →/← peek | + capture                                      │  7 · 2d │
+│  ○ T7 Gl│  →/← peek | + capture                                      │      2d │
 │         │  alt+e title | alt+x/Delete delete                         │         │
 │         │  alt+u undo | z drawer                                     │         │
 │         │  : palette | ? help                                        │         │

--- a/tests/fixtures/queue_board/palette.txt
+++ b/tests/fixtures/queue_board/palette.txt
@@ -4,12 +4,12 @@
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ Smoke┌─ command ───────────────────────────────────────────── [x]─┐tsk · 3m │
-│  ▸ Edit │                                                            │dr · 12m │
+│  ▸ T1 Sm┌─ command ───────────────────────────────────────────── [x]─┐tsk · 3m │
+│  ▸ T2 Ed│                                                            │dr · 12m │
 │         │   set status: ready                                        │         │
 │ desk ───│   set status: started                                      │───────1 │
 │         │ ▸ set status: blocked                                      │         │
-│  ○ Globa│   set status: review                                       │  7 · 2d │
+│  ○ T7 Gl│   set status: review                                       │      2d │
 │         │                                                            │         │
 │         ├────────────────────────────────────────────────────────────┤         │
 │         │ ↑/↓ move · enter run · esc close                           │         │

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -988,10 +988,10 @@ fn task_page_footer_hits_use_display_columns_and_stay_within_the_painted_row() {
     );
 }
 
-/// AC-25: a persisted task page paints its bare number before the footer scope, while the
-/// FormScope target starts after that non-interactive number chrome.
+/// A persisted task page presents its identifier in the title and leaves the footer scope
+/// as a direct, independent hit target.
 #[test]
-fn ac_25_task_page_footer_number_precedes_the_form_scope_hit_target() {
+fn task_page_header_identifier_precedes_the_title_and_footer_scope() {
     let mut domain = DomainState::new();
     let id = domain
         .create(
@@ -1022,16 +1022,21 @@ fn ac_25_task_page_footer_number_precedes_the_form_scope_hit_target() {
         .into_iter()
         .find(|hit| hit.target == QueueHitTarget::FormScope)
         .expect("scope hit");
-    let footer = row_text(&terminal, width, scope.area.y);
+    let header = (0..height)
+        .map(|y| row_text(&terminal, width, y))
+        .find(|row| row.contains("Numbered task"))
+        .expect("task page header");
     assert!(
-        footer.trim_start().starts_with("1 · app"),
-        "the painted footer must start with the persisted bare number: {footer:?}"
+        header.contains("T1 Numbered task"),
+        "the header must lead with the identifier: {header:?}"
     );
-    assert_eq!(
-        scope.area.x,
-        2 + "1 · ".chars().count() as u16,
-        "FormScope starts after the inset and non-interactive number chrome"
-    );
+    let identifier = board_hit_map(Rect::new(0, 0, width, height), &model)
+        .regions
+        .into_iter()
+        .find(|hit| hit.target == QueueHitTarget::TaskNumber(id))
+        .expect("identifier hit");
+    assert_eq!(identifier.area.width, 2, "only T1 is clickable");
+    assert_eq!(scope.area.x, 2, "scope starts at the footer inset");
 }
 
 #[test]

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -1036,6 +1036,11 @@ fn task_page_header_identifier_precedes_the_title_and_footer_scope() {
         .find(|hit| hit.target == QueueHitTarget::TaskNumber(id))
         .expect("identifier hit");
     assert_eq!(identifier.area.width, 2, "only T1 is clickable");
+    let footer = row_text(&terminal, width, scope.area.y);
+    assert!(
+        !footer.contains("1 ·"),
+        "the production footer must not repeat the identifier: {footer:?}"
+    );
     assert_eq!(scope.area.x, 2, "scope starts at the footer inset");
 }
 

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1494,6 +1494,31 @@ fn a_row_click_selects_and_peeks_and_a_second_click_opens_the_task_page() {
 }
 
 #[test]
+fn task_identifier_click_copies_without_falling_through_to_row_or_page_actions() {
+    let (domain, _model, id) = board_with_task("Copy this identifier", HumanStatus::Ready);
+    let mut task = domain.get(id).expect("task").clone();
+    task.number = Some(30);
+    let model = BoardModel::from_tasks(vec![task], Some(PathBuf::from(THIS_REPO)));
+
+    let hits = board_hit_map(STANDARD, &model);
+    let identifier = hits
+        .regions
+        .iter()
+        .find(|hit| hit.target == QueueHitTarget::TaskNumber(id))
+        .expect("identifier hit")
+        .area;
+    assert_eq!(
+        identifier.width, 3,
+        "the T30 cells are the whole click target"
+    );
+    assert_eq!(
+        map_board_mouse(&model, &hits, left_click(identifier.x, identifier.y)),
+        Some(BoardIntent::CopyTaskNumber(id)),
+        "identifier click must not become a row selection"
+    );
+}
+
+#[test]
 fn page_field_clicks_stay_inert_including_the_scope_footer() {
     let (mut domain, mut model) = deck_of(1);
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open the page");

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1519,6 +1519,71 @@ fn task_identifier_click_copies_without_falling_through_to_row_or_page_actions()
 }
 
 #[test]
+fn quick_add_identifier_click_copies_without_discarding_the_draft() {
+    let (mut domain, _model, id) = board_with_task("Copy while drafting", HumanStatus::Ready);
+    let mut task = domain.get(id).expect("task").clone();
+    task.number = Some(30);
+    let mut model = BoardModel::from_tasks(vec![task], Some(PathBuf::from(THIS_REPO)));
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenCapture, None).expect("open draft");
+
+    let hits = board_hit_map(STANDARD, &model);
+    let identifier = hits
+        .regions
+        .iter()
+        .find(|hit| hit.target == QueueHitTarget::TaskNumber(id))
+        .expect("identifier hit")
+        .area;
+    assert_eq!(
+        map_board_mouse(&model, &hits, left_click(identifier.x, identifier.y)),
+        Some(BoardIntent::CopyTaskNumber(id))
+    );
+}
+
+#[test]
+fn unnumbered_rows_and_drafts_register_no_identifier_hit() {
+    let (mut domain, mut model, _id) = board_with_task("Unsaved task", HumanStatus::Ready);
+    assert!(
+        !board_hit_map(STANDARD, &model)
+            .regions
+            .iter()
+            .any(|hit| matches!(hit.target, QueueHitTarget::TaskNumber(_))),
+        "a task without a persisted number must not paint an identifier"
+    );
+
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenCapture, None).expect("open draft");
+    assert!(
+        !board_hit_map(STANDARD, &model)
+            .regions
+            .iter()
+            .any(|hit| matches!(hit.target, QueueHitTarget::TaskNumber(_))),
+        "an unsaved quick-add draft must not synthesize an identifier"
+    );
+}
+
+#[test]
+fn task_page_identifier_click_copies_instead_of_hitting_the_title_region() {
+    let (mut domain, _model, id) = board_with_task("Copy this page identifier", HumanStatus::Ready);
+    let mut task = domain.get(id).expect("task").clone();
+    task.number = Some(31);
+    let mut model = BoardModel::from_tasks(vec![task], Some(PathBuf::from(THIS_REPO)));
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
+    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+
+    let hits = board_hit_map(STANDARD, &model);
+    let identifier = hits
+        .regions
+        .iter()
+        .find(|hit| hit.target == QueueHitTarget::TaskNumber(id))
+        .expect("page identifier hit")
+        .area;
+    assert_eq!(
+        map_board_mouse(&model, &hits, left_click(identifier.x, identifier.y)),
+        Some(BoardIntent::CopyTaskNumber(id)),
+        "the identifier must outrank the broad title hit"
+    );
+}
+
+#[test]
 fn page_field_clicks_stay_inert_including_the_scope_footer() {
     let (mut domain, mut model) = deck_of(1);
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open the page");

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1551,12 +1551,21 @@ fn unnumbered_rows_and_drafts_register_no_identifier_hit() {
     );
 
     apply_intent(&mut domain, &mut model, BoardIntent::OpenCapture, None).expect("open draft");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddInsertText("Draft title".to_string()),
+        None,
+    )
+    .expect("type draft");
+    apply_intent(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None)
+        .expect("expand draft onto the task page");
     assert!(
         !board_hit_map(STANDARD, &model)
             .regions
             .iter()
             .any(|hit| matches!(hit.target, QueueHitTarget::TaskNumber(_))),
-        "an unsaved quick-add draft must not synthesize an identifier"
+        "an unsaved quick-add task page must not synthesize an identifier"
     );
 }
 

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -933,7 +933,7 @@ fn compact_77x24_and_48x19_and_40x10_paint_glyph_title_only_rows_and_leq_5_verb_
 /// status word), notes body, and meta footer. The selector row stays hidden, the base list
 /// never bleeds through, and every row is width-bounded at the 40x10 floor.
 #[test]
-fn board_row_meta_shows_bare_digits_not_hash_or_t_prefix() {
+fn board_row_leads_title_with_uppercase_t_identifier() {
     let mut tasks = fixture_tasks();
     tasks[0].number = Some(12);
     let view = fixture_view(&tasks, false);
@@ -941,17 +941,17 @@ fn board_row_meta_shows_bare_digits_not_hash_or_t_prefix() {
     let body = paint(80, 24, &model).0.join("\n");
 
     assert!(
-        body.contains("12 · tsk · 3m"),
-        "number must lead row meta:\n{body}"
+        body.contains("T12 Smoke-test worktree dispatch"),
+        "identifier must lead the title:\n{body}"
     );
     assert!(
-        !body.contains("#12") && !body.contains("T12"),
-        "number must be bare:\n{body}"
+        !body.contains("12 · tsk · 3m"),
+        "trailing meta must not repeat the identifier:\n{body}"
     );
 }
 
 #[test]
-fn standard_row_meta_keeps_age_when_number_and_long_project_compete() {
+fn standard_row_meta_keeps_age_when_long_project_competes() {
     let mut tasks = fixture_tasks();
     tasks[0].number = Some(7);
     tasks[0].scope = project("/src/customer-portal-api");
@@ -966,12 +966,12 @@ fn standard_row_meta_keeps_age_when_number_and_long_project_compete() {
     assert!(row.contains('7'), "number must remain visible:\n{row}");
     assert!(
         row.contains("12m"),
-        "age must remain visible when number plus a long project share the meta column:\n{row}"
+        "age must remain visible when a long project shares the meta column:\n{row}"
     );
 }
 
 #[test]
-fn peek_shows_bare_digits() {
+fn peek_keeps_the_identifier_on_its_task_row_not_in_detail_meta() {
     let mut tasks = fixture_tasks();
     tasks[0].number = Some(12);
     let view = fixture_view(&tasks, false);
@@ -980,22 +980,24 @@ fn peek_shows_bare_digits() {
     let body = paint(80, 24, &model).0.join("\n");
 
     assert!(
-        body.contains("12 · created 3m ago"),
-        "peek must show bare number:\n{body}"
+        body.contains("T12 Smoke-test worktree dispatch"),
+        "row must lead with T12:\n{body}"
     );
     assert!(
-        !body.contains("#12") && !body.contains("T12"),
-        "number must be bare:\n{body}"
+        !body.contains("12 · created"),
+        "peek detail must not duplicate the identifier:\n{body}"
     );
 }
 
 #[test]
-fn task_page_footer_shows_bare_digits() {
+fn task_page_header_shows_identifier_not_footer() {
     let tasks = fixture_tasks();
     let view = fixture_view(&tasks, false);
     let mut model = fixture_model(&tasks, &view);
     model.overlay = QueueOverlay::TaskPage {
         header_rows: vec!["○ numbered page".to_string()],
+        header_identifier: Some("T12".to_string()),
+        header_identifier_task: Some(Uuid::from_u128(1)),
         title_cursor: None,
         status_word: "ready",
         notes_rows: Vec::new(),
@@ -1006,8 +1008,8 @@ fn task_page_footer_shows_bare_digits() {
         step_scroll: 0,
         step_marked: None,
         step_editor: None,
-        meta: "12 · desk · created 1m ago · updated 1m ago".to_string(),
-        meta_scope_x: 5,
+        meta: "desk · created 1m ago · updated 1m ago".to_string(),
+        meta_scope_x: 0,
         meta_scope_width: 4,
         thread_slot_width: None,
         focus: None,
@@ -1016,17 +1018,17 @@ fn task_page_footer_shows_bare_digits() {
     let body = paint(80, 24, &model).0.join("\n");
 
     assert!(
-        body.contains("12 · desk"),
-        "footer must start with the bare number:\n{body}"
+        body.contains("T12 numbered page"),
+        "header must lead with T12:\n{body}"
     );
     assert!(
-        !body.contains("#12") && !body.contains("T12"),
-        "number must be bare:\n{body}"
+        !body.contains("12 · desk"),
+        "footer must not repeat the identifier:\n{body}"
     );
 }
 
 #[test]
-fn done_drawer_rows_show_bare_digits() {
+fn done_drawer_rows_lead_with_identifiers() {
     let mut tasks = fixture_tasks();
     tasks[7].number = Some(12);
     let view = fixture_view(&tasks, true);
@@ -1034,12 +1036,12 @@ fn done_drawer_rows_show_bare_digits() {
     let body = paint(80, 24, &model).0.join("\n");
 
     assert!(
-        body.contains("12 · tsk · 5h"),
-        "done row must show bare number:\n{body}"
+        body.contains("T12"),
+        "done row must show a leading identifier:\n{body}"
     );
     assert!(
-        !body.contains("#12") && !body.contains("T12"),
-        "number must be bare:\n{body}"
+        !body.contains("12 · tsk · 5h"),
+        "done row must not retain trailing number chrome:\n{body}"
     );
 }
 
@@ -1092,6 +1094,8 @@ fn task_page_renders_header_notes_and_meta_as_a_full_takeover_in_both_tiers() {
     let mut model = fixture_model(&tasks, &view);
     model.overlay = QueueOverlay::TaskPage {
         header_rows: vec!["\u{25cb} Rename this task".to_string()],
+        header_identifier: None,
+        header_identifier_task: None,
         title_cursor: None,
         status_word: "ready",
         notes_rows: vec![


### PR DESCRIPTION
## Summary
- render persisted tasks as dim `T<number>` prefixes instead of trailing bare-number chrome
- copy the identifier with a targeted click on rows and task-page headers
- accept `T12`, `t12`, and `12` in direct CLI task lookups

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo build --release`
- `cd site && npm test && npm run build`

No Agent SDLC ledger exists for this direct UI change; the commands above were verified on the branch.