### PR TITLE
Agent CLI: status, edit, and step rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,9 +187,10 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   dedupe by id and skip torn lines, and trash is always durable before the live document loses
   a task. `tsk list --deleted` reads it; `tsk trash restore T<n>` brings a task back. Nothing on
   the board reads trash.
-- CLI verbs beyond add/list/steps: `tsk trash restore`, `tsk archive|unarchive T<n>`,
+- CLI verbs beyond add/list/steps: `tsk status T<n> <status>`, `tsk edit T<n>`, `tsk trash restore`, `tsk archive|unarchive T<n>`,
   `tsk project archive|unarchive <name>`, `tsk list --archived`; `tsk add` into an archived
-  project refuses with error code `project-archived`.
+  project refuses with error code `project-archived`. `tsk status` accepts ready, started
+  (or start), blocked, review, or done. `tsk steps` also renames and removes.
 - `~/.tsk` must live on a local disk (flock plus rename-based replace); synced folders are
   unsupported, `TSK_STATE_DIR` is the escape hatch. State/config directory roots must be real
   directories, not symlinks; permission hardening refuses a symlink instead of chmodding its target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Agent CLI mutations: `tsk status T<n> <status>` sets ready, started, blocked, or
 review, or done (`start` is an alias for `started`; idempotent on repeat), `tsk edit T<n>`
 updates title and/or notes, and `tsk steps` gains `rename` and `remove`.
 
-Human CLI output escapes C0/C1 controls in titles, step text, and project names.
+Human CLI output escapes C0/C1 controls in titles, step text, project names, and usage reasons that echo argv.
 `tsk list T<n>` documents live-store lookup vs `trash.jsonl`. Install docs keep
 `./target/release/tsk` after build, with an optional PATH export.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Agent CLI mutations: `tsk status T<n> <status>` sets ready, started, blocked, or
+review, or done (`start` is an alias for `started`; idempotent on repeat), `tsk edit T<n>`
+updates title and/or notes, and `tsk steps` gains `rename` and `remove`.
+
+Human CLI output escapes C0/C1 controls in titles, step text, and project names.
+`tsk list T<n>` documents live-store lookup vs `trash.jsonl`. Install docs keep
+`./target/release/tsk` after build, with an optional PATH export.
+
 ## 0.5.0
 
 Wide task view: at 110 usable columns or wider, the board and task page form a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,11 +4,13 @@ Canonical terms for this repo. No implementation detail.
 
 - **add command**: headless `tsk add` subcommand that creates tasks without opening a TUI.
 - **list command**: headless `tsk list` subcommand that prints tasks from the board store without changing them.
+- **status command**: headless `tsk status` subcommand that sets a task's human status to ready, started, blocked, review, or done. `start` is an alias for `started`.
+- **edit command**: headless `tsk edit` subcommand that updates a task's title and/or notes without changing scope or thread.
 - **bulk add**: one `add` invocation that accepts many items, reports each, and makes one durable write of the successes.
 - **invocation default**: capture scope used when the caller omits `project` / `-p`. The cwd repo when known, otherwise the desk.
 - **desk**: your desk holds everything not tied to a project. Selected by `--desk` and by bare `!p`. Stored as scope value `global`.
 - **tiny result**: JSON report from a plan-shaped `add`. `created` and `existing` rows carry index, id, title. `failed` rows carry index, title (string or null), error code, and human error text. Notes are not echoed.
-- **exit contract**: `add`/`list` exit `0` means every item was created or already existed (or list succeeded). `1` means one or more item refusals: retry only the failed subset. `2` means usage or parse error: nothing persisted. `3` means store I/O: commit is indeterminate; verify with `list` and retry only what is missing.
+- **exit contract**: `add`/`list`/`status`/`edit`/`steps` exit `0` means the write happened or was already true (or list succeeded). `1` means one or more item refusals: retry only the failed subset. `2` means usage or parse error: nothing persisted. `3` means store I/O: commit is indeterminate; verify with `list` and retry only what is missing.
 - **error code**: stable machine-matchable token on a failed item (`empty-title`, `invalid-title`, `invalid-item`). Any C0 control makes a title `invalid-title` before trimming, including a control-only title. The human `error` string is not a contract.
 - **persisted**: a later `list` against the same store returns that task.
 - **nothing persisted**: a later `list` against the same store shows no task created by that invocation.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 You and your agents put work on one board and move it through human status:
 ready, started, blocked, review, done. Agents reach the board through the CLI.
-Only a human marks a task done. It ships as a [herdr](https://herdr.dev) plugin,
-and the `tsk` binary also runs standalone against `~/.tsk`.
+It ships as a [herdr](https://herdr.dev) plugin, and the `tsk` binary also runs
+standalone against `~/.tsk`.
 
 - Queue board with desk · projects · threads
 - Quick-add on the board, plus a herdr capture overlay
 - Task page for notes, thread, scope, and steps
-- Headless `tsk add`, `tsk list`, and `tsk steps`
+- Headless `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`
 
 Park, resume, attention, linking, and dispatch are not part of this tree.
 
@@ -23,6 +23,8 @@ cargo build --release
 ./target/release/tsk add -t "Draft release notes"
 ./target/release/tsk
 ```
+
+To run `tsk` without the path, `export PATH="$PWD/target/release:$PATH"`.
 
 As a herdr plugin: `cargo build --release`, then `herdr plugin link "$PWD"`,
 then **Open tsk board**. Rebuild after you pull. A running board keeps the old

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,6 +1,6 @@
 # tsk
 
-> A task board for you and your agents, in your terminal. Both put work on one board and move it through ready, started, blocked, review, done. Agents reach it through the CLI; only a human marks done.
+> A task board for you and your agents, in your terminal. Both put work on one board and move it through ready, started, blocked, review, done. Agents reach it through the CLI.
 
 User guide: https://gettsk.sh/docs/
 

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: Headless tsk add, list, steps, trash, and archive. The agents' door to the board.
+description: Headless tsk add, list, steps, status, edit, trash, and archive. The agents' door to the board.
 ---
 
 The same `~/.tsk` store backs the board, herdr, and these commands. The board
@@ -19,11 +19,11 @@ The CLI is how an agent reaches the board. The rules that matter:
   `--file`. A repeat of the same title, project, and thread returns the existing
   task, so a retried plan is safe.
 - Plan with `tsk steps <task> add`. Read back with `tsk list <task>` before a
-  toggle, because toggle is not idempotent.
+  toggle or remove, because those are not idempotent.
+- Move work with `tsk status <task> start` (or `started`, `blocked`, `review`, `ready`, `done`).
+  Repeating the same status is safe. Rewrite title or notes with `tsk edit`.
 - Prefer `--json` and read the exit code. Exit 1 means retry only the failed
   items. Exit 3 means list before retrying.
-- Done is a human verb on the board. The CLI has no verb for it, and no status
-  verb yet.
 
 The repo ships the same rules as an agent skill in
 [`skills/tsk-cli/SKILL.md`](https://github.com/smarzban/herdr-tsk/blob/main/skills/tsk-cli/SKILL.md).
@@ -34,11 +34,14 @@ The repo ships the same rules as an agent skill in
 | --- | --- |
 | `tsk` | opens the board |
 | `tsk capture` | opens the capture form (also `TSK_MODE=capture`) |
-| `tsk add` · `tsk list` · `tsk steps` · `tsk trash` · `tsk archive` · `tsk unarchive` · `tsk project` | headless; below |
+| `tsk add` · `tsk list` · `tsk steps` · `tsk status` · `tsk edit` · `tsk trash` · `tsk archive` · `tsk unarchive` · `tsk project` | headless; below |
 | `tsk --help` | usage, exit 0 |
 | `tsk --find-board-pane` | herdr helper: reads `pane list` JSON on stdin, prints the id of the pane labelled `tsk`; exit 1 when none |
 
 Every headless command takes `--state-dir <dir>` to work against another store.
+
+Human-readable stdout and stderr escape C0/C1 controls in stored titles, step
+text, and project names as `\u{00xx}`. JSON keeps the underlying values.
 
 ## add
 
@@ -110,8 +113,11 @@ trailing scope label (`desk` or `project: <path>`) tells the groups apart.
 
 A store-global task number (`T12`, `t12`, or bare `12`) or a task UUID lists
 that one task and its steps (`[x]` / `[ ]` plus the step short id). Direct lookup
-ignores cwd. A task operand cannot combine with scope, thread, or status
-filters. An address that matches nothing is a usage error (exit 2).
+ignores cwd and searches the live store, including done and live soft-deleted
+tasks. A task that has moved to `trash.jsonl` is not found by `tsk list T12`;
+use `tsk list --deleted`, then `tsk trash restore T12`. A task operand cannot
+combine with scope, thread, or status filters. An address that matches nothing
+is a usage error (exit 2).
 
 `--json` is a flat array of `id`, `number`, `title`, `status`, `project`, and
 `thread`. Single-task JSON also attaches `steps`.
@@ -123,12 +129,42 @@ To recover a typo scope: `tsk list --all --json`.
 ```
 tsk steps <task> add <text> [--state-dir <dir>]
 tsk steps <task> toggle <step-short-id> [--state-dir <dir>]
+tsk steps <task> rename <step-short-id> <text> [--state-dir <dir>]
+tsk steps <task> remove <step-short-id> [--state-dir <dir>]
 ```
 
-Output is `added <short-id> <text>` or `toggled <short-id> [x] <text>`.
+Output is `added <short-id> <text>`, `toggled <short-id> [x] <text>`,
+`renamed <short-id> <text>`, or `removed <short-id> <text>`.
 
-See [steps](/docs/steps/) for the board side. `toggle` is not idempotent. Verify
-with `tsk list <task>` before a retry.
+See [steps](/docs/steps/) for the board side. `toggle` and `remove` are not
+idempotent. `rename` is idempotent on the trimmed text. Verify with
+`tsk list <task>` before a retry of toggle or remove.
+
+## status
+
+```
+tsk status <task> <status> [--state-dir <dir>]
+```
+
+`<status>` is `ready`, `started` (or `start`), `blocked`, `review`, or `done` (`tsk status <task> done`). Output is
+`status T<n> <status> <title>` and always uses the stored name (`started`). Repeating the same status is idempotent.
+
+Unknown task: `unknown-task`. Soft-deleted: `soft-deleted-task`.
+
+## edit
+
+```
+tsk edit <task> [--title <title>] [--notes <notes>] [--state-dir <dir>]
+```
+
+At least one of `--title` or `--notes` is required. Scope and thread are
+unchanged. Notes that trim to nothing are cleared. Output is
+`edited T<n> <title>`. Repeating the stored values is idempotent.
+
+Values that start with `-` need `--title=…` or `--notes=…`.
+
+Refusal tokens: `unknown-task`, `soft-deleted-task`, `empty-title`,
+`invalid-title`, `invalid-notes`.
 
 ## trash
 
@@ -176,8 +212,8 @@ idempotent on repeat. A name matching no project that has tasks exits 1 with
 
 | Exit | Meaning |
 | --- | --- |
-| 0 | listed, every add item created/existed, the step applied, the task restored, or the archive flag written (or already had the value) |
-| 1 | one or more item refusals (add/steps), a trash restore with no matching line, an unknown or deleted `archive`/`unarchive` task, or a project action matching nothing. Retry only the failed subset. For toggle, list first. |
+| 0 | listed, every add item created/existed, the step applied, status or edit written (or already had the value), the task restored, or the archive flag written (or already had the value) |
+| 1 | one or more item refusals (add/steps/status/edit), a trash restore with no matching line, an unknown or deleted `archive`/`unarchive` task, or a project action matching nothing. Retry only the failed subset. For toggle and remove, list first. |
 | 2 | usage or parse error, including a `list` address that matches nothing. Nothing persisted. |
 | 3 | store I/O. Commit is indeterminate. `tsk list` before retrying. |
 
@@ -190,3 +226,8 @@ before trimming.
 
 Steps refusals (exit 1): `empty-step-text`, `invalid-step-text`, `unknown-task`,
 `soft-deleted-task`, `unknown-step`, `ambiguous-step`.
+
+Status refusals (exit 1): `unknown-task`, `soft-deleted-task`.
+
+Edit refusals (exit 1): `unknown-task`, `soft-deleted-task`, `empty-title`,
+`invalid-title`, `invalid-notes`.

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -5,7 +5,7 @@ description: What tsk is, who moves the work, and where to read next.
 
 **tsk** is a task board for you and your agents, in your terminal. You both put
 work on one board and move it through human status: ready, started, blocked,
-review, done. Only a human marks a task done.
+review, done.
 
 It ships as the herdr plugin `herdr-tsk`. The `tsk` binary also runs standalone
 against `~/.tsk`. The pane, the capture overlay, and the CLI edit the same store.
@@ -17,13 +17,14 @@ This site is the user guide.
 - **You** work the board: tabs, peek, the task page, and the status verbs behind
   Ctrl.
 - **Agents** work the [CLI](/docs/cli/): `tsk add` puts work on the board,
-  `tsk steps` plans it, `tsk list` reads it back. Adding a task that already
-  exists returns the existing one, so a retried plan is safe.
-- **Done is a human verb.** Nothing in tsk completes a task on an agent's behalf,
-  and the CLI has no verb for it.
+  `tsk steps` plans it, `tsk status` and `tsk edit` move it, `tsk list` reads it
+  back. Adding a task that already exists returns the existing one, so a retried
+  plan is safe.
+- **Status is shared.** Agents set ready, started, blocked, review, or done with
+  `tsk status`. Nothing auto-completes a task from agent lifecycle.
 
-Moving status from the CLI, assigning a task to an agent, and starting that agent
-from the board are in progress. They are not in the current build.
+Assigning a task to an agent, and starting that agent from the board, are in
+progress. They are not in the current build.
 
 ## What you can do
 
@@ -31,7 +32,7 @@ from the board are in progress. They are not in the current build.
   planning space: general to-dos, future projects, anything outside a repository.
 - Capture with `+` on the board, or a herdr overlay
 - Open a task page for title, notes, thread, scope, and steps
-- Script the same store with `tsk add`, `tsk list`, and `tsk steps`
+- Script the same store with `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`
 
 Park, resume, attention, linking, and dispatch are not in this product.
 

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -17,7 +17,12 @@ cd herdr-tsk
 cargo build --release
 ```
 
-The binary is `target/release/tsk`.
+The binary is `target/release/tsk`. Run it with that path, or put the directory
+on `PATH` for this shell:
+
+```bash
+export PATH="$PWD/target/release:$PATH"
+```
 
 ## Standalone
 
@@ -42,9 +47,12 @@ at a directory on a local disk. State and config directory roots must be real
 directories, not symlinks.
 
 ```bash
-tsk add -t "Draft release notes"
-tsk list
+./target/release/tsk add -t "Draft release notes"
+./target/release/tsk list
 ```
+
+After `export PATH="$PWD/target/release:$PATH"`, the same commands work as
+`tsk add` and `tsk list`.
 
 ## As a herdr plugin
 

--- a/site/src/content/docs/docs/steps.md
+++ b/site/src/content/docs/docs/steps.md
@@ -50,6 +50,8 @@ without closing or trapping that row.
 ```bash
 tsk steps <task> add "Write the failing test"
 tsk steps <task> toggle <step-short-id>
+tsk steps <task> rename <step-short-id> "Pin the saved id"
+tsk steps <task> remove <step-short-id>
 tsk list <task>
 ```
 
@@ -60,7 +62,9 @@ A step short id is the shortest unambiguous prefix of that step's id, as printed
 by `tsk list <task>`.
 
 `toggle` flips the flag. A blind retry after an unseen success flips it back.
-Verify with `tsk list <task>` before retrying.
+`rename` is idempotent on the trimmed text. `remove` is not: a retry after an
+unseen success is `unknown-step`. Verify with `tsk list <task>` before retrying
+toggle or remove.
 
 Soft-deleted tasks refuse step changes.
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -526,9 +526,9 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
             <span class="index">05 <span class="index-label">cli</span></span>
             <h2 id="cli-heading">Built for agents from the first commit.</h2>
             <p class="band-lede">
-              Headless <code>add</code>, <code>list</code>, and <code>steps</code> against the
+              Headless <code>add</code>, <code>list</code>, <code>status</code>, <code>edit</code>, and <code>steps</code> against the
               same store. An agent drops a plan in as JSON and it lands as <b>ready</b> tasks. It
-              can check off steps and report progress. It cannot mark anything done.
+              can move status, rewrite notes, check off steps, and mark work done.
             </p>
           </header>
 
@@ -537,8 +537,10 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
 <span class="dim">&#123;"outcome":"created","id":"5c1e…","number":32,"title":"Draft release notes","project":"tsk"&#125;</span>
 <span class="prompt">$</span> tsk steps T32 add "Write the failing test"
 <span class="dim">added 9f Write the failing test</span>
+<span class="prompt">$</span> tsk status T32 start
+<span class="dim">status T32 started Draft release notes</span>
 <span class="prompt">$</span> tsk list T32
-<span class="dim">READY
+<span class="dim">STARTED
  - 32 Draft release notes #release
    [ ] 9f Write the failing test</span>
 <span class="prompt">$</span> cat plan.json | tsk add

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -145,12 +145,14 @@ test("docs paint keys as keycaps and leave flags as code", async () => {
   }
 });
 
-test("docs open on the two-party board and keep done human", async () => {
+test("docs open on the two-party board and let agents set status", async () => {
   const overview = await read("../src/content/docs/docs/index.mdx");
   assert.match(overview, /a task board for you and your agents/);
-  assert.match(overview, /Done is a human verb/);
+  assert.match(overview, /tsk status/);
+  assert.doesNotMatch(overview, /Done is a human verb/);
   const cli = await read("../src/content/docs/docs/cli.md");
   assert.match(cli, /## For agents/);
+  assert.match(cli, /tsk status <task> done/);
 });
 
 test("docs keep the phone layout until the right TOC fits", async () => {

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: tsk-cli
-description: Use when asked to add tasks, a task list, or a plan to the Tasks board, or to inspect Tasks board items. Use `tsk add` and `tsk list`, never the TUI.
+description: Use when asked to add, list, edit, or change status of Tasks board items. Use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`, never the TUI.
 ---
 
 # tsk CLI
 
-Use `tsk add` to create a task or JSON plan, and `tsk list` to
-inspect the shared board store before and after adding work.
+Use `tsk add` to create a task or JSON plan, `tsk list` to inspect the shared
+board store, `tsk status` to set human status, `tsk edit` to change title or
+notes, and `tsk steps` to add, toggle, rename, or remove steps. Human output
+escapes terminal controls in titles, step text, and project names; JSON does not.
 
 ## Adding
 
@@ -69,13 +71,19 @@ A typo in a project name silently files the task under a new scope. Use
 A task number is the human handle: resolve `T12` with `tsk list T12`.
 `T12`, `t12`, bare digits, and UUIDs are valid task operands. Direct lookup ignores cwd,
 invocation default, and task scope: `tsk list T12` finds its one task even in
-another project, including done and soft-deleted tasks. JSON list rows include
+another project, including done and live soft-deleted tasks still in `tsk.json`.
+A task that has left the live store for `trash.jsonl` is not found that way; use
+`tsk list --deleted` and `tsk trash restore T12`. JSON list rows include
 numeric `number` beside `id`. Do not combine a direct task operand with scope,
 thread, or status filters.
 
 ```sh
+tsk status T12 start
+tsk edit T12 --title "Draft outline" --notes "Scope note"
 tsk steps 12 add "Draft outline"
 tsk steps 12 toggle <step-short-id>
+tsk steps 12 rename <step-short-id> "Write the failing test"
+tsk steps 12 remove <step-short-id>
 tsk list 12
 ```
 
@@ -85,12 +93,41 @@ the row's `steps` array carries each step's `id`, `text`, `done`, and
 `short_id`. UUID remains valid in each command where a task number is shown.
 
 `toggle` flips the step state: a retry after an unseen success flips it back.
-Never blind-retry a `steps` invocation, run `tsk list 12`
-first and retry only a real refusal. `steps` exits 0 when the step was created
-or toggled, 1 for a refusal (stable tokens `empty-step-text`,
-`invalid-step-text`, `unknown-task`, `soft-deleted-task`, `unknown-step`,
-`ambiguous-step`), 2 for a usage error, and 3 for store I/O — verify with
-`list` before retrying an exit 3, same as add.
+`rename` is idempotent on the trimmed text. `remove` is not: a retry after an
+unseen success is `unknown-step`. Never blind-retry a `steps` invocation, run
+`tsk list 12` first and retry only a real refusal. `steps` exits 0 when the
+step was created, toggled, renamed, or removed, 1 for a refusal (stable tokens
+`empty-step-text`, `invalid-step-text`, `unknown-task`, `soft-deleted-task`,
+`unknown-step`, `ambiguous-step`), 2 for a usage error, and 3 for store I/O —
+verify with `list` before retrying an exit 3, same as add.
+
+## Status and edit
+
+Agents set human status and rewrite title or notes by task address. Direct
+lookup ignores cwd, same as `tsk list T12`.
+
+```sh
+tsk status T12 start
+tsk status T12 blocked
+tsk status T12 review
+tsk status T12 done
+tsk edit T12 --title "New title"
+tsk edit T12 --notes "Replacement notes"
+tsk edit T12 --title="-fix parser" --notes="-5 degrees"
+```
+
+`status` accepts `ready`, `started` (or `start`), `blocked`, `review`, or `done`.
+Output always uses the stored name (`started`, not `start`). Repeating the same
+status is idempotent.
+
+`edit` needs at least one of `--title` or `--notes`. Scope and thread stay as
+they are. Notes that trim to nothing are cleared. Repeating the stored values
+is idempotent. Values that start with `-` need `--title=<value>` or
+`--notes=<value>`.
+
+Both exit 0 on success, 1 for a refusal (`unknown-task`, `soft-deleted-task`,
+and for edit also `empty-title`, `invalid-title`, `invalid-notes`), 2 for usage,
+and 3 for store I/O. Verify with `tsk list T12` before retrying an exit 3.
 
 ## Archived tasks and projects
 

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -1,0 +1,148 @@
+//! Headless title and notes edits.
+
+use std::path::PathBuf;
+
+use crate::cli::add::has_c0_control;
+use crate::cli::parser::TaskAddress;
+use crate::domain::{DomainError, DomainState, TaskScope};
+use crate::store::{default_state_dir, TaskStore};
+use uuid::Uuid;
+
+/// Parsed field values after the argv boundary. `None` means leave the stored value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditFields {
+    pub title: Option<String>,
+    pub notes: Option<String>,
+}
+
+/// A successful edit, including an idempotent repeat.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditResult {
+    pub number: u64,
+    pub title: String,
+}
+
+/// An edit failure after parsing and before presenting output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditError {
+    UnknownTask,
+    SoftDeletedTask,
+    EmptyTitle,
+    InvalidTitle,
+    InvalidNotes,
+    Store(String),
+}
+
+impl EditError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::UnknownTask => "unknown-task",
+            Self::SoftDeletedTask => "soft-deleted-task",
+            Self::EmptyTitle => "empty-title",
+            Self::InvalidTitle => "invalid-title",
+            Self::InvalidNotes => "invalid-notes",
+            Self::Store(_) => "store-error",
+        }
+    }
+}
+
+/// Replace the supplied title and/or notes, keeping scope and thread.
+///
+/// Whitespace-only notes clear the field. Repeating the stored values writes nothing.
+pub fn run(
+    target: TaskAddress,
+    fields: EditFields,
+    state_dir: Option<PathBuf>,
+) -> Result<EditResult, EditError> {
+    if let Some(title) = fields.title.as_deref() {
+        if has_c0_control(title) {
+            return Err(EditError::InvalidTitle);
+        }
+        if title.trim().is_empty() {
+            return Err(EditError::EmptyTitle);
+        }
+    }
+    if let Some(notes) = fields.notes.as_deref() {
+        if has_c0_control(notes) {
+            return Err(EditError::InvalidNotes);
+        }
+    }
+
+    let store = TaskStore::new(state_dir.unwrap_or_else(default_state_dir));
+    store
+        .locked_transition_if_changed(|state: &mut DomainState| {
+            let found = state
+                .tasks()
+                .iter()
+                .find(|task| target.matches(task))
+                .map(|task| Found {
+                    id: task.id,
+                    number: task.number,
+                    title: task.title.clone(),
+                    notes: task.notes.clone(),
+                    scope: task.scope.clone(),
+                    thread: task.thread.clone(),
+                    soft_deleted: task.soft_deleted,
+                });
+            Ok(apply(state, found, &fields))
+        })
+        .map_err(EditError::Store)?
+}
+
+struct Found {
+    id: Uuid,
+    number: Option<u64>,
+    title: String,
+    notes: Option<String>,
+    scope: TaskScope,
+    thread: Option<String>,
+    soft_deleted: bool,
+}
+
+fn apply(
+    state: &mut DomainState,
+    found: Option<Found>,
+    fields: &EditFields,
+) -> (Result<EditResult, EditError>, bool) {
+    let Some(found) = found else {
+        return (Err(EditError::UnknownTask), false);
+    };
+    let Some(number) = found.number else {
+        return (Err(EditError::UnknownTask), false);
+    };
+    if found.soft_deleted {
+        return (Err(EditError::SoftDeletedTask), false);
+    }
+    let next_title = fields
+        .title
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or(found.title.as_str())
+        .to_string();
+    let next_notes = match fields.notes.as_deref() {
+        Some(value) if value.trim().is_empty() => None,
+        Some(value) => Some(value.to_string()),
+        None => found.notes.clone(),
+    };
+    if next_title == found.title && next_notes == found.notes {
+        return (
+            Ok(EditResult {
+                number,
+                title: found.title,
+            }),
+            false,
+        );
+    }
+    match state.edit(found.id, &next_title, next_notes, found.scope, found.thread) {
+        Ok(()) => (
+            Ok(EditResult {
+                number,
+                title: next_title,
+            }),
+            true,
+        ),
+        Err(DomainError::EmptyTitle) => (Err(EditError::EmptyTitle), false),
+        Err(DomainError::UnknownId(_)) => (Err(EditError::UnknownTask), false),
+        Err(other) => (Err(EditError::Store(other.to_string())), false),
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,10 +7,12 @@ use serde_json::Value;
 
 pub mod add;
 pub mod archive;
+pub mod edit;
 pub mod list;
 pub mod parser;
 pub mod presenter;
 pub mod router;
+pub mod status;
 pub mod steps;
 pub mod trash;
 
@@ -37,6 +39,8 @@ where
         Some("add") => run_add(args, &mut stdin, stdin_is_tty),
         Some("steps") => run_steps(args),
         Some("list") => run_list(args),
+        Some("status") => run_status(args),
+        Some("edit") => run_edit(args),
         Some("trash") => run_trash(args),
         Some("project") => run_project(args),
         verb @ (Some("archive") | Some("unarchive")) => {
@@ -48,7 +52,7 @@ where
             run_archive(args, verb, archive)
         }
         _ => presenter::usage(
-            "expected add, steps, list, trash, archive, unarchive, or project command",
+            "expected add, steps, list, status, edit, trash, archive, unarchive, or project command",
         ),
     }
 }
@@ -67,6 +71,54 @@ fn run_steps(args: Vec<String>) -> CliOutput {
     match steps::run(task, action, input.state_dir) {
         Ok(result) => presenter::steps(result),
         Err(error) => presenter::steps_rejected(error),
+    }
+}
+
+fn run_status(args: Vec<String>) -> CliOutput {
+    let input = match parser::parse_flag_status(&args) {
+        Ok(input) => input,
+        Err(reason) => return presenter::status_usage(&reason),
+    };
+    if input.help {
+        return presenter::status_help();
+    }
+    let (Some(task), Some(status)) = (input.task, input.status) else {
+        return presenter::status_usage(if input.task.is_none() {
+            "task number is required"
+        } else {
+            "status is required"
+        });
+    };
+    match status::run(task, status, input.state_dir) {
+        Ok(result) => presenter::status(result),
+        Err(error) => presenter::status_rejected(error),
+    }
+}
+
+fn run_edit(args: Vec<String>) -> CliOutput {
+    let input = match parser::parse_flag_edit(&args) {
+        Ok(input) => input,
+        Err(reason) => return presenter::edit_usage(&reason),
+    };
+    if input.help {
+        return presenter::edit_help();
+    }
+    let Some(task) = input.task else {
+        return presenter::edit_usage("task number is required");
+    };
+    if input.title.is_none() && input.notes.is_none() {
+        return presenter::edit_usage("title or notes is required");
+    }
+    match edit::run(
+        task,
+        edit::EditFields {
+            title: input.title,
+            notes: input.notes,
+        },
+        input.state_dir,
+    ) {
+        Ok(result) => presenter::edited(result),
+        Err(error) => presenter::edit_rejected(error),
     }
 }
 

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use super::steps::StepsAction;
-use crate::domain::normalize_thread;
+use crate::domain::{normalize_thread, HumanStatus};
 
 /// A direct task operand, either the internal UUID or its human task number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,6 +19,13 @@ impl TaskAddress {
         match self {
             Self::Id(id) => task.id == id,
             Self::Number(number) => task.number == Some(number),
+        }
+    }
+
+    pub fn display(self) -> String {
+        match self {
+            Self::Number(number) => format!("T{number}"),
+            Self::Id(id) => id.to_string(),
         }
     }
 }
@@ -256,15 +263,172 @@ pub fn parse_flag_trash(args: &[String]) -> Result<FlagTrash, String> {
     Ok(parsed)
 }
 
+/// Parsed `status` input. Positionals are the task address then the status name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlagStatus {
+    pub task: Option<TaskAddress>,
+    pub status: Option<HumanStatus>,
+    pub state_dir: Option<PathBuf>,
+    pub help: bool,
+}
+
+/// Parse `tsk status <task> <status>` arguments, including argv0.
+pub fn parse_flag_status(args: &[String]) -> Result<FlagStatus, String> {
+    if args.get(1).map(String::as_str) != Some("status") {
+        return Err("expected status command".into());
+    }
+
+    let mut parsed = FlagStatus {
+        task: None,
+        status: None,
+        state_dir: None,
+        help: false,
+    };
+    let mut positionals: Vec<&str> = Vec::new();
+    let mut index = 2;
+    while let Some(flag) = args.get(index).map(String::as_str) {
+        let value = |name: &str| match args.get(index + 1) {
+            Some(value) if !value.starts_with('-') => Ok(value.clone()),
+            _ => Err(format!("missing value for {name}")),
+        };
+        match flag {
+            "--help" => {
+                parsed.help = true;
+                index += 1;
+            }
+            flag if flag.starts_with("--state-dir=") => {
+                parsed.state_dir = Some(PathBuf::from(flag["--state-dir=".len()..].to_owned()));
+                index += 1;
+            }
+            "--state-dir" => {
+                parsed.state_dir = Some(PathBuf::from(value(flag)?));
+                index += 2;
+            }
+            flag if flag.starts_with('-') => return Err(format!("unknown status argument {flag}")),
+            positional => {
+                if positionals.len() == 2 {
+                    return Err(format!("unexpected status argument {positional}"));
+                }
+                positionals.push(positional);
+                index += 1;
+            }
+        }
+    }
+
+    if parsed.help {
+        return Ok(parsed);
+    }
+    match positionals.as_slice() {
+        [] => {}
+        [task] => {
+            parsed.task = Some(parse_task_address(task)?);
+        }
+        [task, status] => {
+            parsed.task = Some(parse_task_address(task)?);
+            parsed.status = Some(parse_human_status(status)?);
+        }
+        _ => unreachable!("positionals are capped at two"),
+    }
+    Ok(parsed)
+}
+
+fn parse_human_status(value: &str) -> Result<HumanStatus, String> {
+    match value {
+        "ready" => Ok(HumanStatus::Ready),
+        "start" | "started" => Ok(HumanStatus::Started),
+        "blocked" => Ok(HumanStatus::Blocked),
+        "review" => Ok(HumanStatus::Review),
+        "done" => Ok(HumanStatus::Done),
+        other => Err(format!("unknown status {other}")),
+    }
+}
+
+/// Parsed `edit` input. One positional task address, then title/notes flags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlagEdit {
+    pub task: Option<TaskAddress>,
+    pub title: Option<String>,
+    pub notes: Option<String>,
+    pub state_dir: Option<PathBuf>,
+    pub help: bool,
+}
+
+/// Parse `tsk edit <task> [--title <title>] [--notes <notes>]` arguments, including argv0.
+pub fn parse_flag_edit(args: &[String]) -> Result<FlagEdit, String> {
+    if args.get(1).map(String::as_str) != Some("edit") {
+        return Err("expected edit command".into());
+    }
+
+    let mut parsed = FlagEdit {
+        task: None,
+        title: None,
+        notes: None,
+        state_dir: None,
+        help: false,
+    };
+    let mut index = 2;
+    while let Some(flag) = args.get(index).map(String::as_str) {
+        let value = |name: &str| match args.get(index + 1) {
+            Some(value) if !value.starts_with('-') => Ok(value.clone()),
+            _ => Err(format!("missing value for {name}")),
+        };
+        match flag {
+            flag if flag.starts_with("--title=") => {
+                parsed.title = Some(flag["--title=".len()..].to_owned());
+                index += 1;
+            }
+            flag if flag.starts_with("--notes=") => {
+                parsed.notes = Some(flag["--notes=".len()..].to_owned());
+                index += 1;
+            }
+            "-t" | "--title" => {
+                parsed.title = Some(value(flag)?);
+                index += 2;
+            }
+            "-n" | "--notes" => {
+                parsed.notes = Some(value(flag)?);
+                index += 2;
+            }
+            "--help" => {
+                parsed.help = true;
+                index += 1;
+            }
+            flag if flag.starts_with("--state-dir=") => {
+                parsed.state_dir = Some(PathBuf::from(flag["--state-dir=".len()..].to_owned()));
+                index += 1;
+            }
+            "--state-dir" => {
+                parsed.state_dir = Some(PathBuf::from(value(flag)?));
+                index += 2;
+            }
+            flag if flag.starts_with('-') => return Err(format!("unknown edit argument {flag}")),
+            flag => {
+                if parsed.task.is_some() {
+                    return Err(format!("unknown edit argument {flag}"));
+                }
+                parsed.task = Some(parse_task_address(flag)?);
+                index += 1;
+            }
+        }
+    }
+    Ok(parsed)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{parse_flag_trash, parse_task_address, TaskAddress, TrashAction};
+    use super::{
+        parse_flag_edit, parse_flag_status, parse_flag_steps, parse_flag_trash, parse_task_address,
+        FlagEdit, FlagStatus, TaskAddress, TrashAction,
+    };
+    use crate::cli::steps::StepsAction;
+    use crate::domain::HumanStatus;
 
     #[test]
     fn task_addresses_accept_the_displayed_identifier_case_insensitively() {
         assert_eq!(parse_task_address("T30"), Ok(TaskAddress::Number(30)));
         assert_eq!(parse_task_address("t30"), Ok(TaskAddress::Number(30)));
         assert_eq!(parse_task_address("30"), Ok(TaskAddress::Number(30)));
+        assert_eq!(TaskAddress::Number(30).display(), "T30");
         assert!(parse_task_address("T-30").is_err());
     }
 
@@ -304,6 +468,119 @@ mod tests {
             "restore".into(),
             "T1".into(),
             "extra".into()
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn status_parse_accepts_task_and_status() {
+        let parsed = parse_flag_status(&[
+            "tsk".into(),
+            "status".into(),
+            "T4".into(),
+            "blocked".into(),
+            "--state-dir".into(),
+            "/tmp/dir".into(),
+        ])
+        .expect("parse");
+        assert_eq!(
+            parsed,
+            FlagStatus {
+                task: Some(TaskAddress::Number(4)),
+                status: Some(HumanStatus::Blocked),
+                state_dir: Some(std::path::PathBuf::from("/tmp/dir")),
+                help: false,
+            }
+        );
+        assert!(
+            parse_flag_status(&["tsk".into(), "status".into(), "T4".into(), "nope".into()])
+                .is_err()
+        );
+        assert!(parse_flag_status(&[
+            "tsk".into(),
+            "status".into(),
+            "T4".into(),
+            "blocked".into(),
+            "extra".into()
+        ])
+        .is_err());
+        let parsed =
+            parse_flag_status(&["tsk".into(), "status".into(), "T4".into(), "start".into()])
+                .expect("start alias");
+        assert_eq!(parsed.status, Some(HumanStatus::Started));
+    }
+
+    #[test]
+    fn edit_parse_accepts_equals_forms_for_dash_leading_values() {
+        let parsed = parse_flag_edit(&[
+            "tsk".into(),
+            "edit".into(),
+            "12".into(),
+            "--title=-fix parser".into(),
+            "--notes=-5 degrees".into(),
+        ])
+        .expect("parse");
+        assert_eq!(
+            parsed,
+            FlagEdit {
+                task: Some(TaskAddress::Number(12)),
+                title: Some("-fix parser".into()),
+                notes: Some("-5 degrees".into()),
+                state_dir: None,
+                help: false,
+            }
+        );
+    }
+
+    #[test]
+    fn steps_parse_accepts_rename_and_remove() {
+        let parsed = parse_flag_steps(&[
+            "tsk".into(),
+            "steps".into(),
+            "T2".into(),
+            "rename".into(),
+            "ab".into(),
+            "new text".into(),
+        ])
+        .expect("parse rename");
+        assert_eq!(parsed.task, Some(TaskAddress::Number(2)));
+        assert_eq!(
+            parsed.action,
+            Some(StepsAction::Rename {
+                short_id: "ab".into(),
+                text: "new text".into(),
+            })
+        );
+
+        let parsed = parse_flag_steps(&[
+            "tsk".into(),
+            "steps".into(),
+            "T2".into(),
+            "remove".into(),
+            "ab".into(),
+        ])
+        .expect("parse remove");
+        assert_eq!(
+            parsed.action,
+            Some(StepsAction::Remove {
+                short_id: "ab".into(),
+            })
+        );
+        assert!(parse_flag_steps(&[
+            "tsk".into(),
+            "steps".into(),
+            "T2".into(),
+            "rename".into(),
+            "ab".into()
+        ])
+        .is_err());
+        assert!(parse_flag_steps(&[
+            "tsk".into(),
+            "steps".into(),
+            "T2".into(),
+            "add".into(),
+            "one".into(),
+            "two".into()
         ])
         .is_err());
     }
@@ -489,7 +766,7 @@ pub fn parse_flag_steps(args: &[String]) -> Result<FlagSteps, String> {
             }
             flag if flag.starts_with('-') => return Err(format!("unknown steps argument {flag}")),
             positional => {
-                if positionals.len() == 3 {
+                if positionals.len() == 4 {
                     return Err(format!("unexpected steps argument {positional}"));
                 }
                 positionals.push(positional);
@@ -506,19 +783,63 @@ pub fn parse_flag_steps(args: &[String]) -> Result<FlagSteps, String> {
                 "steps action is required".into()
             });
         }
+        let extra = |index: usize| {
+            positionals
+                .get(index)
+                .copied()
+                .map(|positional| format!("unexpected steps argument {positional}"))
+        };
         let task = parse_task_address(positionals[0])?;
-        let operand = positionals
-            .get(2)
-            .copied()
-            .map(str::to_owned)
-            .ok_or_else(|| match positionals[1] {
-                "add" => "step text is required".to_owned(),
-                "toggle" => "step short id is required".to_owned(),
-                other => format!("unknown steps action {other}"),
-            })?;
         parsed.action = Some(match positionals[1] {
-            "add" => StepsAction::Add { text: operand },
-            "toggle" => StepsAction::Toggle { short_id: operand },
+            "add" => {
+                if let Some(reason) = extra(3) {
+                    return Err(reason);
+                }
+                StepsAction::Add {
+                    text: positionals
+                        .get(2)
+                        .copied()
+                        .map(str::to_owned)
+                        .ok_or_else(|| "step text is required".to_owned())?,
+                }
+            }
+            "toggle" => {
+                if let Some(reason) = extra(3) {
+                    return Err(reason);
+                }
+                StepsAction::Toggle {
+                    short_id: positionals
+                        .get(2)
+                        .copied()
+                        .map(str::to_owned)
+                        .ok_or_else(|| "step short id is required".to_owned())?,
+                }
+            }
+            "remove" => {
+                if let Some(reason) = extra(3) {
+                    return Err(reason);
+                }
+                StepsAction::Remove {
+                    short_id: positionals
+                        .get(2)
+                        .copied()
+                        .map(str::to_owned)
+                        .ok_or_else(|| "step short id is required".to_owned())?,
+                }
+            }
+            "rename" => {
+                let short_id = positionals
+                    .get(2)
+                    .copied()
+                    .map(str::to_owned)
+                    .ok_or_else(|| "step short id is required".to_owned())?;
+                let text = positionals
+                    .get(3)
+                    .copied()
+                    .map(str::to_owned)
+                    .ok_or_else(|| "step text is required".to_owned())?;
+                StepsAction::Rename { short_id, text }
+            }
             other => return Err(format!("unknown steps action {other}")),
         });
         parsed.task = Some(task);

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -13,6 +13,10 @@ use crate::cli::trash::{TrashCliError, TrashRestoreResult};
 use crate::domain::HumanStatus;
 use crate::ui::terminal_text;
 
+fn human_reason(reason: &str) -> String {
+    terminal_text(reason)
+}
+
 pub fn add_help() -> CliOutput {
     help_output(
         "usage: tsk add -t <title> [-n <notes>] [-p <project> | --desk] [--thread <name>] [--json] [--state-dir <dir>]\n       tsk add [--file <path|->] [--state-dir <dir>]",
@@ -108,7 +112,8 @@ pub fn usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk add: {reason}\nusage: tsk add -t <title> [-n <notes>] [-p <project> | --desk] [--thread <name>] [--json] [--state-dir <dir>]\n"
+            "tsk add: {}\nusage: tsk add -t <title> [-n <notes>] [-p <project> | --desk] [--thread <name>] [--json] [--state-dir <dir>]\n",
+            human_reason(reason)
         ),
         code: 2,
     }
@@ -445,7 +450,8 @@ pub fn steps_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk steps: {reason}\nusage: tsk steps <task> add <text> | toggle <step-short-id> | rename <step-short-id> <text> | remove <step-short-id> [--state-dir <dir>]\n"
+            "tsk steps: {}\nusage: tsk steps <task> add <text> | toggle <step-short-id> | rename <step-short-id> <text> | remove <step-short-id> [--state-dir <dir>]\n",
+            human_reason(reason)
         ),
         code: 2,
     }
@@ -508,7 +514,8 @@ pub fn status_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk status: {reason}\nusage: tsk status <task> <status> [--state-dir <dir>]\n"
+            "tsk status: {}\nusage: tsk status <task> <status> [--state-dir <dir>]\n",
+            human_reason(reason)
         ),
         code: 2,
     }
@@ -562,7 +569,8 @@ pub fn edit_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk edit: {reason}\nusage: tsk edit <task> [--title <title>] [--notes <notes>] [--state-dir <dir>]\n"
+            "tsk edit: {}\nusage: tsk edit <task> [--title <title>] [--notes <notes>] [--state-dir <dir>]\n",
+            human_reason(reason)
         ),
         code: 2,
     }
@@ -602,7 +610,8 @@ pub fn trash_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk trash: {reason}\nusage: tsk trash restore <task> [--state-dir <dir>]\n"
+            "tsk trash: {}\nusage: tsk trash restore <task> [--state-dir <dir>]\n",
+            human_reason(reason)
         ),
         code: 2,
     }
@@ -653,7 +662,10 @@ pub fn archive_help(verb: &str) -> CliOutput {
 pub fn archive_usage(verb: &str, reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
-        stderr: format!("tsk {verb}: {reason}\nusage: tsk {verb} <task> [--state-dir <dir>]\n"),
+        stderr: format!(
+            "tsk {verb}: {}\nusage: tsk {verb} <task> [--state-dir <dir>]\n",
+            human_reason(reason)
+        ),
         code: 2,
     }
 }
@@ -670,7 +682,8 @@ pub fn project_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk project: {reason}\nusage: tsk project archive <name> | tsk project unarchive <name> [--state-dir <dir>]\n"
+            "tsk project: {}\nusage: tsk project archive <name> | tsk project unarchive <name> [--state-dir <dir>]\n",
+            human_reason(reason)
         ),
         code: 2,
     }
@@ -729,7 +742,8 @@ pub fn list_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk list: {reason}\nusage: tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted | --archived] [--json] [--state-dir <dir>]\n"
+            "tsk list: {}\nusage: tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted | --archived] [--json] [--state-dir <dir>]\n",
+            human_reason(reason)
         ),
         code: 2,
     }

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -5,7 +5,9 @@ use std::collections::BTreeMap;
 use super::CliOutput;
 use crate::cli::add::{AddError, FlagAddResult};
 use crate::cli::archive::{ArchiveCliError, ArchiveResult, ProjectResult};
+use crate::cli::edit::{EditError, EditResult};
 use crate::cli::list::{ListError, ListResult, ListRow, ListView};
+use crate::cli::status::{StatusError, StatusResult};
 use crate::cli::steps::{StepLine, StepsError, StepsResult};
 use crate::cli::trash::{TrashCliError, TrashRestoreResult};
 use crate::domain::HumanStatus;
@@ -22,7 +24,7 @@ pub fn list_help() -> CliOutput {
         stdout: concat!(
             "usage: tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted | --archived] [--json] [--state-dir <dir>]\n\n",
             "Lists ready, started, blocked, and review tasks in the invocation project by default, or your desk outside a repository.\n",
-            "With a task number (bare digits) or UUID from add --json or list --json, lists that one task alone and prints its steps: one line per step with its [x]/[ ] state and step short id. Direct lookup ignores cwd. A task operand cannot be combined with scope, thread, or status filters.\n",
+            "With a task number (bare digits) or UUID from add --json or list --json, lists that one task alone and prints its steps: one line per step with its [x]/[ ] state and step short id. Direct lookup ignores cwd and searches the live store, including done and live soft-deleted tasks. Tasks that have moved to trash.jsonl need tsk list --deleted. A task operand cannot be combined with scope, thread, or status filters.\n",
             "--project uses the same basename-or-path scope resolution as add; --desk selects your desk, tasks not tied to a project; --all selects every scope. --thread normalizes a thread name and filters within the selected scope; an invalid name is a usage error (exit 2). For dash-leading project and state-directory values, use --project=<scope> and --state-dir=<dir>.\n",
             "--archived lists archived tasks only: individually archived tasks plus tasks of archived projects, each row marked `archived` or `project archived`. --done lists done tasks only. --deleted lists soft-deleted tasks only, regardless of status: live soft-deletes plus trash entries from trash.jsonl (kept 30 days), deduped by task with the live copy winning, newest deletion first.\n",
             "To recover a typo scope, use tsk list --all --json.\n",
@@ -80,7 +82,7 @@ pub fn added(result: FlagAddResult, json: bool) -> CliOutput {
                 "project": project,
             })
         ),
-        FlagAddResult::Created { title, .. } => format!("added {title}\n"),
+        FlagAddResult::Created { title, .. } => format!("added {}\n", terminal_text(&title)),
         FlagAddResult::Existing { .. } => "task already exists\n".into(),
     };
     CliOutput {
@@ -391,13 +393,16 @@ pub fn steps_help() -> CliOutput {
     CliOutput {
         stdout: concat!(
             "usage: tsk steps <task> add <text> [--state-dir <dir>]\n",
-            "       tsk steps <task> toggle <step-short-id> [--state-dir <dir>]\n\n",
-            "steps adds one step to a task or toggles one step's done flag. The task is a bare task number or UUID from tsk list --json; direct lookup ignores cwd.\n",
+            "       tsk steps <task> toggle <step-short-id> [--state-dir <dir>]\n",
+            "       tsk steps <task> rename <step-short-id> <text> [--state-dir <dir>]\n",
+            "       tsk steps <task> remove <step-short-id> [--state-dir <dir>]\n\n",
+            "steps adds, toggles, renames, or removes one step on a task. The task is a bare task number or UUID from tsk list --json; direct lookup ignores cwd.\n",
             "A step short id is the shortest unambiguous prefix of the step id, as printed by tsk list <task>.\n",
-            "toggle flips the step state: a blind retry after an unseen success flips it back, so verify with tsk list <task> before retrying.\n\n",
+            "toggle flips the step state: a blind retry after an unseen success flips it back, so verify with tsk list <task> before retrying.\n",
+            "rename is idempotent on the trimmed text. remove is not: a retry after an unseen success is unknown-step, so verify with list before retrying.\n\n",
             "Refusal tokens (exit 1): empty-step-text, invalid-step-text, unknown-task, soft-deleted-task, unknown-step, ambiguous-step.\n\n",
             "Exit contract:\n",
-            "  exit 0: step created or toggled\n",
+            "  exit 0: step created, toggled, renamed, or removed\n",
             "  exit 1: step refusal; verify state with list before retrying\n",
             "  exit 2: usage or parse error, nothing persisted\n",
             "  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
@@ -410,15 +415,24 @@ pub fn steps_help() -> CliOutput {
 
 pub fn steps(result: StepsResult) -> CliOutput {
     let stdout = match result {
-        StepsResult::Added { short_id, text } => format!("added {short_id} {text}\n"),
+        StepsResult::Added { short_id, text } => {
+            format!("added {short_id} {}\n", terminal_text(&text))
+        }
         StepsResult::Toggled {
             short_id,
             text,
             done,
         } => format!(
-            "toggled {short_id} [{}] {text}\n",
-            if done { "x" } else { " " }
+            "toggled {short_id} [{}] {}\n",
+            if done { "x" } else { " " },
+            terminal_text(&text)
         ),
+        StepsResult::Renamed { short_id, text } => {
+            format!("renamed {short_id} {}\n", terminal_text(&text))
+        }
+        StepsResult::Removed { short_id, text } => {
+            format!("removed {short_id} {}\n", terminal_text(&text))
+        }
     };
     CliOutput {
         stdout,
@@ -431,7 +445,7 @@ pub fn steps_usage(reason: &str) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!(
-            "tsk steps: {reason}\nusage: tsk steps <task> add <text> | toggle <step-short-id> [--state-dir <dir>]\n"
+            "tsk steps: {reason}\nusage: tsk steps <task> add <text> | toggle <step-short-id> | rename <step-short-id> <text> | remove <step-short-id> [--state-dir <dir>]\n"
         ),
         code: 2,
     }
@@ -445,6 +459,123 @@ pub fn steps_rejected(error: StepsError) -> CliOutput {
     CliOutput {
         stdout: String::new(),
         stderr: format!("tsk steps: {detail}\n"),
+        code,
+    }
+}
+
+fn status_name(status: HumanStatus) -> &'static str {
+    match status {
+        HumanStatus::Ready => "ready",
+        HumanStatus::Started => "started",
+        HumanStatus::Blocked => "blocked",
+        HumanStatus::Review => "review",
+        HumanStatus::Done => "done",
+    }
+}
+
+pub fn status_help() -> CliOutput {
+    CliOutput {
+        stdout: concat!(
+            "usage: tsk status <task> <status> [--state-dir <dir>]\n\n",
+            "status sets a task's human status to ready, started, blocked, review, or done. start is accepted as an alias for started. The task is a task number (T<number>, or bare digits) or UUID, as shown by tsk list. Repeating the same status is idempotent: the same output prints and nothing changes.\n\n",
+            "Refusal tokens (exit 1): unknown-task, soft-deleted-task.\n\n",
+            "Exit contract:\n",
+            "  exit 0: status set, or it already had the value\n",
+            "  exit 1: status refusal; verify state with list before retrying\n",
+            "  exit 2: usage or parse error, nothing persisted\n",
+            "  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
+        )
+        .into(),
+        stderr: String::new(),
+        code: 0,
+    }
+}
+
+pub fn status(result: StatusResult) -> CliOutput {
+    CliOutput {
+        stdout: format!(
+            "status T{} {} {}\n",
+            result.number,
+            status_name(result.status),
+            terminal_text(&result.title)
+        ),
+        stderr: String::new(),
+        code: 0,
+    }
+}
+
+pub fn status_usage(reason: &str) -> CliOutput {
+    CliOutput {
+        stdout: String::new(),
+        stderr: format!(
+            "tsk status: {reason}\nusage: tsk status <task> <status> [--state-dir <dir>]\n"
+        ),
+        code: 2,
+    }
+}
+
+pub fn status_rejected(error: StatusError) -> CliOutput {
+    let (detail, code) = match error {
+        StatusError::Store(detail) => (detail, 3),
+        other => (other.code().into(), 1),
+    };
+    CliOutput {
+        stdout: String::new(),
+        stderr: format!("tsk status: {detail}\n"),
+        code,
+    }
+}
+
+pub fn edit_help() -> CliOutput {
+    CliOutput {
+        stdout: concat!(
+            "usage: tsk edit <task> [--title <title>] [--notes <notes>] [--state-dir <dir>]\n\n",
+            "edit updates a task's title and/or notes. Scope and thread are unchanged. The task is a task number (T<number>, or bare digits) or UUID, as shown by tsk list. At least one of --title or --notes is required.\n",
+            "Notes that trim to nothing are cleared. Repeating the stored values is idempotent: the same output prints and nothing changes.\n",
+            "Values beginning with - must use --title=<value> or --notes=<value>.\n\n",
+            "Refusal tokens (exit 1): unknown-task, soft-deleted-task, empty-title, invalid-title, invalid-notes.\n\n",
+            "Exit contract:\n",
+            "  exit 0: fields written, or they already had the values\n",
+            "  exit 1: edit refusal; verify state with list before retrying\n",
+            "  exit 2: usage or parse error, nothing persisted\n",
+            "  exit 3: store I/O, commit indeterminate, verify with list before retrying\n"
+        )
+        .into(),
+        stderr: String::new(),
+        code: 0,
+    }
+}
+
+pub fn edited(result: EditResult) -> CliOutput {
+    CliOutput {
+        stdout: format!(
+            "edited T{} {}\n",
+            result.number,
+            terminal_text(&result.title)
+        ),
+        stderr: String::new(),
+        code: 0,
+    }
+}
+
+pub fn edit_usage(reason: &str) -> CliOutput {
+    CliOutput {
+        stdout: String::new(),
+        stderr: format!(
+            "tsk edit: {reason}\nusage: tsk edit <task> [--title <title>] [--notes <notes>] [--state-dir <dir>]\n"
+        ),
+        code: 2,
+    }
+}
+
+pub fn edit_rejected(error: EditError) -> CliOutput {
+    let (detail, code) = match error {
+        EditError::Store(detail) => (detail, 3),
+        other => (other.code().into(), 1),
+    };
+    CliOutput {
+        stdout: String::new(),
+        stderr: format!("tsk edit: {detail}\n"),
         code,
     }
 }
@@ -479,7 +610,11 @@ pub fn trash_usage(reason: &str) -> CliOutput {
 
 pub fn trash_restored(result: TrashRestoreResult) -> CliOutput {
     CliOutput {
-        stdout: format!("restored T{} {}\n", result.number, result.title),
+        stdout: format!(
+            "restored T{} {}\n",
+            result.number,
+            terminal_text(&result.title)
+        ),
         stderr: String::new(),
         code: 0,
     }
@@ -548,7 +683,7 @@ pub fn project_archived(result: ProjectResult, verb: &str) -> CliOutput {
         "unarchived"
     };
     CliOutput {
-        stdout: format!("{past} project {}\n", result.name),
+        stdout: format!("{past} project {}\n", terminal_text(&result.name)),
         stderr: String::new(),
         code: 0,
     }
@@ -562,7 +697,11 @@ pub fn archived(result: ArchiveResult, verb: &str) -> CliOutput {
         "unarchived"
     };
     CliOutput {
-        stdout: format!("{past} T{} {}\n", result.number, result.title),
+        stdout: format!(
+            "{past} T{} {}\n",
+            result.number,
+            terminal_text(&result.title)
+        ),
         stderr: String::new(),
         code: 0,
     }
@@ -575,7 +714,9 @@ pub fn archive_rejected(error: ArchiveCliError, verb: &str) -> CliOutput {
         ArchiveCliError::Store(detail) => (verb.to_string(), detail, 3),
         ArchiveCliError::UnknownTask(detail) => (verb.to_string(), detail, 1),
         ArchiveCliError::SoftDeleted(detail) => (verb.to_string(), detail, 1),
-        ArchiveCliError::UnknownProject(detail) => ("project".to_string(), detail, 1),
+        ArchiveCliError::UnknownProject(detail) => {
+            ("project".to_string(), terminal_text(&detail), 1)
+        }
     };
     CliOutput {
         stdout: String::new(),
@@ -608,12 +749,15 @@ pub fn list_rejected(error: ListError) -> CliOutput {
 
 pub fn rejected(error: AddError) -> CliOutput {
     let (detail, code) = match &error {
-        AddError::ProjectArchived(name) => (
-            format!(
-                "project-archived: project {name} is archived. Use --desk, -p <other project>, or tsk project unarchive <name>"
-            ),
-            1,
-        ),
+        AddError::ProjectArchived(name) => {
+            let name = terminal_text(name);
+            (
+                format!(
+                    "project-archived: project {name} is archived. Use --desk, -p <other project>, or tsk project unarchive {name}"
+                ),
+                1,
+            )
+        }
         AddError::Store(detail) => (detail.clone(), 3),
         other => (other.code().into(), 1),
     };

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -8,6 +8,8 @@ pub enum Surface {
     Add,
     Steps,
     List,
+    Status,
+    Edit,
     Trash,
     Archive,
     Unarchive,
@@ -52,6 +54,8 @@ pub fn route<S: AsRef<str>>(
             "add" => Surface::Add,
             "steps" => Surface::Steps,
             "list" => Surface::List,
+            "status" => Surface::Status,
+            "edit" => Surface::Edit,
             "trash" => Surface::Trash,
             "archive" => Surface::Archive,
             "unarchive" => Surface::Unarchive,
@@ -125,6 +129,22 @@ mod tests {
         assert_eq!(
             route(["tsk", "trash", "restore", "T3"], None),
             Surface::Trash
+        );
+    }
+
+    #[test]
+    fn status_positional_selects_status_surface() {
+        assert_eq!(
+            route(["tsk", "status", "T3", "started"], None),
+            Surface::Status
+        );
+    }
+
+    #[test]
+    fn edit_positional_selects_edit_surface() {
+        assert_eq!(
+            route(["tsk", "edit", "T3", "--title", "new"], None),
+            Surface::Edit
         );
     }
 

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,0 +1,98 @@
+//! Headless human-status changes.
+
+use std::path::PathBuf;
+
+use crate::cli::parser::TaskAddress;
+use crate::domain::{DomainError, DomainState, HumanStatus};
+use crate::store::{default_state_dir, TaskStore};
+use uuid::Uuid;
+
+/// A successful status change, including an idempotent repeat.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusResult {
+    pub number: u64,
+    pub title: String,
+    pub status: HumanStatus,
+}
+
+/// A status failure after parsing and before presenting output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StatusError {
+    UnknownTask,
+    SoftDeletedTask,
+    Store(String),
+}
+
+impl StatusError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::UnknownTask => "unknown-task",
+            Self::SoftDeletedTask => "soft-deleted-task",
+            Self::Store(_) => "store-error",
+        }
+    }
+}
+
+/// Set one task's human status. Repeating the same status is idempotent.
+///
+/// Soft-deleted and unknown tasks refuse the same way as archive.
+pub fn run(
+    target: TaskAddress,
+    status: HumanStatus,
+    state_dir: Option<PathBuf>,
+) -> Result<StatusResult, StatusError> {
+    let store = TaskStore::new(state_dir.unwrap_or_else(default_state_dir));
+    store
+        .locked_transition_if_changed(|state: &mut DomainState| {
+            let found = state
+                .tasks()
+                .iter()
+                .find(|task| target.matches(task))
+                .map(|task| Found {
+                    id: task.id,
+                    number: task.number,
+                    title: task.title.clone(),
+                    current: task.status,
+                    soft_deleted: task.soft_deleted,
+                });
+            Ok(apply(state, found, status))
+        })
+        .map_err(StatusError::Store)?
+}
+
+struct Found {
+    id: Uuid,
+    number: Option<u64>,
+    title: String,
+    current: HumanStatus,
+    soft_deleted: bool,
+}
+
+fn apply(
+    state: &mut DomainState,
+    found: Option<Found>,
+    status: HumanStatus,
+) -> (Result<StatusResult, StatusError>, bool) {
+    let Some(found) = found else {
+        return (Err(StatusError::UnknownTask), false);
+    };
+    let Some(number) = found.number else {
+        return (Err(StatusError::UnknownTask), false);
+    };
+    if found.soft_deleted {
+        return (Err(StatusError::SoftDeletedTask), false);
+    }
+    let result = StatusResult {
+        number,
+        title: found.title,
+        status,
+    };
+    if found.current == status {
+        return (Ok(result), false);
+    }
+    match state.set_status(found.id, status) {
+        Ok(()) => (Ok(result), true),
+        Err(DomainError::UnknownId(_)) => (Err(StatusError::UnknownTask), false),
+        Err(other) => (Err(StatusError::Store(other.to_string())), false),
+    }
+}

--- a/src/cli/steps.rs
+++ b/src/cli/steps.rs
@@ -1,4 +1,4 @@
-//! Headless step creation and toggling by step short id.
+//! Headless step creation, toggling, rename, and remove by step short id.
 
 use std::path::PathBuf;
 
@@ -15,6 +15,8 @@ use uuid::Uuid;
 pub enum StepsAction {
     Add { text: String },
     Toggle { short_id: String },
+    Rename { short_id: String, text: String },
+    Remove { short_id: String },
 }
 
 /// A steps failure after parsing and before presenting output.
@@ -55,6 +57,14 @@ pub enum StepsResult {
         text: String,
         done: bool,
     },
+    Renamed {
+        short_id: String,
+        text: String,
+    },
+    Removed {
+        short_id: String,
+        text: String,
+    },
 }
 
 /// Add one step or toggle one step, refusing before any mutation.
@@ -77,7 +87,8 @@ pub fn run(
             let outcome = task_id.map_or(Err(StepsError::UnknownTask), |task_id| {
                 apply(domain, task_id, &action)
             });
-            let changed = outcome.is_ok();
+            let changed = outcome.as_ref().is_ok_and(|(_, changed)| *changed);
+            let outcome = outcome.map(|(result, _)| result);
             Ok((outcome, changed))
         })
         .map_err(StepsError::Store)?
@@ -87,7 +98,7 @@ fn apply(
     domain: &mut DomainState,
     task_id: Uuid,
     action: &StepsAction,
-) -> Result<StepsResult, StepsError> {
+) -> Result<(StepsResult, bool), StepsError> {
     // A deleted task's steps are not scriptable (park/link discipline, not edit's).
     match domain.get(task_id) {
         None => return Err(StepsError::UnknownTask),
@@ -106,18 +117,17 @@ fn apply(
             }
             let step_id = domain.add_step(task_id, text).map_err(map_domain_error)?;
             let steps = &domain.get(task_id).expect("task exists").steps;
-            Ok(StepsResult::Added {
-                short_id: step_short_id(steps, step_id),
-                text: text.to_owned(),
-            })
+            Ok((
+                StepsResult::Added {
+                    short_id: step_short_id(steps, step_id),
+                    text: text.to_owned(),
+                },
+                true,
+            ))
         }
         StepsAction::Toggle { short_id } => {
             let steps = domain.get(task_id).expect("task exists").steps.clone();
-            let step_id = match resolve_step_short_id(&steps, short_id) {
-                ShortIdResolution::One(id) => id,
-                ShortIdResolution::Ambiguous => return Err(StepsError::AmbiguousStep),
-                ShortIdResolution::None => return Err(StepsError::UnknownStep),
-            };
+            let step_id = resolve_existing_step(&steps, short_id)?;
             domain
                 .toggle_step(task_id, step_id)
                 .map_err(map_domain_error)?;
@@ -127,17 +137,80 @@ fn apply(
                 .steps
                 .iter()
                 .any(|step| step.id == step_id && step.done);
-            Ok(StepsResult::Toggled {
-                short_id: step_short_id(&steps, step_id),
-                text: steps
-                    .iter()
-                    .find(|step| step.id == step_id)
-                    .expect("toggled step exists")
-                    .text
-                    .clone(),
-                done,
-            })
+            Ok((
+                StepsResult::Toggled {
+                    short_id: step_short_id(&steps, step_id),
+                    text: steps
+                        .iter()
+                        .find(|step| step.id == step_id)
+                        .expect("toggled step exists")
+                        .text
+                        .clone(),
+                    done,
+                },
+                true,
+            ))
         }
+        StepsAction::Rename { short_id, text } => {
+            if has_c0_control(text) {
+                return Err(StepsError::InvalidStepText);
+            }
+            let text = text.trim();
+            if text.is_empty() {
+                return Err(StepsError::EmptyStepText);
+            }
+            let steps = domain.get(task_id).expect("task exists").steps.clone();
+            let step_id = resolve_existing_step(&steps, short_id)?;
+            let printed = step_short_id(&steps, step_id);
+            let current = steps
+                .iter()
+                .find(|step| step.id == step_id)
+                .expect("renamed step exists")
+                .text
+                .as_str();
+            let changed = current != text;
+            if changed {
+                domain
+                    .rename_step(task_id, step_id, text)
+                    .map_err(map_domain_error)?;
+            }
+            Ok((
+                StepsResult::Renamed {
+                    short_id: printed,
+                    text: text.to_owned(),
+                },
+                changed,
+            ))
+        }
+        StepsAction::Remove { short_id } => {
+            let steps = domain.get(task_id).expect("task exists").steps.clone();
+            let step_id = resolve_existing_step(&steps, short_id)?;
+            let text = steps
+                .iter()
+                .find(|step| step.id == step_id)
+                .expect("removed step exists")
+                .text
+                .clone();
+            let printed = step_short_id(&steps, step_id);
+            domain
+                .remove_step(task_id, step_id)
+                .map_err(map_domain_error)?;
+            Ok((
+                StepsResult::Removed {
+                    short_id: printed,
+                    text,
+                },
+                true,
+            ))
+        }
+    }
+}
+
+fn resolve_existing_step(steps: &[Step], short_id: &str) -> Result<Uuid, StepsError> {
+    match resolve_step_short_id(steps, short_id) {
+        ShortIdResolution::One(id) => Ok(id),
+        ShortIdResolution::Ambiguous => Err(StepsError::AmbiguousStep),
+        ShortIdResolution::None => Err(StepsError::UnknownStep),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
         Surface::FindBoardPane => find_board_pane_main(),
         Surface::GlobalHelp => {
             println!(
-                "usage: tsk [capture] | add | steps | list | trash | archive | unarchive | project | --find-board-pane | --help\n\nCommands:\n  add    create one task or apply a JSON plan\n  steps  add or toggle one step on a task\n  list   inspect tasks\n  trash  restore a trashed task\n  archive    keep a task off the working views\n  unarchive  put an archived task back\n  project    archive or unarchive a project\n\nRun `tsk add --help`, `tsk steps --help`, `tsk list --help`, `tsk trash --help`, `tsk archive --help`, `tsk unarchive --help`, or `tsk project --help` for command details."
+                "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | --find-board-pane | --help\n\nCommands:\n  add    create one task or apply a JSON plan\n  steps  add, toggle, rename, or remove one step on a task\n  list   inspect tasks\n  status set a task's human status\n  edit   update a task's title or notes\n  trash  restore a trashed task\n  archive    keep a task off the working views\n  unarchive  put an archived task back\n  project    archive or unarchive a project\n\nRun `tsk add --help`, `tsk steps --help`, `tsk list --help`, `tsk status --help`, `tsk edit --help`, `tsk trash --help`, `tsk archive --help`, `tsk unarchive --help`, or `tsk project --help` for command details."
             );
             ExitCode::SUCCESS
         }
@@ -19,6 +19,8 @@ fn main() -> ExitCode {
         Surface::Add
         | Surface::Steps
         | Surface::List
+        | Surface::Status
+        | Surface::Edit
         | Surface::Trash
         | Surface::Archive
         | Surface::Unarchive
@@ -35,7 +37,7 @@ fn main() -> ExitCode {
 
 fn usage_exit() -> ExitCode {
     eprintln!(
-        "usage: tsk [capture] | add | steps | list | trash | archive | unarchive | project | --find-board-pane | --help"
+        "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | --find-board-pane | --help"
     );
     ExitCode::from(2)
 }

--- a/tests/cli_discovery.rs
+++ b/tests/cli_discovery.rs
@@ -7,6 +7,8 @@ fn skill_documents_retry_and_misfiling() {
 
     for term in [
         "tsk add -t",
+        "tsk status",
+        "tsk edit",
         "--desk",
         "--project",
         "--file plan.json",

--- a/tests/cli_edit.rs
+++ b/tests/cli_edit.rs
@@ -1,0 +1,226 @@
+//! Edit CLI: `tsk edit T<n> --title/--notes`. Uses temp dirs only.
+
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tsk_tui::cli::{run_with, CliOutput};
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskEventKind, TaskScope};
+use tsk_tui::store::TaskStore;
+
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn temp_state_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("tsk-cli-edit-{label}-{nanos}-{seq}"));
+    fs::create_dir_all(&dir).expect("create temp state dir");
+    dir
+}
+
+struct TempDirGuard(PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn cli(args: Vec<String>) -> CliOutput {
+    run_with(args, Cursor::new(Vec::<u8>::new()), true)
+}
+
+fn add_task(dir: &Path, title: &str) -> CliOutput {
+    cli(vec![
+        "tsk".into(),
+        "add".into(),
+        "-t".into(),
+        title.into(),
+        "-n".into(),
+        "original notes".into(),
+        "--desk".into(),
+        "--state-dir".into(),
+        dir.to_string_lossy().into_owned(),
+    ])
+}
+
+fn edit(dir: &Path, args: &[&str]) -> CliOutput {
+    let mut command = vec![
+        "tsk".into(),
+        "edit".into(),
+        "--state-dir".into(),
+        dir.to_string_lossy().into_owned(),
+    ];
+    command.extend(args.iter().map(|argument| (*argument).to_string()));
+    cli(command)
+}
+
+#[test]
+fn edit_title_and_notes_and_repeat_is_idempotent() {
+    let dir = temp_state_dir("round-trip");
+    let _guard = TempDirGuard(dir.clone());
+    assert_eq!(add_task(&dir, "old title").code, 0);
+
+    let titled = edit(&dir, &["T1", "--title", "  new title  "]);
+    assert_eq!(titled.code, 0, "{:?}", titled.stderr);
+    assert_eq!(titled.stdout, "edited T1 new title\n");
+    let state = TaskStore::new(&dir).load().expect("load");
+    let task = &state.tasks()[0];
+    assert_eq!(task.title, "new title");
+    assert_eq!(task.notes.as_deref(), Some("original notes"));
+
+    let noted = edit(&dir, &["T1", "--notes", "updated notes"]);
+    assert_eq!(noted.code, 0, "{:?}", noted.stderr);
+    let state = TaskStore::new(&dir).load().expect("load");
+    let task = &state.tasks()[0];
+    assert_eq!(task.title, "new title");
+    assert_eq!(task.notes.as_deref(), Some("updated notes"));
+
+    let events = task
+        .history
+        .iter()
+        .filter(|event| event.kind == TaskEventKind::Edited)
+        .count();
+    let again = edit(
+        &dir,
+        &["T1", "--title", "new title", "--notes", "updated notes"],
+    );
+    assert_eq!(again.code, 0, "{:?}", again.stderr);
+    assert_eq!(again.stdout, "edited T1 new title\n");
+    let state = TaskStore::new(&dir).load().expect("load");
+    let after = state.tasks()[0]
+        .history
+        .iter()
+        .filter(|event| event.kind == TaskEventKind::Edited)
+        .count();
+    assert_eq!(after, events, "a repeat edit writes no second event");
+}
+
+#[test]
+fn edit_clears_notes_and_keeps_scope_and_thread() {
+    let dir = temp_state_dir("preserve");
+    let _guard = TempDirGuard(dir.clone());
+    let mut state = DomainState::new();
+    let id = state
+        .create(
+            "keep scope",
+            Some("drop these".into()),
+            TaskScope::Project {
+                path: "/tmp/edit-cli-project".into(),
+            },
+            ProvenanceOrigin::Manual,
+            Some("v6".into()),
+        )
+        .expect("seed");
+    TaskStore::new(&dir).save(&state).expect("save seed");
+    let number = TaskStore::new(&dir)
+        .load()
+        .expect("reload")
+        .get(id)
+        .expect("task")
+        .number
+        .expect("number");
+
+    let output = edit(&dir, &[&format!("T{number}"), "--notes="]);
+    assert_eq!(output.code, 0, "{:?}", output.stderr);
+    let task = TaskStore::new(&dir).load().expect("load").tasks()[0].clone();
+    assert!(
+        task.notes.is_none(),
+        "whitespace-only notes clear the field"
+    );
+    assert_eq!(
+        task.scope,
+        TaskScope::Project {
+            path: "/tmp/edit-cli-project".into(),
+        }
+    );
+    assert_eq!(task.thread.as_deref(), Some("v6"));
+    assert_eq!(task.title, "keep scope");
+}
+
+#[test]
+fn edit_refuses_empty_title_and_control_chars_without_mutation() {
+    let dir = temp_state_dir("refusals");
+    let _guard = TempDirGuard(dir.clone());
+    assert_eq!(add_task(&dir, "keep me").code, 0);
+    let state_file = dir.join("tsk.json");
+    let before = fs::read(&state_file).expect("read seeded state");
+
+    for (args, token) in [
+        (["T1", "--title", "   "].as_slice(), "empty-title"),
+        (["T1", "--title", "line\nbreak"].as_slice(), "invalid-title"),
+        (["T1", "--notes", "line\nbreak"].as_slice(), "invalid-notes"),
+    ] {
+        let output = edit(&dir, args);
+        assert_eq!(output.code, 1, "{token}: {:?}", output.stderr);
+        assert!(output.stdout.is_empty());
+        assert!(output.stderr.contains(token), "{token}: {}", output.stderr);
+        assert_eq!(
+            fs::read(&state_file).expect("read after refusal"),
+            before,
+            "{token} must persist nothing"
+        );
+    }
+}
+
+#[test]
+fn edit_unknown_and_deleted_refuse() {
+    let dir = temp_state_dir("missing");
+    let _guard = TempDirGuard(dir.clone());
+    let missing = edit(&dir, &["T9", "--title", "nope"]);
+    assert_eq!(missing.code, 1);
+    assert!(missing.stderr.contains("unknown-task"));
+
+    assert_eq!(add_task(&dir, "delete me").code, 0);
+    let mut state = TaskStore::new(&dir).load().expect("load");
+    let id = state.tasks()[0].id;
+    state.soft_delete(id).expect("soft delete");
+    TaskStore::new(&dir).save(&state).expect("save deleted");
+    let deleted = edit(&dir, &["T1", "--title", "nope"]);
+    assert_eq!(deleted.code, 1);
+    assert!(deleted.stderr.contains("soft-deleted-task"));
+}
+
+#[test]
+fn edit_without_fields_is_usage() {
+    let dir = temp_state_dir("usage");
+    let _guard = TempDirGuard(dir.clone());
+    assert_eq!(add_task(&dir, "keep me").code, 0);
+    let output = edit(&dir, &["T1"]);
+    assert_eq!(output.code, 2);
+    assert!(output.stderr.contains("title or notes is required"));
+}
+
+#[test]
+fn edit_help_names_title_notes_and_equals_forms() {
+    let output = cli(vec!["tsk".into(), "edit".into(), "--help".into()]);
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    assert!(output.stderr.is_empty());
+    for term in [
+        "usage: tsk edit",
+        "--title",
+        "--notes",
+        "--title=<value>",
+        "--notes=<value>",
+        "idempotent",
+        "empty-title",
+        "invalid-title",
+        "invalid-notes",
+        "exit 0",
+        "exit 1",
+        "exit 2",
+        "exit 3",
+        "nothing persisted",
+        "indeterminate",
+    ] {
+        assert!(
+            output.stdout.contains(term),
+            "edit help should contain {term:?}"
+        );
+    }
+}

--- a/tests/cli_router_process.rs
+++ b/tests/cli_router_process.rs
@@ -60,9 +60,13 @@ fn top_level_help_names_subcommands_and_their_help() {
     let stdout = String::from_utf8(output.stdout).expect("UTF-8 help");
     assert!(stdout.contains("add"));
     assert!(stdout.contains("list"));
+    assert!(stdout.contains("status"));
+    assert!(stdout.contains("edit"));
     assert!(stdout.contains("archive") && stdout.contains("unarchive"));
     assert!(stdout.contains("tsk add --help"));
     assert!(stdout.contains("tsk list --help"));
+    assert!(stdout.contains("tsk status --help"));
+    assert!(stdout.contains("tsk edit --help"));
     assert!(stdout.contains("tsk archive --help"));
 }
 

--- a/tests/cli_status.rs
+++ b/tests/cli_status.rs
@@ -1,0 +1,199 @@
+//! Status CLI: `tsk status T<n> <status>`. Uses temp dirs only.
+
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tsk_tui::cli::{run_with, CliOutput};
+use tsk_tui::domain::{HumanStatus, TaskEventKind};
+use tsk_tui::store::TaskStore;
+
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn temp_state_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("tsk-cli-status-{label}-{nanos}-{seq}"));
+    fs::create_dir_all(&dir).expect("create temp state dir");
+    dir
+}
+
+struct TempDirGuard(PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn cli(args: Vec<String>) -> CliOutput {
+    run_with(args, Cursor::new(Vec::<u8>::new()), true)
+}
+
+fn add_task(dir: &Path, title: &str) -> CliOutput {
+    cli(vec![
+        "tsk".into(),
+        "add".into(),
+        "-t".into(),
+        title.into(),
+        "--desk".into(),
+        "--state-dir".into(),
+        dir.to_string_lossy().into_owned(),
+    ])
+}
+
+fn status(dir: &Path, task: &str, value: &str) -> CliOutput {
+    cli(vec![
+        "tsk".into(),
+        "status".into(),
+        task.into(),
+        value.into(),
+        "--state-dir".into(),
+        dir.to_string_lossy().into_owned(),
+    ])
+}
+
+fn loaded_status(dir: &Path) -> (HumanStatus, usize) {
+    let state = TaskStore::new(dir).load().expect("load store");
+    let task = state.tasks().first().expect("seeded task");
+    (
+        task.status,
+        task.history
+            .iter()
+            .filter(|event| event.kind == TaskEventKind::StatusSet)
+            .count(),
+    )
+}
+
+#[test]
+fn status_sets_each_agent_status_and_repeat_is_idempotent() {
+    let dir = temp_state_dir("round-trip");
+    let _guard = TempDirGuard(dir.clone());
+    let added = add_task(&dir, "move me");
+    assert_eq!(added.code, 0, "{:?}", added.stderr);
+
+    for value in ["started", "blocked", "review", "ready"] {
+        let output = status(&dir, "T1", value);
+        assert_eq!(output.code, 0, "{value}: {:?}", output.stderr);
+        assert_eq!(output.stdout, format!("status T1 {value} move me\n"));
+        let (current, _) = loaded_status(&dir);
+        assert_eq!(
+            current,
+            match value {
+                "started" => HumanStatus::Started,
+                "blocked" => HumanStatus::Blocked,
+                "review" => HumanStatus::Review,
+                "ready" => HumanStatus::Ready,
+                _ => unreachable!(),
+            }
+        );
+    }
+
+    let (_, events) = loaded_status(&dir);
+    let again = status(&dir, "T1", "ready");
+    assert_eq!(again.code, 0, "{:?}", again.stderr);
+    assert_eq!(again.stdout, "status T1 ready move me\n");
+    let (current, after) = loaded_status(&dir);
+    assert_eq!(current, HumanStatus::Ready);
+    assert_eq!(after, events, "a repeat status writes no second event");
+}
+
+#[test]
+fn status_start_is_an_alias_for_started() {
+    let dir = temp_state_dir("start-alias");
+    let _guard = TempDirGuard(dir.clone());
+    assert_eq!(add_task(&dir, "move me").code, 0);
+
+    let output = status(&dir, "T1", "start");
+    assert_eq!(output.code, 0, "{:?}", output.stderr);
+    assert_eq!(output.stdout, "status T1 started move me\n");
+    assert_eq!(loaded_status(&dir).0, HumanStatus::Started);
+
+    let again = status(&dir, "T1", "start");
+    assert_eq!(again.code, 0);
+    assert_eq!(again.stdout, "status T1 started move me\n");
+    assert_eq!(loaded_status(&dir).1, 1, "start then start writes once");
+}
+
+#[test]
+fn status_done_sets_done_and_repeat_is_idempotent() {
+    let dir = temp_state_dir("done");
+    let _guard = TempDirGuard(dir.clone());
+    assert_eq!(add_task(&dir, "finish me").code, 0);
+
+    let output = status(&dir, "T1", "done");
+    assert_eq!(output.code, 0, "{:?}", output.stderr);
+    assert_eq!(output.stdout, "status T1 done finish me\n");
+    assert_eq!(loaded_status(&dir).0, HumanStatus::Done);
+
+    let again = status(&dir, "T1", "done");
+    assert_eq!(again.code, 0);
+    assert_eq!(again.stdout, "status T1 done finish me\n");
+    assert_eq!(loaded_status(&dir).1, 1, "done then done writes once");
+}
+
+#[test]
+fn status_unknown_and_deleted_refuse_without_mutation() {
+    let dir = temp_state_dir("refusals");
+    let _guard = TempDirGuard(dir.clone());
+    let missing = status(&dir, "T9", "started");
+    assert_eq!(missing.code, 1);
+    assert!(missing.stderr.contains("unknown-task"));
+
+    assert_eq!(add_task(&dir, "delete me").code, 0);
+    let mut state = TaskStore::new(&dir).load().expect("load");
+    let id = state.tasks()[0].id;
+    state.soft_delete(id).expect("soft delete");
+    TaskStore::new(&dir).save(&state).expect("save deleted");
+    let state_file = dir.join("tsk.json");
+    let before = fs::read(&state_file).expect("read deleted state");
+
+    let deleted = status(&dir, "T1", "started");
+    assert_eq!(deleted.code, 1);
+    assert!(deleted.stderr.contains("soft-deleted-task"));
+    assert_eq!(fs::read(&state_file).expect("read after"), before);
+}
+
+#[test]
+fn status_unknown_name_is_usage() {
+    let dir = temp_state_dir("usage");
+    let _guard = TempDirGuard(dir.clone());
+    assert_eq!(add_task(&dir, "keep me").code, 0);
+    let output = status(&dir, "T1", "nope");
+    assert_eq!(output.code, 2);
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.contains("unknown status"));
+}
+
+#[test]
+fn status_help_names_statuses_and_done_token() {
+    let output = cli(vec!["tsk".into(), "status".into(), "--help".into()]);
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    assert!(output.stderr.is_empty());
+    for term in [
+        "usage: tsk status",
+        "ready",
+        "started",
+        "start",
+        "blocked",
+        "review",
+        "done",
+        "idempotent",
+        "exit 0",
+        "exit 1",
+        "exit 2",
+        "exit 3",
+        "nothing persisted",
+        "indeterminate",
+    ] {
+        assert!(
+            output.stdout.contains(term),
+            "status help should contain {term:?}"
+        );
+    }
+}

--- a/tests/cli_steps.rs
+++ b/tests/cli_steps.rs
@@ -430,9 +430,12 @@ fn steps_help_documents_toggle_flip_and_verify_guidance() {
     for term in [
         "usage: tsk steps",
         "toggle",
+        "rename",
+        "remove",
         "flips",
         "verify",
         "list",
+        "idempotent",
         "exit 0",
         "exit 1",
         "exit 2",
@@ -445,4 +448,129 @@ fn steps_help_documents_toggle_flip_and_verify_guidance() {
             "steps help should contain {term:?}"
         );
     }
+}
+
+#[test]
+fn steps_rename_then_remove_round_trips() {
+    let dir = temp_state_dir("rename-remove");
+    let task = seed_task(&dir, "rename target");
+
+    let mut add = steps_args(&dir, task);
+    add.extend(["add".into(), "  first draft  ".into()]);
+    let add = steps(&add);
+    assert_eq!(add.code, 0, "{}", add.stderr);
+
+    let listed = steps(&[
+        "tsk".into(),
+        "list".into(),
+        task.to_string(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    let lines = step_lines(&listed.stdout);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].text, "first draft");
+
+    let mut rename = steps_args(&dir, task);
+    rename.extend([
+        "rename".into(),
+        lines[0].short_id.clone(),
+        "  renamed step  ".into(),
+    ]);
+    let rename = steps(&rename);
+    assert_eq!(rename.code, 0, "{}", rename.stderr);
+    assert_eq!(
+        rename.stdout,
+        format!("renamed {} renamed step\n", lines[0].short_id)
+    );
+
+    let after_rename = TaskStore::new(&dir)
+        .load()
+        .expect("reload")
+        .get(task)
+        .expect("task")
+        .steps[0]
+        .text
+        .clone();
+    assert_eq!(after_rename, "renamed step");
+
+    let mut again = steps_args(&dir, task);
+    again.extend([
+        "rename".into(),
+        lines[0].short_id.clone(),
+        "renamed step".into(),
+    ]);
+    let again = steps(&again);
+    assert_eq!(again.code, 0, "{}", again.stderr);
+    let events = TaskStore::new(&dir)
+        .load()
+        .expect("reload")
+        .get(task)
+        .expect("task")
+        .history
+        .iter()
+        .filter(|event| event.kind == tsk_tui::domain::TaskEventKind::StepRenamed)
+        .count();
+    assert_eq!(events, 1, "a repeat rename writes no second event");
+
+    let mut remove = steps_args(&dir, task);
+    remove.extend(["remove".into(), lines[0].short_id.clone()]);
+    let remove = steps(&remove);
+    assert_eq!(remove.code, 0, "{}", remove.stderr);
+    assert_eq!(
+        remove.stdout,
+        format!("removed {} renamed step\n", lines[0].short_id)
+    );
+    assert!(TaskStore::new(&dir)
+        .load()
+        .expect("reload")
+        .get(task)
+        .expect("task")
+        .steps
+        .is_empty());
+
+    let mut missing = steps_args(&dir, task);
+    missing.extend(["remove".into(), lines[0].short_id.clone()]);
+    let missing = steps(&missing);
+    assert_eq!(missing.code, 1);
+    assert!(missing.stderr.contains("unknown-step"));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn steps_rename_refuses_empty_and_control_char_text_without_mutation() {
+    let dir = temp_state_dir("rename-text");
+    let task = seed_task(&dir, "rename refusal");
+    let mut add = steps_args(&dir, task);
+    add.extend(["add".into(), "keep me".into()]);
+    assert_eq!(steps(&add).code, 0);
+    let listed = steps(&[
+        "tsk".into(),
+        "list".into(),
+        task.to_string(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    let short_id = step_lines(&listed.stdout)[0].short_id.clone();
+    let state_file = dir.join("tsk.json");
+    let before = std::fs::read(&state_file).expect("read seeded state");
+
+    for (text, token) in [
+        ("", "empty-step-text"),
+        ("   ", "empty-step-text"),
+        ("   \t ", "invalid-step-text"),
+        ("line\nbreak", "invalid-step-text"),
+    ] {
+        let mut args = steps_args(&dir, task);
+        args.extend(["rename".into(), short_id.clone(), text.into()]);
+        let output = steps(&args);
+        assert_eq!(output.code, 1, "refuse {text:?}");
+        assert!(output.stderr.contains(token), "{token}: {}", output.stderr);
+    }
+    assert_eq!(
+        std::fs::read(&state_file).expect("read after refusals"),
+        before
+    );
+    let _ = std::fs::remove_dir_all(dir);
 }

--- a/tests/cli_terminal_escape.rs
+++ b/tests/cli_terminal_escape.rs
@@ -1,0 +1,284 @@
+//! Human CLI output must not emit raw terminal controls from stored text.
+//! Isolated state only; output is captured, never sent to a live terminal.
+
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tsk_tui::cli::{run_with, CliOutput};
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::store::TaskStore;
+
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+const TITLE: &str = "safe\u{001b}[2Jtitle";
+const ESCAPED_TITLE: &str = "safe\\u{001b}[2Jtitle";
+const STEP: &str = "step\u{001b}[2Jtext";
+const ESCAPED_STEP: &str = "step\\u{001b}[2Jtext";
+const PROJECT_PATH: &str = "/tmp/safe\u{001b}[2Jproj";
+const ESCAPED_PROJECT: &str = "safe\\u{001b}[2Jproj";
+
+fn temp_state_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("tsk-cli-escape-{label}-{nanos}-{seq}"));
+    fs::create_dir_all(&dir).expect("create temp state dir");
+    dir
+}
+
+struct TempDirGuard(PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn cli(args: Vec<String>) -> CliOutput {
+    run_with(args, Cursor::new(Vec::<u8>::new()), true)
+}
+
+fn state_dir_arg(dir: &Path) -> String {
+    dir.to_string_lossy().into_owned()
+}
+
+fn seed_task(dir: &Path, title: &str, scope: TaskScope) -> (u64, uuid::Uuid) {
+    let mut state = DomainState::new();
+    let id = state
+        .create(title, None, scope, ProvenanceOrigin::Manual, None)
+        .expect("seed task");
+    TaskStore::new(dir).save(&state).expect("save seed");
+    let loaded = TaskStore::new(dir).load().expect("reload");
+    let task = loaded.get(id).expect("seeded task");
+    (task.number.expect("number"), id)
+}
+
+fn assert_human_safe(output: &CliOutput, escaped: &str) {
+    assert_eq!(output.code, 0, "{}", output.stderr);
+    assert!(output.stderr.is_empty(), "{}", output.stderr);
+    assert!(
+        output.stdout.contains(escaped),
+        "escaped form missing: {}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains('\u{001b}'),
+        "raw ESC in stdout: {:?}",
+        output.stdout.as_bytes()
+    );
+    assert!(
+        output.stdout.contains("safe") || output.stdout.contains("step"),
+        "ordinary text should stay readable: {}",
+        output.stdout
+    );
+}
+
+#[test]
+fn archive_and_unarchive_escape_control_titles() {
+    let dir = temp_state_dir("archive");
+    let _guard = TempDirGuard(dir.clone());
+    let (number, _) = seed_task(&dir, TITLE, TaskScope::Global);
+    let address = format!("T{number}");
+
+    let listed = cli(vec![
+        "tsk".into(),
+        "list".into(),
+        address.clone(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_human_safe(&listed, ESCAPED_TITLE);
+
+    let archived = cli(vec![
+        "tsk".into(),
+        "archive".into(),
+        address.clone(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_human_safe(&archived, ESCAPED_TITLE);
+    assert!(archived.stdout.starts_with(&format!("archived {address} ")));
+
+    let unarchived = cli(vec![
+        "tsk".into(),
+        "unarchive".into(),
+        address,
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_human_safe(&unarchived, ESCAPED_TITLE);
+}
+
+#[test]
+fn steps_toggle_escapes_control_step_text() {
+    let dir = temp_state_dir("steps");
+    let _guard = TempDirGuard(dir.clone());
+    let mut state = DomainState::new();
+    let id = state
+        .create(
+            TITLE,
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("seed task");
+    state.add_step(id, STEP).expect("seed step");
+    TaskStore::new(&dir).save(&state).expect("save seed");
+    let loaded = TaskStore::new(&dir).load().expect("reload");
+    let number = loaded.get(id).expect("task").number.expect("number");
+    let listed = cli(vec![
+        "tsk".into(),
+        "list".into(),
+        format!("T{number}"),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&listed.stdout).expect("json");
+    assert_eq!(rows[0]["steps"][0]["text"], STEP);
+    let short = rows[0]["steps"][0]["short_id"]
+        .as_str()
+        .expect("short id")
+        .to_string();
+
+    let toggled = cli(vec![
+        "tsk".into(),
+        "steps".into(),
+        format!("T{number}"),
+        "toggle".into(),
+        short,
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_human_safe(&toggled, ESCAPED_STEP);
+    assert!(toggled.stdout.contains("toggled"));
+}
+
+#[test]
+fn project_archive_escapes_control_project_names() {
+    let dir = temp_state_dir("project");
+    let _guard = TempDirGuard(dir.clone());
+    seed_task(
+        &dir,
+        "widget",
+        TaskScope::Project {
+            path: PROJECT_PATH.into(),
+        },
+    );
+
+    let archived = cli(vec![
+        "tsk".into(),
+        "project".into(),
+        "archive".into(),
+        PROJECT_PATH.into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_human_safe(&archived, ESCAPED_PROJECT);
+
+    let unarchived = cli(vec![
+        "tsk".into(),
+        "project".into(),
+        "unarchive".into(),
+        PROJECT_PATH.into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_human_safe(&unarchived, ESCAPED_PROJECT);
+
+    let unknown = cli(vec![
+        "tsk".into(),
+        "project".into(),
+        "archive".into(),
+        format!("missing\u{001b}[2Jname"),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(unknown.code, 1);
+    assert!(unknown.stdout.is_empty());
+    assert!(
+        unknown.stderr.contains("missing\\u{001b}[2Jname"),
+        "{}",
+        unknown.stderr
+    );
+    assert!(!unknown.stderr.contains('\u{001b}'));
+}
+
+#[test]
+fn trash_restore_escapes_control_titles() {
+    let dir = temp_state_dir("trash");
+    let _guard = TempDirGuard(dir.clone());
+    let mut state = DomainState::new();
+    let deleted = state
+        .create(
+            TITLE,
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("deleted");
+    let other = state
+        .create(
+            "other",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("other");
+    state.soft_delete(deleted).expect("soft delete");
+    state.complete(other).expect("later undoable action");
+    TaskStore::new(&dir).save(&state).expect("save");
+
+    let listed = cli(vec![
+        "tsk".into(),
+        "list".into(),
+        "--deleted".into(),
+        "--desk".into(),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(listed.code, 0, "{}", listed.stderr);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&listed.stdout).expect("json");
+    let row = rows
+        .iter()
+        .find(|row| row["title"] == TITLE)
+        .expect("trashed title in JSON");
+    let number = row["number"].as_u64().expect("number");
+
+    let restored = cli(vec![
+        "tsk".into(),
+        "trash".into(),
+        "restore".into(),
+        format!("T{number}"),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_human_safe(&restored, ESCAPED_TITLE);
+}
+
+#[test]
+fn json_list_keeps_raw_control_values() {
+    let dir = temp_state_dir("json");
+    let _guard = TempDirGuard(dir.clone());
+    let (number, _) = seed_task(&dir, TITLE, TaskScope::Global);
+    let json = cli(vec![
+        "tsk".into(),
+        "list".into(),
+        format!("T{number}"),
+        "--json".into(),
+        "--state-dir".into(),
+        state_dir_arg(&dir),
+    ]);
+    assert_eq!(json.code, 0, "{}", json.stderr);
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json.stdout).expect("json");
+    assert_eq!(rows[0]["title"], TITLE);
+}

--- a/tests/cli_terminal_escape.rs
+++ b/tests/cli_terminal_escape.rs
@@ -282,3 +282,30 @@ fn json_list_keeps_raw_control_values() {
     let rows: Vec<serde_json::Value> = serde_json::from_str(&json.stdout).expect("json");
     assert_eq!(rows[0]["title"], TITLE);
 }
+
+#[test]
+fn status_usage_escapes_control_status_operands() {
+    let output = cli(vec![
+        "tsk".into(),
+        "status".into(),
+        "T1".into(),
+        "bad\u{001b}[2J".into(),
+    ]);
+    assert_eq!(output.code, 2);
+    assert!(output.stdout.is_empty());
+    assert!(
+        output.stderr.contains("unknown status bad\\u{001b}[2J"),
+        "escaped operand missing: {}",
+        output.stderr
+    );
+    assert!(
+        !output.stderr.contains('\u{001b}'),
+        "raw ESC in stderr: {:?}",
+        output.stderr.as_bytes()
+    );
+    assert!(
+        output.stderr.contains("unknown status"),
+        "ordinary usage text should stay readable: {}",
+        output.stderr
+    );
+}


### PR DESCRIPTION
## Summary

Headless agents can now move work without the TUI.

- `tsk status T<n> <status>` sets ready, started (`start` alias), blocked, review, or done. Repeating the same status is a no-op.
- `tsk edit T<n>` updates title and/or notes. Scope and thread stay put.
- `tsk steps` gains `rename` and `remove`.
- Human CLI output escapes C0/C1 controls in titles, step text, and project names. JSON keeps the stored values.
- Install docs keep `./target/release/tsk` after build, with an optional PATH export. Direct `tsk list T<n>` is live-store only; trash needs `--deleted` then `tsk trash restore`.

No spec-chain ledger. Quality review is the green bar plus Review panel.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] Manual herdr open-board smoke (if host paths changed) — not run; CLI only
- [x] `cd site && npm ci && npm test && npm run build` (if `site/` changed)

Escape regressions in `tests/cli_terminal_escape.rs` failed with presenter hunks reverted (raw ESC on archive, steps toggle, project archive, trash restore) and passed with them restored.