### PR TITLE
Run Actions only from main while private

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  pull_request:
   push:
+    branches: [main]
     paths-ignore:
       - "site/**"
       - ".github/workflows/site.yml"

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,9 +1,8 @@
 name: Site
 
 on:
-  # Run on every PR so `build` can be a stable required check on main.
-  pull_request:
   push:
+    branches: [main]
     paths:
       - "site/**"
       - ".github/workflows/site.yml"

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -9,33 +9,21 @@ on:
     paths:
       - "site/**"
       - ".github/workflows/vercel.yml"
-  pull_request:
-    paths:
-      - "site/**"
-      - ".github/workflows/vercel.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: vercel-${{ github.event.pull_request.number || github.ref }}
+  group: vercel-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: read
-      pull-requests: write
-    # Trusted refs only: fork pull requests skip the deploy (their VERCEL_TOKEN
-    # would be empty) and can never post comments. Production stays on pushes to
-    # main; same-repository pull requests keep getting previews. Plain
-    # pull_request checkout only — never pull_request_target.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    # Manual runs are allowed only from main, matching the automatic trigger.
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,8 +36,7 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@58.11.0
 
-      - name: Deploy
-        id: deploy
+      - name: Deploy production
         # Run from the repo root: the Vercel project's Root Directory is
         # site/, so the CLI resolves the path itself and would double it.
         env:
@@ -58,45 +45,10 @@ jobs:
           VERCEL_PROJECT_ID: prj_CNHAMn4BHWAvMCIasGuOhVHu9jZy
         run: |
           set -o pipefail
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ] && [ "$GITHUB_REF_NAME" = "main" ]; then
-            prod=--prod
-          fi
-          if vercel deploy $prod --yes --token "$VERCEL_TOKEN" > deploy.log 2>&1; then
+          if vercel deploy --prod --yes --token "$VERCEL_TOKEN" > deploy.log 2>&1; then
             cat deploy.log
           else
             status=$?
             cat deploy.log
             exit "$status"
           fi
-          url=$(grep -oE 'https://[a-zA-Z0-9.-]+\.vercel\.app' deploy.log | tail -1)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-
-      - name: Comment preview URL on the PR
-        if: github.event_name == 'pull_request' && steps.deploy.outputs.url != ''
-        uses: actions/github-script@v7
-        env:
-          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
-        with:
-          script: |
-            const url = process.env.PREVIEW_URL;
-            const marker = '<!-- vercel-preview -->';
-            const body = `${marker}\nPreview deployed: ${url}`;
-            const { data: comments } = await github.rest.issues.listComments({
-              ...context.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-            const existing = comments.find((c) => c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                ...context.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,10 +136,10 @@ For scriptable board work, use `tsk add` and `tsk list`; read
 - Temp state dirs need a per-binary atomic counter, not just `SystemTime::now()`.
 - Green bar: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
 - CI installs Rust **1.96.0** with `rustfmt` + `clippy` on ubuntu and macos. The
-  frame-time bench is Linux-only. Site-only pushes skip that matrix
-  (`paths-ignore: site/**`). Site CI runs on every pull request so its `build`
-  job can be required, and on site-only pushes: `npm ci && npm test && npm run build`
-  in `site/` (`.github/workflows/site.yml`).
+  frame-time bench is Linux-only. While the repository is private, workflows run
+  automatically only on pushes to `main` to conserve Actions usage; PR checks are
+  not required. Site-only pushes skip the Rust matrix (`paths-ignore: site/**`).
+  Site CI is `npm ci && npm test && npm run build` in `site/`.
 - Landing page and Starlight docs live in `site/` (Astro). They are not part of
   the `tsk` binary. Production: https://gettsk.sh. Point Vercel at
   this repo with Root Directory `site`.


### PR DESCRIPTION
## Status

- stops CI, Site, and Vercel workflows from running on pull requests
- limits automatic workflow runs to pushes on `main`
- keeps manual Vercel deploys available only when dispatched from `main`
- removes obsolete preview deployment and PR-comment machinery
- required status checks were temporarily removed from `main` protection so PRs do not wait forever

## Ask

Please review this temporary Actions-usage reduction. PR-only checks should be restored when the repository becomes public.

## Verification

- [x] workflow YAML parses successfully
- [x] `git diff --check`
- [x] branch protection still requires PRs and resolved conversations
- [x] branch protection no longer requires unavailable status checks
