### PR TITLE
Add NEEDS YOU for blocked and review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,11 @@ For scriptable board work, use `tsk add` and `tsk list`; read
 - Home is a tabbed board: **desk** · **projects** · **threads** (`1`/`2`/`3`). Tabs
   show only at home; project focus (`P` → project) hides them and paints the project
   name chip (`P ▾` on the right). At home the chip is hidden — tabs already say where
-  you are; `P` still opens the scope picker from the keyboard. **desk**: global IN MOTION
-  plus desk/global ON DECK. **projects**: one collapsible group per project (single-click
+  you are; `P` still opens the scope picker from the keyboard. **desk**: NEEDS YOU (desk
+  blocked and review), global IN MOTION, then desk/global ON DECK (ready). **projects**: one collapsible group per project (single-click
   collapse, double-click → project focus); in motion under each project, then review,
   blocked, open. **threads**: cross-project thread names with collapsible project
-  sub-groups; same status order. Collapse state is session-only. IN MOTION · ON DECK when
+  sub-groups; same status order. Collapse state is session-only. NEEDS YOU · IN MOTION · ON DECK when
   project-scoped · done drawer (`z`). Scoped ON DECK thread blocks paint dim `#name`
   headers with open counts; headers consume row budget but are not selectable or
   hit-testable. The done drawer ends with a collapsible `▾ archived · n` group (closed by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 NEEDS YOU section: blocked and review tasks sit above IN MOTION on desk and on a
-project board. Desk ON DECK / project ON DECK keep ready work.
+project board. Desk ON DECK / project ON DECK keep ready work. An empty deck
+header is omitted while NEEDS YOU has rows.
+
+`tsk edit --notes` keeps newlines and tabs, same as `tsk add -n`.
 
 Agent CLI mutations: `tsk status T<n> <status>` sets ready, started, blocked, or
 review, or done (`start` is an alias for `started`; idempotent on repeat), `tsk edit T<n>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+NEEDS YOU section: blocked and review tasks sit above IN MOTION on desk and on a
+project board. Desk ON DECK / project ON DECK keep ready work.
+
 Agent CLI mutations: `tsk status T<n> <status>` sets ready, started, blocked, or
 review, or done (`start` is an alias for `started`; idempotent on repeat), `tsk edit T<n>`
 updates title and/or notes, and `tsk steps` gains `rename` and `remove`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,7 @@ Canonical terms for this repo. No implementation detail.
 - **archived group**: the collapsible `archived · n` header and its rows inside the done drawer, closed by default, session-only collapse state. Chrome plus dimmed task rows.
 - **file**: the `ctrl+f` verb. On a task row it toggles the task's archived flag; in the picker it archives the project, on the picker's archived tab it unarchives it. Has no undo entry. `ctrl+u` on an archived selection also unarchives; on anything else it stays undo.
 - **thread block**: the derived unit of one thread's header plus its ordered open tasks inside a deck section. Exists only in query output, never in the store.
-- **working lens**: any board or CLI view meant for current work: desk tab, projects tab, threads tab, project focus, IN MOTION, ON DECK, thread headers and counts, the rail, and default `tsk list` views. Archived tasks and archived projects never paint in one.
+- **working lens**: any board or CLI view meant for current work: desk tab, projects tab, threads tab, project focus, NEEDS YOU, IN MOTION, ON DECK, thread headers and counts, the rail, and default `tsk list` views. Archived tasks and archived projects never paint in one.
+- **NEEDS YOU**: queue section for non-deleted, non-archived blocked and review tasks. Desk shows desk/global ones; project focus shows that project's. Omitted when empty. Sits above IN MOTION.
 - **session**: one board process from launch to quit. Session-only state (collapse, wide stage, the launch card having been shown) resets on relaunch.
 - **hidden**: a task that is archived, or whose project is archived. The single predicate every working lens filters on; distinct from soft-deleted.

--- a/site/public/board-demo.js
+++ b/site/public/board-demo.js
@@ -70,7 +70,7 @@ import { parseCapture } from "./capture.js";
       task({
         title: "Check the landing copy once more",
         status: "review",
-        notes: "Global review sits on desk ON DECK with blocked and ready.",
+        notes: "Global review sits on desk NEEDS YOU with blocked.",
         createdAt: NOW - 5 * HOUR,
         updatedAt: NOW - 20 * MIN,
       }),
@@ -259,12 +259,14 @@ import { parseCapture } from "./capture.js";
     if (state.tab === "desk") {
       return {
         started: open.filter((t) => t.status === "started").sort(byUpdated),
-        desk: open
+        need: open
           .filter(
             (t) =>
-              !t.project &&
-              (t.status === "ready" || t.status === "blocked" || t.status === "review"),
+              !t.project && (t.status === "blocked" || t.status === "review"),
           )
+          .sort(byUpdated),
+        desk: open
+          .filter((t) => !t.project && t.status === "ready")
           .sort(byUpdated),
         done,
       };
@@ -283,6 +285,10 @@ import { parseCapture } from "./capture.js";
 
     if (state.tab === "desk" && !state.focusProject) {
       const v = visibleTasks();
+      if (v.need.length) {
+        pushHeader("section", "NEEDS YOU", v.need.length);
+        v.need.forEach((t) => pushTask(t));
+      }
       pushHeader("section", "IN MOTION", v.started.length);
       v.started.forEach((t) => pushTask(t));
       pushHeader("section", "desk", v.desk.length);
@@ -301,17 +307,14 @@ import { parseCapture } from "./capture.js";
 
     if (state.focusProject) {
       const v = visibleTasks();
+      const need = [...v.review, ...v.blocked].sort(byUpdated);
+      if (need.length) {
+        pushHeader("section", "NEEDS YOU", need.length);
+        need.forEach((t) => pushTask(t));
+      }
       pushHeader("section", "IN MOTION", v.started.length);
       v.started.forEach((t) => pushTask(t));
-      pushHeader("section", "ON DECK", v.review.length + v.blocked.length + v.ready.length);
-      if (v.review.length) {
-        pushHeader("sub", "review", v.review.length);
-        v.review.forEach((t) => pushTask(t, 1));
-      }
-      if (v.blocked.length) {
-        pushHeader("sub", "blocked", v.blocked.length);
-        v.blocked.forEach((t) => pushTask(t, 1));
-      }
+      pushHeader("section", "ON DECK", v.ready.length);
       v.ready.forEach((t) => pushTask(t));
       if (state.drawer) {
         pushHeader("section", "DONE", v.done.length);

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -8,10 +8,10 @@ home (`1` / `2` / `3`). `P` opens the project picker from the keyboard.
 
 ## Tabs
 
-- **desk**: your own planning space. IN MOTION is every started task, from any
-  project. ON DECK is desk work that is ready, blocked, or review: general to-dos,
-  future projects, anything that belongs to no repository. Thread headers sit
-  above those open desk tasks.
+- **desk**: your own planning space. NEEDS YOU is desk work that is blocked or
+  review. IN MOTION is every started task, from any project. ON DECK is desk work
+  that is ready: general to-dos, future projects, anything that belongs to no
+  repository. Thread headers sit above those open ready desk tasks.
 - **projects**: one collapsible group per project. Single-click a header to
   collapse it. Double-click a header to focus that project. Inside a group:
   started, then review, blocked, ready.
@@ -34,9 +34,11 @@ group with nothing open reads `no open tasks here — P rescope or + capture`.
 
 One urgency-ordered list. Sections are computed, not navigated.
 
+- **NEEDS YOU**: blocked and review, on desk (desk/global tasks) and on a project
+  board (that project). Omitted when empty. Sits above IN MOTION.
 - **IN MOTION**: work you have started
-- **ON DECK** when you are on a project board: that project's ready, blocked, and
-  review tasks, with thread headers above their open rows
+- **ON DECK** when you are on a project board: that project's ready tasks, with
+  thread headers above their open rows
 - **z** opens the done drawer
 
 An archived task keeps its human status and leaves every working lens (desk,

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -158,13 +158,13 @@ tsk edit <task> [--title <title>] [--notes <notes>] [--state-dir <dir>]
 ```
 
 At least one of `--title` or `--notes` is required. Scope and thread are
-unchanged. Notes that trim to nothing are cleared. Output is
+unchanged. Notes that trim to nothing are cleared. Newlines and tabs in notes are kept, same as add. Output is
 `edited T<n> <title>`. Repeating the stored values is idempotent.
 
 Values that start with `-` need `--title=…` or `--notes=…`.
 
 Refusal tokens: `unknown-task`, `soft-deleted-task`, `empty-title`,
-`invalid-title`, `invalid-notes`.
+`invalid-title`.
 
 ## trash
 
@@ -230,4 +230,4 @@ Steps refusals (exit 1): `empty-step-text`, `invalid-step-text`, `unknown-task`,
 Status refusals (exit 1): `unknown-task`, `soft-deleted-task`.
 
 Edit refusals (exit 1): `unknown-task`, `soft-deleted-task`, `empty-title`,
-`invalid-title`, `invalid-notes`.
+`invalid-title`.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -420,7 +420,7 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
               </li>
               <li>
                 <span class="legend-n">2</span>
-                <div><b>IN MOTION.</b> Everything you have started, from any project, always on top.</div>
+                <div><b>NEEDS YOU.</b> Blocked and review, on desk and on a project board, above IN MOTION.</div>
               </li>
               <li>
                 <span class="legend-n">3</span>

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -121,12 +121,13 @@ Output always uses the stored name (`started`, not `start`). Repeating the same
 status is idempotent.
 
 `edit` needs at least one of `--title` or `--notes`. Scope and thread stay as
-they are. Notes that trim to nothing are cleared. Repeating the stored values
+they are. Notes that trim to nothing are cleared. Newlines and tabs in notes are
+kept, same as add. Repeating the stored values
 is idempotent. Values that start with `-` need `--title=<value>` or
 `--notes=<value>`.
 
 Both exit 0 on success, 1 for a refusal (`unknown-task`, `soft-deleted-task`,
-and for edit also `empty-title`, `invalid-title`, `invalid-notes`), 2 for usage,
+and for edit also `empty-title`, `invalid-title`), 2 for usage,
 and 3 for store I/O. Verify with `tsk list T12` before retrying an exit 3.
 
 ## Archived tasks and projects

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -29,7 +29,6 @@ pub enum EditError {
     SoftDeletedTask,
     EmptyTitle,
     InvalidTitle,
-    InvalidNotes,
     Store(String),
 }
 
@@ -40,7 +39,6 @@ impl EditError {
             Self::SoftDeletedTask => "soft-deleted-task",
             Self::EmptyTitle => "empty-title",
             Self::InvalidTitle => "invalid-title",
-            Self::InvalidNotes => "invalid-notes",
             Self::Store(_) => "store-error",
         }
     }
@@ -60,11 +58,6 @@ pub fn run(
         }
         if title.trim().is_empty() {
             return Err(EditError::EmptyTitle);
-        }
-    }
-    if let Some(notes) = fields.notes.as_deref() {
-        if has_c0_control(notes) {
-            return Err(EditError::InvalidNotes);
         }
     }
 

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -538,9 +538,9 @@ pub fn edit_help() -> CliOutput {
         stdout: concat!(
             "usage: tsk edit <task> [--title <title>] [--notes <notes>] [--state-dir <dir>]\n\n",
             "edit updates a task's title and/or notes. Scope and thread are unchanged. The task is a task number (T<number>, or bare digits) or UUID, as shown by tsk list. At least one of --title or --notes is required.\n",
-            "Notes that trim to nothing are cleared. Repeating the stored values is idempotent: the same output prints and nothing changes.\n",
+            "Notes that trim to nothing are cleared. Newlines and tabs in notes are kept, same as add. Repeating the stored values is idempotent: the same output prints and nothing changes.\n",
             "Values beginning with - must use --title=<value> or --notes=<value>.\n\n",
-            "Refusal tokens (exit 1): unknown-task, soft-deleted-task, empty-title, invalid-title, invalid-notes.\n\n",
+            "Refusal tokens (exit 1): unknown-task, soft-deleted-task, empty-title, invalid-title.\n\n",
             "Exit contract:\n",
             "  exit 0: fields written, or they already had the values\n",
             "  exit 1: edit refusal; verify state with list before retrying\n",

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -2226,14 +2226,18 @@ impl BoardModel {
     /// Browse), and the notice is stated **without** its `u Undo` control, because `u` types
     /// a `u` into the draft here and there is no hit region on this row. The deletion stays
     /// visible; the route it names comes back with the row when the edit closes.
-    /// Seed selection on open: first visible IN MOTION id, else first visible ON DECK id.
+    /// Seed selection on open: first visible NEEDS YOU id, else IN MOTION, else ON DECK.
     ///
     /// Honors collapse state via [`Self::visible_ids`]: a seeded row must be one the
     /// renderer painted, or verbs would mutate a task the user cannot see.
     pub(super) fn seed_selection(&mut self) {
         let visible: HashSet<Uuid> = self.visible_ids().into_iter().collect();
         let view = self.queue_view();
-        for kind in [SectionKind::InMotion, SectionKind::OnDeck] {
+        for kind in [
+            SectionKind::NeedsYou,
+            SectionKind::InMotion,
+            SectionKind::OnDeck,
+        ] {
             if let Some(id) = view
                 .sections
                 .iter()

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -274,7 +274,7 @@ fn query_home_desk(
     if !motion.is_empty() {
         sections.push(section_from(SectionKind::InMotion, None, None, &motion));
     }
-    sections.push(deck_section(None, &ready));
+    push_deck(&mut sections, None, &ready, &need);
 
     append_done(&mut sections, &live, drawer_open);
     append_archived(&mut sections, &archived_pool, drawer_open);
@@ -420,7 +420,7 @@ fn query_project_focus(
     if !motion.is_empty() {
         sections.push(section_from(SectionKind::InMotion, None, None, &motion));
     }
-    sections.push(deck_section(Some(label), &ready));
+    push_deck(&mut sections, Some(label), &ready, &need);
     append_done(&mut sections, &live, drawer_open);
     let in_scope: Vec<&Task> = tasks
         .iter()
@@ -594,6 +594,19 @@ fn push_needs_you(sections: &mut Vec<QueueSection>, need: &[&Task]) {
     if !need.is_empty() {
         sections.push(section_from(SectionKind::NeedsYou, None, None, need));
     }
+}
+
+/// Keep an empty desk/ON DECK header only when NEEDS YOU is also empty.
+fn push_deck(
+    sections: &mut Vec<QueueSection>,
+    project_label: Option<String>,
+    ready: &[&Task],
+    need: &[&Task],
+) {
+    if ready.is_empty() && !need.is_empty() {
+        return;
+    }
+    sections.push(deck_section(project_label, ready));
 }
 
 fn task_matches_scope(task: &Task, scope: DeckScope<'_>) -> bool {
@@ -1034,6 +1047,27 @@ mod tests {
         );
         assert!(!all_listed_ids(&view).contains(&Uuid::from_u128(5)));
         assert_eq!(view.sections[0].kind, SectionKind::NeedsYou);
+    }
+
+    #[test]
+    fn empty_deck_is_omitted_when_needs_you_has_rows() {
+        let desk_tasks = vec![task(1, HumanStatus::Blocked, TaskScope::Global, false, 10)];
+        let desk = query_lens(&desk_tasks, None, BoardLens::Home(BoardTab::Desk), false);
+        assert!(desk.sections.iter().all(|s| s.kind != SectionKind::OnDeck));
+        assert!(!desk.sections.iter().any(|s| s.empty_hint));
+
+        let project_tasks = vec![task(2, HumanStatus::Review, project("/repos/a"), false, 10)];
+        let project = query_lens(
+            &project_tasks,
+            None,
+            BoardLens::Project(Path::new("/repos/a")),
+            false,
+        );
+        assert!(project
+            .sections
+            .iter()
+            .all(|s| s.kind != SectionKind::OnDeck));
+        assert!(!project.sections.iter().any(|s| s.empty_hint));
     }
 
     #[test]

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -21,6 +21,8 @@ pub enum BoardTab {
 /// Which list region a section belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SectionKind {
+    /// Blocked and review tasks that need a human.
+    NeedsYou,
     InMotion,
     OnDeck,
     Done,
@@ -69,7 +71,7 @@ pub struct ThreadProjectSubgroup {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueueSection {
     pub kind: SectionKind,
-    /// Project path for a project-group section. `None` for IN MOTION, DONE, desk ON DECK, and
+    /// Project path for a project-group section. `None` for NEEDS YOU, IN MOTION, DONE, desk ON DECK, and
     /// thread-group sections.
     pub project_label: Option<String>,
     /// Thread name for a thread-group section on the Threads tab.
@@ -265,12 +267,14 @@ fn query_home_desk(
         })
         .collect();
     sort_by_updated_desc(&mut desk);
+    let (need, ready) = split_needs_you(&desk);
 
     let mut sections = Vec::new();
+    push_needs_you(&mut sections, &need);
     if !motion.is_empty() {
         sections.push(section_from(SectionKind::InMotion, None, None, &motion));
     }
-    sections.push(deck_section(None, &desk));
+    sections.push(deck_section(None, &ready));
 
     append_done(&mut sections, &live, drawer_open);
     append_archived(&mut sections, &archived_pool, drawer_open);
@@ -398,6 +402,7 @@ fn query_project_focus(
         .filter(|t| !matches!(t.status, HumanStatus::Started | HumanStatus::Done))
         .collect();
     sort_by_updated_desc(&mut open);
+    let (need, ready) = split_needs_you(&open);
 
     let (label, _) = live
         .iter()
@@ -411,10 +416,11 @@ fn query_project_focus(
         .unwrap_or_else(|| (path.to_string_lossy().into_owned(), ()));
 
     let mut sections = Vec::new();
+    push_needs_you(&mut sections, &need);
     if !motion.is_empty() {
         sections.push(section_from(SectionKind::InMotion, None, None, &motion));
     }
-    sections.push(deck_section(Some(label), &open));
+    sections.push(deck_section(Some(label), &ready));
     append_done(&mut sections, &live, drawer_open);
     let in_scope: Vec<&Task> = tasks
         .iter()
@@ -556,10 +562,37 @@ fn status_counts(live: &[&Task], drawer_open: bool) -> StatusCounts {
             .filter(|t| t.status == HumanStatus::Done)
             .count()
     };
+    let need = live
+        .iter()
+        .filter(|t| is_needs_you_status(t.status))
+        .count();
     StatusCounts {
         in_motion,
         done,
-        need: 0,
+        need,
+    }
+}
+
+fn is_needs_you_status(status: HumanStatus) -> bool {
+    matches!(status, HumanStatus::Blocked | HumanStatus::Review)
+}
+
+fn split_needs_you<'a>(tasks: &[&'a Task]) -> (Vec<&'a Task>, Vec<&'a Task>) {
+    let mut need = Vec::new();
+    let mut rest = Vec::new();
+    for task in tasks {
+        if is_needs_you_status(task.status) {
+            need.push(*task);
+        } else {
+            rest.push(*task);
+        }
+    }
+    (need, rest)
+}
+
+fn push_needs_you(sections: &mut Vec<QueueSection>, need: &[&Task]) {
+    if !need.is_empty() {
+        sections.push(section_from(SectionKind::NeedsYou, None, None, need));
     }
 }
 
@@ -945,6 +978,62 @@ mod tests {
         assert_eq!(ids(desk[0]), vec![Uuid::from_u128(4)]);
         assert!(section_ids(&view, SectionKind::InMotion).contains(&Uuid::from_u128(2)));
         assert!(!section_ids(&view, SectionKind::OnDeck).contains(&Uuid::from_u128(2)));
+    }
+
+    #[test]
+    fn home_desk_puts_global_blocked_and_review_in_needs_you() {
+        let tasks = vec![
+            task(1, HumanStatus::Blocked, TaskScope::Global, false, 10),
+            task(2, HumanStatus::Review, TaskScope::Global, false, 30),
+            task(3, HumanStatus::Ready, TaskScope::Global, false, 20),
+            task(4, HumanStatus::Blocked, project("/repos/a"), false, 40),
+            task(5, HumanStatus::Started, TaskScope::Global, false, 50),
+        ];
+
+        let view = query_lens(&tasks, None, BoardLens::Home(BoardTab::Desk), false);
+        assert_eq!(
+            section_ids(&view, SectionKind::NeedsYou),
+            vec![Uuid::from_u128(2), Uuid::from_u128(1)]
+        );
+        assert_eq!(
+            section_ids(&view, SectionKind::OnDeck),
+            vec![Uuid::from_u128(3)]
+        );
+        assert!(!section_ids(&view, SectionKind::NeedsYou).contains(&Uuid::from_u128(4)));
+        assert_eq!(view.counts.need, 3);
+        assert_eq!(
+            view.sections[0].kind,
+            SectionKind::NeedsYou,
+            "NEEDS YOU sits above IN MOTION"
+        );
+    }
+
+    #[test]
+    fn project_focus_puts_blocked_and_review_in_needs_you() {
+        let tasks = vec![
+            task(1, HumanStatus::Started, project("/repos/a"), false, 100),
+            task(2, HumanStatus::Blocked, project("/repos/a"), false, 80),
+            task(3, HumanStatus::Review, project("/repos/a"), false, 90),
+            task(4, HumanStatus::Ready, project("/repos/a"), false, 70),
+            task(5, HumanStatus::Blocked, project("/repos/b"), false, 60),
+        ];
+
+        let view = query_lens(
+            &tasks,
+            None,
+            BoardLens::Project(Path::new("/repos/a")),
+            false,
+        );
+        assert_eq!(
+            section_ids(&view, SectionKind::NeedsYou),
+            vec![Uuid::from_u128(3), Uuid::from_u128(2)]
+        );
+        assert_eq!(
+            section_ids(&view, SectionKind::OnDeck),
+            vec![Uuid::from_u128(4)]
+        );
+        assert!(!all_listed_ids(&view).contains(&Uuid::from_u128(5)));
+        assert_eq!(view.sections[0].kind, SectionKind::NeedsYou);
     }
 
     #[test]

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -3930,6 +3930,7 @@ fn paint_section_header(
 
 fn section_title(section: &QueueSection, at_home: bool, home_tab: BoardTab) -> String {
     match section.kind {
+        SectionKind::NeedsYou => "NEEDS YOU".to_string(),
         SectionKind::InMotion => "IN MOTION".to_string(),
         SectionKind::Done => "DONE".to_string(),
         SectionKind::Archived => "archived".to_string(),

--- a/tests/cli_edit.rs
+++ b/tests/cli_edit.rs
@@ -144,6 +144,18 @@ fn edit_clears_notes_and_keeps_scope_and_thread() {
 }
 
 #[test]
+fn edit_notes_keeps_newlines_and_tabs_like_add() {
+    let dir = temp_state_dir("multiline");
+    let _guard = TempDirGuard(dir.clone());
+    assert_eq!(add_task(&dir, "keep me").code, 0);
+    let notes = "line one\nline\ttwo";
+    let output = edit(&dir, &["T1", "--notes", notes]);
+    assert_eq!(output.code, 0, "{:?}", output.stderr);
+    let task = TaskStore::new(&dir).load().expect("load").tasks()[0].clone();
+    assert_eq!(task.notes.as_deref(), Some(notes));
+}
+
+#[test]
 fn edit_refuses_empty_title_and_control_chars_without_mutation() {
     let dir = temp_state_dir("refusals");
     let _guard = TempDirGuard(dir.clone());
@@ -154,7 +166,6 @@ fn edit_refuses_empty_title_and_control_chars_without_mutation() {
     for (args, token) in [
         (["T1", "--title", "   "].as_slice(), "empty-title"),
         (["T1", "--title", "line\nbreak"].as_slice(), "invalid-title"),
-        (["T1", "--notes", "line\nbreak"].as_slice(), "invalid-notes"),
     ] {
         let output = edit(&dir, args);
         assert_eq!(output.code, 1, "{token}: {:?}", output.stderr);
@@ -210,7 +221,6 @@ fn edit_help_names_title_notes_and_equals_forms() {
         "idempotent",
         "empty-title",
         "invalid-title",
-        "invalid-notes",
         "exit 0",
         "exit 1",
         "exit 2",

--- a/tests/queue_board_model.rs
+++ b/tests/queue_board_model.rs
@@ -411,13 +411,7 @@ fn unthreaded_tasks_list_after_thread_blocks() {
             20,
             "release",
         ),
-        task(
-            3,
-            "loose older",
-            HumanStatus::Blocked,
-            project(THIS_REPO),
-            10,
-        ),
+        task(3, "loose older", HumanStatus::Ready, project(THIS_REPO), 10),
     ];
 
     let view = query_lens(
@@ -453,7 +447,7 @@ fn thread_blocks_order_by_recency_and_tasks_within_by_updated_desc() {
         threaded_task(
             2,
             "alpha newer",
-            HumanStatus::Blocked,
+            HumanStatus::Ready,
             project(THIS_REPO),
             50,
             "alpha",
@@ -461,7 +455,7 @@ fn thread_blocks_order_by_recency_and_tasks_within_by_updated_desc() {
         threaded_task(
             3,
             "beta",
-            HumanStatus::Review,
+            HumanStatus::Ready,
             project(THIS_REPO),
             40,
             "beta",

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -540,7 +540,7 @@ fn standard_78x24_fixture_has_selector_list_rule_status_verb_and_no_other_chrome
     );
     assert!(
         !list.contains("need you") && !list.contains("NEEDS YOU"),
-        "M1 must not paint NEEDS YOU:\n{list}"
+        "default desk fixture has no global blocked/review, so no NEEDS YOU:\n{list}"
     );
     assert!(
         !list.contains("claude") && !list.contains("grok") && !list.contains("agent"),
@@ -598,6 +598,118 @@ fn standard_78x24_fixture_has_selector_list_rule_status_verb_and_no_other_chrome
     for row in &rows {
         assert_eq!(row_display_width(row), 78);
     }
+}
+
+#[test]
+fn desk_and_project_focus_paint_needs_you_above_in_motion() {
+    let mut domain = DomainState::new();
+    let started = domain
+        .create(
+            "started work",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("started");
+    domain
+        .set_status(started, HumanStatus::Started)
+        .expect("start");
+    let blocked = domain
+        .create(
+            "blocked desk",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("blocked");
+    domain
+        .set_status(blocked, HumanStatus::Blocked)
+        .expect("block");
+    let review = domain
+        .create(
+            "review desk",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("review");
+    domain
+        .set_status(review, HumanStatus::Review)
+        .expect("review");
+    let desk = BoardModel::from_domain(&domain, None);
+    let desk_rows = board_rows(&desk, 78, 24).join("\n");
+    let needs = desk_rows.find("NEEDS YOU");
+    let motion = desk_rows.find("IN MOTION");
+    assert!(needs.is_some(), "desk must paint NEEDS YOU:\n{desk_rows}");
+    assert!(
+        motion.is_some(),
+        "desk must still paint IN MOTION:\n{desk_rows}"
+    );
+    assert!(
+        needs.expect("needs") < motion.expect("motion"),
+        "NEEDS YOU must sit above IN MOTION:\n{desk_rows}"
+    );
+    assert!(desk_rows.contains("blocked desk") && desk_rows.contains("review desk"));
+
+    let mut domain = DomainState::new();
+    let project = TaskScope::Project {
+        path: "/repos/tsk".into(),
+    };
+    let started = domain
+        .create(
+            "started project",
+            None,
+            project.clone(),
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("started");
+    domain
+        .set_status(started, HumanStatus::Started)
+        .expect("start");
+    let blocked = domain
+        .create(
+            "blocked project",
+            None,
+            project.clone(),
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("blocked");
+    domain
+        .set_status(blocked, HumanStatus::Blocked)
+        .expect("block");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/tsk")));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenProjectSelector,
+        None,
+    )
+    .expect("open picker");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ProjectPickerNext,
+        None,
+    )
+    .expect("next");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmProjectChoice,
+        None,
+    )
+    .expect("focus project");
+    let project_rows = board_rows(&model, 78, 24).join("\n");
+    assert!(
+        project_rows.contains("NEEDS YOU"),
+        "project focus must paint NEEDS YOU:\n{project_rows}"
+    );
+    assert!(project_rows.contains("blocked project"));
 }
 
 fn assert_visible_chrome(rows: &[String], geo: TierGeometry, dimensions: &str) {


### PR DESCRIPTION
## Summary

Blocked and review tasks sit in a **NEEDS YOU** section above IN MOTION on desk (desk/global tasks) and on a project board (that project). Ready stays on desk / ON DECK. The section is omitted when empty. Not a new status and not the old attention poll.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Live herdr smoke with isolated `TSK_STATE_DIR`: NEEDS YOU painted with a blocked desk row, ready under desk
- [x] `cd site && npm test && npm run build`