### PR TITLE
Prepare the v0.5.0 release

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,10 +1,8 @@
 name: Site
 
 on:
+  # Run on every PR so `build` can be a stable required check on main.
   pull_request:
-    paths:
-      - "site/**"
-      - ".github/workflows/site.yml"
   push:
     paths:
       - "site/**"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,9 @@ For scriptable board work, use `tsk add` and `tsk list`; read
 - Green bar: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
 - CI installs Rust **1.96.0** with `rustfmt` + `clippy` on ubuntu and macos. The
   frame-time bench is Linux-only. Site-only pushes skip that matrix
-  (`paths-ignore: site/**`). Site CI is `.github/workflows/site.yml`:
-  `npm ci && npm test && npm run build` in `site/`.
+  (`paths-ignore: site/**`). Site CI runs on every pull request so its `build`
+  job can be required, and on site-only pushes: `npm ci && npm test && npm run build`
+  in `site/` (`.github/workflows/site.yml`).
 - Landing page and Starlight docs live in `site/` (Astro). They are not part of
   the `tsk` binary. Production: https://gettsk.sh. Point Vercel at
   this repo with Root Directory `site`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ The committed `.gitignore` already covers it.
 board for capture and human-status verbs. It ships as the herdr plugin
 `herdr-tsk`, and the built binary (`tsk`) also runs standalone. Attention,
 park/resume, linking, and dispatch are not in this tree; reference lives on
-`archive/dark-engine-pre-v1`. Crate (`tsk-tui`) and plugin are `0.4.0`.
+`archive/dark-engine-pre-v1`. Crate (`tsk-tui`) and plugin are `0.5.0`.
 
 A gitignored `HANDOFF.md` may hold this clone’s live working state.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.5.0
+
+Wide task view: at 110 usable columns or wider, the board and task page form a
+four-stage slider. Arrow keys move between the full board, board plus task,
+rail plus task, and full task page while preserving drafts and focus across
+resizes. Narrow layouts retain the existing board, peek, and page behavior.
+
 Private state permissions: on Unix the state/config directory (`~/.tsk` by
 default) is `0700` and every file in it — `tsk.json`, `tsk.json.1`,
 `tsk.json.v<N>`, `trash.jsonl`, `tsk.json.lock`, `walkthrough.json`, and any
@@ -55,6 +62,9 @@ Synced-folder note: keep `~/.tsk` on a local disk. The writer lock is
 `flock`-style and every save is a rename-based atomic replace; NFS, Dropbox,
 iCloud Drive, and similar synced folders can break both. `TSK_STATE_DIR` is
 the escape hatch. Windows is not tested in CI.
+
+The landing page and complete user guide now ship from this repository at
+https://gettsk.sh. Current code and release metadata use the MIT license.
 
 ## 0.4.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tsk-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crossterm",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-tui"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "tsk: a task board for your terminal"
 license = "MIT"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -2,7 +2,7 @@
 
 id = "herdr-tsk"
 name = "herdr-tsk"
-version = "0.4.0"
+version = "0.5.0"
 description = "Queue board and quick capture inside herdr."
 min_herdr_version = "0.7.5"
 platforms = ["linux", "macos"]

--- a/site/src/version.mjs
+++ b/site/src/version.mjs
@@ -1,2 +1,2 @@
 // Crate and plugin version, shown in the landing and docs headers.
-export const VERSION = '0.4.0';
+export const VERSION = '0.5.0';

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -33,6 +33,21 @@ test("no tracked file still points at the old preview domain", async () => {
   assert.deepEqual(offenders, [], "stale preview-domain references remain");
 });
 
+test("crate, plugin, lockfile, and site share one release version", async () => {
+  const [cargo, plugin, lockfile, siteVersion] = await Promise.all([
+    read("../../Cargo.toml"),
+    read("../../herdr-plugin.toml"),
+    read("../../Cargo.lock"),
+    read("../src/version.mjs"),
+  ]);
+  const cargoVersion = cargo.match(/^version = "([^"]+)"/m)?.[1];
+  const pluginVersion = plugin.match(/^version = "([^"]+)"/m)?.[1];
+  const lockVersion = lockfile.match(/\[\[package\]\]\nname = "tsk-tui"\nversion = "([^"]+)"/)?.[1];
+  const renderedVersion = siteVersion.match(/VERSION = '([^']+)'/)?.[1];
+  assert.equal(cargoVersion, "0.5.0");
+  assert.deepEqual([pluginVersion, lockVersion, renderedVersion], [cargoVersion, cargoVersion, cargoVersion]);
+});
+
 test("the Astro site and sitemap build on the canonical URL", async () => {
   const config = await read("../astro.config.mjs");
   assert.match(config, /site: 'https:\/\/gettsk\.sh'/);


### PR DESCRIPTION
## Status

- bumps the crate, Herdr plugin, lockfile, and rendered site version to `0.5.0`
- moves the accumulated Unreleased notes into a `0.5.0` changelog section and adds the wide task view and public site highlights
- adds a site test that keeps crate, plugin, lockfile, and rendered versions aligned
- runs the site build on every pull request so `build` can be configured as a stable required check on `main`

## Ask

Please review the release metadata and required-check preparation before the `v0.5.0` tag is created.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release`
- [x] `cd site && npm ci && npm test && npm run build`
- [x] Site workflow parsed with `js-yaml`
