### PR TITLE
Fix T16 bugs: threads, expanded capture, steps, delete confirm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ park/resume, linking, and dispatch are not in this tree; reference lives on
 
 A gitignored `HANDOFF.md` may hold this clone’s live working state.
 
-For scriptable board work, use `tsk add` and `tsk list`; read
-`skills/tsk-cli/SKILL.md` first for retry and scope-check rules.
+For scriptable board work, use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and
+`tsk steps`; read `skills/tsk-cli/SKILL.md` first for retry and scope-check rules.
 
 ### Board
 
@@ -83,15 +83,15 @@ For scriptable board work, use `tsk add` and `tsk list`; read
 - Task creation is the quick-add bar, never a form takeover. `+` opens a one-line
   title input on the status-row slot with a blank row above and below, list still
   visible. `Enter` saves and closes, `Shift+Enter` saves and stays open, `Tab`
-  expands the draft onto the task page with a title·notes·scope stash, so Esc
-  returns to the line and a second `Tab` restores what was typed. A project board
+  expands the draft onto the task page with a title·notes·thread·scope stash and a
+  `+ step` row, so Esc returns to the line and a second `Tab` restores what was typed. A project board
   defaults the draft to that project, a project-less board defaults it to your desk, and home
   keeps the invocation cwd-derived default. Capture tokens in the title: `!p` and
   `!t` each consume one whitespace-delimited argument. Bare `!p` selects your desk,
   `!p name` selects a project basename (case-insensitive), and `!p /path` uses that
   path verbatim. Bare `!t` unthreads, while `!t name` assigns a normalized thread:
-  lowercase ASCII alphanumerics and hyphens, starting with an alphanumeric, at most
-  32 characters. Tokens are stripped from the saved title. A saved task becomes the
+  lowercase ASCII alphanumerics, hyphens, and dots, starting with an alphanumeric, at most
+  32 characters. A refusal names the rule (start character, allowed characters, or length). Tokens are stripped from the saved title. A saved task becomes the
   selection. Success has no status message: the row flash is the feedback. Refusals
   paint while the line is open and clear when it closes.
 - There is no inline board capture form. Creation detail lives on the task page;
@@ -105,8 +105,10 @@ For scriptable board work, use `tsk add` and `tsk list`; read
   the one exception being a quick-add draft expanded with `Tab`, which opens
   straight into Notes edit mode because a draft has nothing to view. `ctrl+s`
   toggles a selected step, otherwise it starts or reopens the task. Plain `Enter`
-  parks an existing-step rename; `Shift+Enter` saves the complete task-edit
-  session, with `Alt+Enter` as the legacy-terminal fallback. The scope footer is
+  parks an existing-step rename; on a new step it saves that step and opens the next empty
+  row. `Shift+Enter` saves the complete task-edit session (and a typed new step), with
+  `Alt+Enter` as the legacy-terminal fallback. An empty new-step row discards if you click
+  elsewhere. `ctrl+x` asks once (`press ctrl+x again to delete`) before deleting a task. The scope footer is
   inert until an edit has started.
 - Content and chrome use mono modifiers only, at every width. No color theme module.
 - No host attention poll, park/resume, linking, or dispatch recovery on the board.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Thread names accept dots (`v0.0.6`). A refusal names the rule instead of `invalid thread name`.
+
+Expanded quick-add can set thread and add steps. Enter on a new step saves it and opens the next empty row; Shift+Enter saves the step and the task-edit session. An empty new-step row discards if you click elsewhere. Deleting a task asks `press ctrl+x again to delete` first.
+
 NEEDS YOU section: blocked and review tasks sit above IN MOTION on desk and on a
 project board. Desk ON DECK / project ON DECK keep ready work. An empty deck
 header is omitted while NEEDS YOU has rows.

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -75,7 +75,7 @@ selected, every verb answers `select a task first`.
 
 ## Delete and undo
 
-`ctrl+x` (or `ctrl+Delete`) soft-deletes the selected task. It leaves every lens
+`ctrl+x` (or `ctrl+Delete`) asks once (`press ctrl+x again to delete`), then soft-deletes the selected task. It leaves every lens
 and the status row reads `Deleted "title" · u Undo` until your next action. Nothing
 on the board hard-deletes; `tsk list --deleted` still shows it.
 

--- a/site/src/content/docs/docs/capture.md
+++ b/site/src/content/docs/docs/capture.md
@@ -32,7 +32,7 @@ rejoined with single spaces.
 | `!p name` | project by basename (case-insensitive) |
 | `!p /path` | that path verbatim |
 | `!t` | unthread |
-| `!t name` | normalized thread (lowercase ASCII alphanumerics and hyphens, first character alphanumeric, at most 32 characters) |
+| `!t name` | normalized thread (lowercase ASCII alphanumerics, hyphens, and dots, first character alphanumeric, at most 32 characters) |
 
 An ambiguous project basename is stored as typed. `tsk list --all --json` is how
 you find a typo scope later.
@@ -61,12 +61,12 @@ If text is selected in the pane you invoked it from, it arrives as the title.
 Scope is three chips: **This project** (the repo the focused pane is in; marked
 unavailable outside one), **Desk**, and **Other…**, which discloses a path field.
 `1` `2` `3` pick a chip, `s` or `Space` cycles, `p` or `e` edits the path and `Enter`
-confirms it. Refusals paint in the card: `Title required`, `invalid thread name`.
+confirms it. Refusals paint in the card: `Title required`, or a thread rule (`thread must start with a letter or number`, `thread: use letters, numbers, hyphens, and dots`, `thread is at most 32 characters`).
 
 An idle board watching the same `~/.tsk` picks up the new task on the next tick.
 
 ## Expanded form
 
 From the `+` line, `Tab` opens the task page in notes edit because a draft has
-nothing to view yet. `Esc` returns to the line. A second `Tab` restores what you
-typed.
+nothing to view yet. Thread and `+ step` are on that page. `Esc` returns to the
+line. A second `Tab` restores what you typed.

--- a/site/src/content/docs/docs/keys.md
+++ b/site/src/content/docs/docs/keys.md
@@ -73,13 +73,13 @@ The page is view-first. Verbs still need the modifier, except Tab and arrows.
 | `ctrl+n` | edit notes |
 | `Tab` / `Shift+Tab` | in view, loop forward or backward through stored steps and `+ step`; in task editing, loop Title, Notes, stored steps, `+ step`, Scope, Thread |
 | `ctrl+a` | open an independent inline [step](/docs/steps/) editor from view or any task-edit focus |
-| `Enter` | opens or saves selected `+ step`, parks an existing-step rename, opens Scope's picker, or toggles Thread's selected text editor |
+| `Enter` | saves a new step and opens the next empty row, parks an existing-step rename, opens Scope's picker, or toggles Thread's selected text editor |
 | click a step | selects it in view, opens it inline only during task editing; click `   + step` to add from any page edit state |
 | `↓` `↑` | Down activates the first stored step, then arrows move selected steps; an open add row scrolls the page |
 | `ctrl+s` | toggle the selected step, otherwise start or reopen the task |
 | `ctrl+d` / `ctrl+o` | complete / reopen the selected step, otherwise act on the task |
-| `ctrl+x` | in view, first mark then remove a selected step on a second press; in task edit immediately hide and stage its removal, otherwise delete the task |
-| `Shift+Enter` | task-edit save, or save a step and open the next empty step editor (`Alt+Enter` is the legacy-terminal save fallback) |
+| `ctrl+x` | in view, first mark then remove a selected step on a second press; in task edit immediately hide and stage its removal, otherwise ask once then delete the task |
+| `Shift+Enter` | task-edit save, or save a new step and exit task editing (`Alt+Enter` is the legacy-terminal save fallback) |
 | `Esc` | cancel the field, restore staged task-edit changes, or close the page |
 
 Title, Notes, Thread, and Scope clicks are inert until task editing starts. Once it

--- a/site/src/content/docs/docs/steps.md
+++ b/site/src/content/docs/docs/steps.md
@@ -33,11 +33,11 @@ The section is labelled `steps <done>/<total>`. Rows paint `▪` open, `✓` don
 
 A new-step draft lives in the steps section. From view or task edit, it persists
 independently: it never joins the enclosing task edit session. Plain `Enter` saves one new
-step and selects that new stored step. `Shift+Enter` saves one and opens the next
-empty editor. Existing-step renames and removals are staged with Title, Notes,
-Thread, and Scope. Plain `Enter` parks an existing-step rename in that session,
-then `Shift+Enter` saves all staged changes (`Alt+Enter` is the legacy-terminal
-fallback). `Esc` cancels a field; Esc from task
+step and opens the next empty editor. `Shift+Enter` saves that step and the enclosing
+task-edit session. An empty new-step row discards if you click elsewhere. Existing-step
+renames and removals are staged with Title, Notes, Thread, and Scope. Plain `Enter` parks
+an existing-step rename in that session, then `Shift+Enter` saves all staged changes
+(`Alt+Enter` is the legacy-terminal fallback). `Esc` cancels a field; Esc from task
 editing restores staged removals. A failed save keeps its drafts until you retry or cancel.
 
 Wheel still scrolls the page. Bare `↓` activates the first stored step, then arrows

--- a/site/src/content/docs/docs/task-page.md
+++ b/site/src/content/docs/docs/task-page.md
@@ -41,8 +41,9 @@ Plain `Enter` parks an existing-step rename without saving the task session.
 Scope, staged existing-step edits, and staged removals, then exits editing. `Alt+Enter`
 is the legacy-terminal fallback. A staged
 `ctrl+x` removal disappears immediately and returns if task editing is cancelled. New
-steps save independently from view or task edit: Enter saves one and selects it,
-Shift+Enter saves one and opens the next empty editor. Field `Esc` cancels that
+steps save independently from view or task edit: Enter saves one and opens the next empty
+editor, Shift+Enter saves that step and the task-edit session. An empty new-step row
+discards if you click elsewhere. Field `Esc` cancels that
 field, while Esc from task editing restores staged removals.
 
 Notes are multiline, so `Enter` inserts a line. `Shift+Enter` saves and does not

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,8 +23,8 @@ use crate::ui::capture::{
     apply_capture_intent, draw_capture, CaptureModel, CaptureOutcome, TITLE_REQUIRED_MESSAGE,
 };
 use crate::ui::input::{
-    map_board_form_key, map_capture_key_state, map_capture_paste_state, map_edit_paste, map_key,
-    map_task_form_key, route_responsive_key, BoardIntent, CaptureIntent, ResponsiveKeyRoute,
+    map_capture_key_state, map_capture_paste_state, map_edit_paste, map_key, map_task_form_key,
+    route_responsive_key, BoardIntent, CaptureIntent, ResponsiveKeyRoute,
 };
 use crate::ui::mouse::{
     capture_layout_for_model, enable_terminal_input, focused_mouse_area,
@@ -968,10 +968,7 @@ fn board_keyboard_intent(
     }
 
     match model.form_focus().filter(|_| form_field_mode) {
-        Some(focus) if model.edit_target().is_some() => {
-            map_task_form_key(focus, mode == BoardInputMode::FormScopeDropdown, key)
-        }
-        Some(focus) => map_board_form_key(focus, mode == BoardInputMode::FormScopeDropdown, key),
+        Some(focus) => map_task_form_key(focus, mode == BoardInputMode::FormScopeDropdown, key),
         None => map_key(mode, key),
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2580,6 +2580,7 @@ mod tests {
                 .expect("create task");
             let mut model = BoardModel::from_domain(&domain, None);
             drive(&mut domain, &mut model, area, ctrl(KeyCode::Char('x')));
+            drive(&mut domain, &mut model, area, ctrl(KeyCode::Char('x')));
             assert!(
                 domain.get(id).expect("task").soft_deleted,
                 "{area:?}: 'x' must actually soft-delete the task through the live route"
@@ -3096,8 +3097,8 @@ mod tests {
         assert!(!recovery.is_pending());
         assert_eq!(
             model.input_mode(),
-            BoardInputMode::EditStep,
-            "successful Shift+Enter reopens add editor"
+            BoardInputMode::TaskPage,
+            "successful Shift+Enter saves the step and exits task editing"
         );
     }
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 
 use crate::cli::parser::FlagAdd;
 use crate::context::snapshot_from_env;
-use crate::domain::{normalize_thread, DomainState, ProvenanceOrigin, TaskScope};
+use crate::domain::{
+    normalize_thread, thread_refusal_message, DomainState, ProvenanceOrigin, TaskScope,
+};
 use crate::scope::{resolve_flag_scope, resolve_project_path};
 use crate::store::{default_state_dir, TaskStore};
 
@@ -67,7 +69,7 @@ struct Failed {
     i: usize,
     title: Option<String>,
     code: &'static str,
-    error: &'static str,
+    error: String,
 }
 
 struct PlanItem {
@@ -203,12 +205,12 @@ pub fn run_plan(
             for item in resolved {
                 if let TaskScope::Project { path } = &item.scope {
                     if domain.is_project_archived(path) {
-                        failed.push(Failed {
-                            i: item.i,
-                            title: Some(item.title),
-                            code: "project-archived",
-                            error: "project is archived: use --desk, -p, or tsk project unarchive",
-                        });
+                        failed.push(fail_item(
+                            item.i,
+                            Some(item.title),
+                            "project-archived",
+                            "project is archived: use --desk, -p, or tsk project unarchive",
+                        ));
                         continue;
                     }
                 }
@@ -308,16 +310,16 @@ fn existing_task<'a>(
 
 fn parse_plan_item(i: usize, value: Value) -> Result<PlanItem, Failed> {
     let Some(object) = value.as_object() else {
-        return Err(failed(i, None, "invalid-item", "item must be an object"));
+        return Err(fail_item(i, None, "invalid-item", "item must be an object"));
     };
     let title = match object.get("title") {
-        None => return Err(failed(i, None, "empty-title", "title is required")),
+        None => return Err(fail_item(i, None, "empty-title", "title is required")),
         Some(Value::String(title)) => title,
-        Some(_) => return Err(failed(i, None, "invalid-item", "title must be a string")),
+        Some(_) => return Err(fail_item(i, None, "invalid-item", "title must be a string")),
     };
     let trimmed_title = title.trim().to_string();
     if has_c0_control(title) {
-        return Err(failed(
+        return Err(fail_item(
             i,
             Some(trimmed_title),
             "invalid-title",
@@ -325,7 +327,7 @@ fn parse_plan_item(i: usize, value: Value) -> Result<PlanItem, Failed> {
         ));
     }
     if trimmed_title.is_empty() {
-        return Err(failed(
+        return Err(fail_item(
             i,
             Some(trimmed_title),
             "empty-title",
@@ -338,7 +340,7 @@ fn parse_plan_item(i: usize, value: Value) -> Result<PlanItem, Failed> {
         Some(Value::String(notes)) if notes.trim().is_empty() => None,
         Some(Value::String(notes)) => Some(notes.clone()),
         Some(_) => {
-            return Err(failed(
+            return Err(fail_item(
                 i,
                 Some(trimmed_title),
                 "invalid-item",
@@ -351,7 +353,7 @@ fn parse_plan_item(i: usize, value: Value) -> Result<PlanItem, Failed> {
         Some(Value::Null) => Some(None),
         Some(Value::String(project)) => Some(Some(project.clone())),
         Some(_) => {
-            return Err(failed(
+            return Err(fail_item(
                 i,
                 Some(trimmed_title),
                 "invalid-item",
@@ -361,16 +363,16 @@ fn parse_plan_item(i: usize, value: Value) -> Result<PlanItem, Failed> {
     };
     let thread = match object.get("thread") {
         None | Some(Value::Null) => None,
-        Some(Value::String(thread)) => normalize_thread(thread).map(Some).map_err(|_| {
-            failed(
+        Some(Value::String(thread)) => normalize_thread(thread).map(Some).map_err(|error| {
+            fail_item(
                 i,
                 Some(trimmed_title.clone()),
                 "invalid-thread",
-                "thread is invalid",
+                thread_refusal_message(error),
             )
         })?,
         Some(_) => {
-            return Err(failed(
+            return Err(fail_item(
                 i,
                 Some(trimmed_title),
                 "invalid-thread",
@@ -388,12 +390,17 @@ fn parse_plan_item(i: usize, value: Value) -> Result<PlanItem, Failed> {
     })
 }
 
-fn failed(i: usize, title: Option<String>, code: &'static str, error: &'static str) -> Failed {
+fn fail_item(
+    i: usize,
+    title: Option<String>,
+    code: &'static str,
+    error: impl Into<String>,
+) -> Failed {
     Failed {
         i,
         title,
         code,
-        error,
+        error: error.into(),
     }
 }
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::cli::parser::{parse_task_address, TaskAddress};
 use crate::context::snapshot_from_env;
-use crate::domain::{normalize_thread, HumanStatus, TaskScope};
+use crate::domain::{normalize_thread, thread_refusal_message, HumanStatus, TaskScope};
 use crate::scope::resolve_flag_scope;
 use crate::store::{default_state_dir, TaskStore};
 
@@ -101,10 +101,9 @@ pub fn parse(args: &[String]) -> Result<ListInput, String> {
                 index += 1;
             }
             flag if flag.starts_with("--thread=") => {
-                input.thread = Some(
-                    normalize_thread(&flag["--thread=".len()..])
-                        .map_err(|_| "invalid thread name".to_owned())?,
-                );
+                input.thread = Some(normalize_thread(&flag["--thread=".len()..]).map_err(
+                    |error| format!("invalid thread name · {}", thread_refusal_message(error)),
+                )?);
                 index += 1;
             }
             "--json" => {
@@ -116,10 +115,9 @@ pub fn parse(args: &[String]) -> Result<ListInput, String> {
                 index += 2;
             }
             "--thread" => {
-                input.thread = Some(
-                    normalize_thread(&value(flag)?)
-                        .map_err(|_| "invalid thread name".to_owned())?,
-                );
+                input.thread = Some(normalize_thread(&value(flag)?).map_err(|error| {
+                    format!("invalid thread name · {}", thread_refusal_message(error))
+                })?);
                 index += 2;
             }
             "--desk" => {

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use super::steps::StepsAction;
-use crate::domain::{normalize_thread, HumanStatus};
+use crate::domain::{normalize_thread, thread_refusal_message, HumanStatus};
 
 /// A direct task operand, either the internal UUID or its human task number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -647,10 +647,9 @@ pub fn parse_flag_add(args: &[String]) -> Result<FlagAdd, String> {
                 index += 1;
             }
             flag if flag.starts_with("--thread=") => {
-                parsed.thread = Some(
-                    normalize_thread(&flag["--thread=".len()..])
-                        .map_err(|_| "invalid thread name".to_owned())?,
-                );
+                parsed.thread = Some(normalize_thread(&flag["--thread=".len()..]).map_err(
+                    |error| format!("invalid thread name · {}", thread_refusal_message(error)),
+                )?);
                 parsed.has_item_flags = true;
                 index += 1;
             }
@@ -670,10 +669,9 @@ pub fn parse_flag_add(args: &[String]) -> Result<FlagAdd, String> {
                 index += 2;
             }
             "--thread" => {
-                parsed.thread = Some(
-                    normalize_thread(&value(flag)?)
-                        .map_err(|_| "invalid thread name".to_owned())?,
-                );
+                parsed.thread = Some(normalize_thread(&value(flag)?).map_err(|error| {
+                    format!("invalid thread name · {}", thread_refusal_message(error))
+                })?);
                 parsed.has_item_flags = true;
                 index += 2;
             }

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -445,12 +445,15 @@ impl DomainState {
         thread: Option<String>,
         step_renames: &[(Uuid, String)],
         step_removals: &[Uuid],
+        step_adds: &[String],
     ) -> Result<(), DomainError> {
         let title = title.as_ref().trim();
         if title.is_empty() {
             return Err(DomainError::EmptyTitle);
         }
-        if step_renames.iter().any(|(_, text)| text.trim().is_empty()) {
+        if step_renames.iter().any(|(_, text)| text.trim().is_empty())
+            || step_adds.iter().any(|text| text.trim().is_empty())
+        {
             return Err(DomainError::EmptyStepText);
         }
         let task = self.task_mut(id)?;
@@ -491,6 +494,16 @@ impl DomainState {
                 step.text.clone_from(text);
             }
         }
+        let added: Vec<Step> = step_adds
+            .iter()
+            .map(|text| Step {
+                id: Uuid::new_v4(),
+                text: text.trim().to_string(),
+                done: false,
+            })
+            .collect();
+        let added_count = added.len();
+        task.steps.extend(added);
         record_mutation(task, TaskEventKind::Edited);
         let at = task.updated_at;
         task.history
@@ -503,6 +516,10 @@ impl DomainState {
                 kind: TaskEventKind::StepRemoved,
                 at,
             }));
+        task.history.extend((0..added_count).map(|_| TaskEvent {
+            kind: TaskEventKind::StepAdded,
+            at,
+        }));
         Ok(())
     }
 
@@ -1256,6 +1273,7 @@ mod tests {
                     (second, "second revised".into()),
                 ],
                 &[],
+                &[],
             )
             .expect("atomic session edit");
 
@@ -1300,6 +1318,7 @@ mod tests {
                     (removed, "renamed but removed".into()),
                 ],
                 &[removed, removed],
+                &[],
             )
             .expect("normalize overlapping changes");
 

--- a/src/domain/thread.rs
+++ b/src/domain/thread.rs
@@ -9,6 +9,10 @@ pub enum ThreadError {
     OverLength { max: usize },
 }
 
+fn is_thread_body_char(character: char) -> bool {
+    character.is_ascii_alphanumeric() || character == '-' || character == '.'
+}
+
 /// Normalize one task thread name.
 pub fn normalize_thread(input: &str) -> Result<String, ThreadError> {
     let mut characters = input.chars();
@@ -18,15 +22,25 @@ pub fn normalize_thread(input: &str) -> Result<String, ThreadError> {
     if !first.is_ascii_alphanumeric() {
         return Err(ThreadError::BadFirstCharacter(first));
     }
-    if let Some(character) =
-        characters.find(|character| !character.is_ascii_alphanumeric() && *character != '-')
-    {
+    if let Some(character) = characters.find(|character| !is_thread_body_char(*character)) {
         return Err(ThreadError::BadCharacter(character));
     }
     if input.chars().count() > 32 {
         return Err(ThreadError::OverLength { max: 32 });
     }
     Ok(input.to_ascii_lowercase())
+}
+
+/// Why a thread name was refused, for TUI and CLI presentation.
+pub fn thread_refusal_message(error: ThreadError) -> String {
+    match error {
+        ThreadError::Empty => "thread name is empty".into(),
+        ThreadError::BadFirstCharacter(_) => "thread must start with a letter or number".into(),
+        ThreadError::BadCharacter(_) => {
+            "thread: use letters, numbers, hyphens, and dots".into()
+        }
+        ThreadError::OverLength { max } => format!("thread is at most {max} characters"),
+    }
 }
 
 #[cfg(test)]
@@ -38,6 +52,8 @@ mod tests {
         assert_eq!(normalize_thread("Release-2026"), Ok("release-2026".into()));
         assert_eq!(normalize_thread("a"), Ok("a".into()));
         assert_eq!(normalize_thread("9-start"), Ok("9-start".into()));
+        assert_eq!(normalize_thread("V0.0.6"), Ok("v0.0.6".into()));
+        assert_eq!(normalize_thread("v0.5.0"), Ok("v0.5.0".into()));
     }
 
     #[test]
@@ -56,5 +72,12 @@ mod tests {
             normalize_thread(&"a".repeat(33)),
             Err(ThreadError::OverLength { max: 32 })
         );
+    }
+
+    #[test]
+    fn refusal_message_explains_the_rule() {
+        assert!(thread_refusal_message(ThreadError::BadCharacter('_')).contains("dots"));
+        assert!(thread_refusal_message(ThreadError::BadFirstCharacter('-')).contains("start"));
+        assert!(thread_refusal_message(ThreadError::OverLength { max: 32 }).contains("32"));
     }
 }

--- a/src/domain/thread.rs
+++ b/src/domain/thread.rs
@@ -36,9 +36,7 @@ pub fn thread_refusal_message(error: ThreadError) -> String {
     match error {
         ThreadError::Empty => "thread name is empty".into(),
         ThreadError::BadFirstCharacter(_) => "thread must start with a letter or number".into(),
-        ThreadError::BadCharacter(_) => {
-            "thread: use letters, numbers, hyphens, and dots".into()
-        }
+        ThreadError::BadCharacter(_) => "thread: use letters, numbers, hyphens, and dots".into(),
         ThreadError::OverLength { max } => format!("thread is at most {max} characters"),
     }
 }

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -889,10 +889,14 @@ fn apply_board_intent(
             }
             // The inline step editor cancels to page view: draft discarded, no mutation,
             // and the page's step cursor state stays intact.
-            if model.input_mode == BoardInputMode::EditStep
-                && model.form.as_ref().is_some_and(BoardForm::is_task)
-            {
+            if model.input_mode == BoardInputMode::EditStep && model.form.is_some() {
+                let capture = model.form.as_ref().is_some_and(|form| !form.is_task());
                 close_step_editor(model);
+                if capture {
+                    if let Some(form) = model.form.as_ref() {
+                        model.input_mode = form.parent_mode();
+                    }
+                }
                 return Ok(IntentOutcome::None);
             }
             // Field edit on the task page: Esc cancels the field being edited (its draft
@@ -948,7 +952,7 @@ fn apply_board_intent(
             // task edit session. Keep the active row allocated until persistence confirms.
             if model.input_mode == BoardInputMode::EditStep {
                 if model.stage_active_rename_draft() {
-                    let outcome = confirm_edit(domain, model)?;
+                    let outcome = confirm_edit(domain, model, None)?;
                     model.sync_from_domain(domain);
                     return Ok(outcome);
                 }
@@ -1025,7 +1029,7 @@ fn apply_board_intent(
                     }
                 };
             }
-            let outcome = confirm_edit(domain, model)?;
+            let outcome = confirm_edit(domain, model, None)?;
             model.sync_from_domain(domain);
             return Ok(outcome);
         }
@@ -2175,6 +2179,7 @@ fn normalize_optional_thread(value: &str) -> Result<Option<String>, ThreadError>
 fn confirm_edit(
     domain: &mut DomainState,
     model: &mut BoardModel,
+    extra_step: Option<&str>,
 ) -> Result<IntentOutcome, DomainError> {
     // The task bound at open, not `model.selected_id()`: refresh may move the visible pin, but
     // it never changes the form's immutable id or any of its three drafts.
@@ -2225,6 +2230,9 @@ fn confirm_edit(
         .iter()
         .map(|(step_id, text)| (*step_id, text.clone()))
         .collect::<Vec<_>>();
+    let extra_steps = extra_step
+        .map(|text| vec![text.trim().to_string()])
+        .unwrap_or_default();
     domain.edit_with_step_changes(
         id,
         &title,
@@ -2233,6 +2241,7 @@ fn confirm_edit(
         thread.clone(),
         &step_rename_list,
         &step_removals.iter().copied().collect::<Vec<_>>(),
+        &extra_steps,
     )?;
 
     // Retain the complete form and mode until the persistence boundary confirms this exact
@@ -2661,7 +2670,17 @@ fn confirm_add_step(
         }
         return apply_intent(domain, model, BoardIntent::ConfirmEdit, snapshot);
     }
-    confirm_step_editor(domain, model, false, true)
+    let extra_step = model.form.as_ref().and_then(|form| {
+        form.steps
+            .editor
+            .as_ref()
+            .filter(|editor| editor.rename.is_none())
+            .map(|editor| editor.buffer.value().trim().to_string())
+    });
+    let Some(text) = extra_step.filter(|text| !text.is_empty()) else {
+        return confirm_step_editor(domain, model, false, true);
+    };
+    confirm_edit(domain, model, Some(&text))
 }
 
 fn stage_capture_step(

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -6,7 +6,10 @@ use std::time::Instant;
 use uuid::Uuid;
 
 use crate::context::InvocationSnapshot;
-use crate::domain::{normalize_thread, DomainError, DomainState, HumanStatus, TaskScope};
+use crate::domain::{
+    normalize_thread, thread_refusal_message, DomainError, DomainState, HumanStatus, TaskScope,
+    ThreadError,
+};
 use crate::ui::capture::{CaptureField, TITLE_REQUIRED_MESSAGE};
 use crate::ui::edit::{flatten_line_breaks, EditBuffer};
 use crate::ui::input::BoardIntent;
@@ -157,6 +160,35 @@ pub fn apply_intent(
     // confirmation routes clears an armed steps delete mark. Command confirmations
     // are excluded here because they recurse below as the intent they resolved to, which
     // then faces this same rule as itself.
+    if model.pending_delete.is_some()
+        && !matches!(
+            intent,
+            BoardIntent::SoftDelete | BoardIntent::ConfirmCommand | BoardIntent::SelectCommand(_)
+        )
+    {
+        model.pending_delete = None;
+    }
+    if model.empty_add_step_editor()
+        && !matches!(
+            intent,
+            BoardIntent::EditInsert(_)
+                | BoardIntent::EditInsertText(_)
+                | BoardIntent::EditBackspace
+                | BoardIntent::EditDeleteForward
+                | BoardIntent::EditMoveLeft
+                | BoardIntent::EditMoveRight
+                | BoardIntent::EditMoveLineStart
+                | BoardIntent::EditMoveLineEnd
+                | BoardIntent::EditMoveWordLeft
+                | BoardIntent::EditMoveWordRight
+                | BoardIntent::ConfirmEdit
+                | BoardIntent::ConfirmEditNext
+                | BoardIntent::CancelEdit
+                | BoardIntent::BeginAddStep
+        )
+    {
+        let _ = model.park_rename_step_draft();
+    }
     if !model.task_editing()
         && model
             .form
@@ -688,11 +720,10 @@ fn apply_board_intent(
         }
         BoardIntent::BeginAddStep => {
             model.close_popup();
-            // Ctrl+A and the trailing target both open the independent add row from task view
-            // or an active task edit. Park a rename first, so Ctrl+A never drops an existing
-            // staged rename while replacing its cursor with the add row.
-            if model.form.as_ref().is_some_and(BoardForm::is_task) && model.park_rename_step_draft()
-            {
+            // Ctrl+A and the trailing target both open the independent add row from a task
+            // page or an expanded capture. Park a rename first, so Ctrl+A never drops an
+            // existing staged rename while replacing its cursor with the add row.
+            if model.form.is_some() && model.park_rename_step_draft() {
                 open_step_editor(model, "", None);
             }
             return Ok(IntentOutcome::None);
@@ -913,28 +944,29 @@ fn apply_board_intent(
             return Ok(IntentOutcome::None);
         }
         BoardIntent::ConfirmEditNext => {
-            // Shift+Enter on an existing step commits the complete task edit session. Keep the
-            // active row allocated until persistence confirms, while an add remains its own
-            // save-and-next operation.
+            // Shift+Enter on an existing step, or on a typed new step, commits the complete
+            // task edit session. Keep the active row allocated until persistence confirms.
             if model.input_mode == BoardInputMode::EditStep {
                 if model.stage_active_rename_draft() {
                     let outcome = confirm_edit(domain, model)?;
                     model.sync_from_domain(domain);
                     return Ok(outcome);
                 }
-                return confirm_step_editor(domain, model, true);
+                return confirm_add_step(domain, model, snapshot, true);
             }
             return apply_intent(domain, model, BoardIntent::ConfirmEdit, snapshot);
         }
         BoardIntent::ConfirmEdit => {
             if model.input_mode == BoardInputMode::EditStep {
-                // Plain Enter closes an existing-step editor into the task session without
-                // crossing the persistence boundary. New-step adds still save independently.
-                if model.park_rename_step_draft() {
-                    model.input_mode = BoardInputMode::TaskPage;
+                // Plain Enter parks an existing-step rename. New-step adds save and open the
+                // next empty row, including an empty draft which stays on the line as a refusal.
+                if model.has_active_step_rename() {
+                    if model.park_rename_step_draft() {
+                        model.input_mode = BoardInputMode::TaskPage;
+                    }
                     return Ok(IntentOutcome::None);
                 }
-                return confirm_step_editor(domain, model, false);
+                return confirm_add_step(domain, model, snapshot, false);
             }
             if model.form.as_ref().is_some_and(|form| !form.is_task()) {
                 // Capture keeps its immutable invocation snapshot in the shared form. Without
@@ -950,13 +982,14 @@ fn apply_board_intent(
                 let scope_override = Some(form.scope.clone());
                 let thread = match normalize_optional_thread(form.thread.value()) {
                     Ok(thread) => thread,
-                    Err(()) => {
+                    Err(error) => {
                         if let Some(form) = model.form.as_mut() {
-                            form.thread_refusal = Some("invalid thread name".into());
+                            form.thread_refusal = Some(thread_refusal_message(error));
                         }
                         return Ok(IntentOutcome::None);
                     }
                 };
+                let pending_adds = form.steps.pending_adds.clone();
                 return match crate::capture::capture_save(
                     domain,
                     None,
@@ -967,6 +1000,9 @@ fn apply_board_intent(
                     thread,
                 ) {
                     Ok(id) => {
+                        for text in &pending_adds {
+                            domain.add_step(id, text)?;
+                        }
                         let expanded_quick_add = model.quick_add.is_some();
                         if expanded_quick_add {
                             // The app save boundary still owns this create. Retain the expanded
@@ -1653,6 +1689,12 @@ fn apply_board_intent(
                         model.set_message(NO_SELECTION);
                         return Ok(IntentOutcome::None);
                     };
+                    if model.pending_delete != Some(id) {
+                        model.pending_delete = Some(id);
+                        model.set_message("press ctrl+x again to delete");
+                        return Ok(IntentOutcome::None);
+                    }
+                    model.pending_delete = None;
                     // Read the title before the delete, and only arm the notice once the delete
                     // itself succeeded: a refused delete has nothing to recover from.
                     let title = domain.get(id).map(|task| task.title.clone());
@@ -2093,9 +2135,7 @@ fn lift_quick_add_tokens(
             "!t" => {
                 let argument = quick_add_token_argument(&words, index);
                 thread = match argument {
-                    Some(name) => Some(
-                        normalize_thread(name).map_err(|_| "invalid thread name".to_string())?,
-                    ),
+                    Some(name) => Some(normalize_thread(name).map_err(thread_refusal_message)?),
                     None => None,
                 };
                 index += usize::from(argument.is_some()) + 1;
@@ -2123,12 +2163,12 @@ fn quick_add_token_argument<'a>(words: &'a [&str], index: usize) -> Option<&'a s
         .filter(|word| *word != "!p" && *word != "!t" && !word.starts_with('#'))
 }
 
-fn normalize_optional_thread(value: &str) -> Result<Option<String>, ()> {
+fn normalize_optional_thread(value: &str) -> Result<Option<String>, ThreadError> {
     let value = value.trim();
     if value.is_empty() {
         Ok(None)
     } else {
-        normalize_thread(value).map(Some).map_err(|_| ())
+        normalize_thread(value).map(Some)
     }
 }
 
@@ -2147,9 +2187,9 @@ fn confirm_edit(
     let scope = form.scope.clone();
     let thread = match normalize_optional_thread(form.thread.value()) {
         Ok(thread) => thread,
-        Err(()) => {
+        Err(error) => {
             if let Some(form) = model.form.as_mut() {
-                form.thread_refusal = Some("invalid thread name".into());
+                form.thread_refusal = Some(thread_refusal_message(error));
             }
             return Ok(IntentOutcome::None);
         }
@@ -2557,7 +2597,7 @@ fn page_step_delete(
 /// Open an in-place step row seeded with `text`, renaming `step` when given and adding
 /// a transient row when `None`.
 fn open_step_editor(model: &mut BoardModel, text: &str, rename: Option<Uuid>) {
-    if let Some(form) = model.form.as_mut().filter(|form| form.is_task()) {
+    if let Some(form) = model.form.as_mut() {
         form.steps.add_selected = false;
         if form
             .steps
@@ -2599,6 +2639,63 @@ fn close_step_editor(model: &mut BoardModel) {
 /// on the row itself, never the board status row.
 const STEP_TEXT_REQUIRED: &str = "text required";
 
+/// Enter saves a new step and opens the next empty row. Shift+Enter saves it and
+/// then the enclosing form (task session or expanded capture).
+fn confirm_add_step(
+    domain: &mut DomainState,
+    model: &mut BoardModel,
+    snapshot: Option<&InvocationSnapshot>,
+    save_session: bool,
+) -> Result<IntentOutcome, DomainError> {
+    if !save_session {
+        return confirm_step_editor(domain, model, true, false);
+    }
+    if model.form.as_ref().is_some_and(|form| !form.is_task()) {
+        let outcome = confirm_step_editor(domain, model, false, false)?;
+        if model
+            .form
+            .as_ref()
+            .is_some_and(|form| form.steps.editor.is_some())
+        {
+            return Ok(outcome);
+        }
+        return apply_intent(domain, model, BoardIntent::ConfirmEdit, snapshot);
+    }
+    confirm_step_editor(domain, model, false, true)
+}
+
+fn stage_capture_step(
+    model: &mut BoardModel,
+    keep_open: bool,
+) -> Result<IntentOutcome, DomainError> {
+    let Some(form) = model.form.as_mut().filter(|form| !form.is_task()) else {
+        return Ok(IntentOutcome::None);
+    };
+    let Some(editor) = form.steps.editor.as_ref() else {
+        return Ok(IntentOutcome::None);
+    };
+    let text = editor.buffer.value().trim().to_string();
+    if text.is_empty() {
+        if let Some(editor) = form.steps.editor.as_mut() {
+            editor.refusal = Some(STEP_TEXT_REQUIRED.to_string());
+        }
+        return Ok(IntentOutcome::None);
+    }
+    form.steps.pending_adds.push(text);
+    if keep_open {
+        form.steps.editor = Some(StepEditor {
+            buffer: crate::ui::edit::seeded_draft(""),
+            rename: None,
+            refusal: None,
+        });
+        model.input_mode = BoardInputMode::EditStep;
+    } else {
+        form.steps.editor = None;
+        model.input_mode = form.parent_mode();
+    }
+    Ok(IntentOutcome::None)
+}
+
 /// Persist a new-step editor draft through the domain command.
 ///
 /// Existing-step editors are parked into the enclosing task session before this function is
@@ -2615,7 +2712,11 @@ fn confirm_step_editor(
     domain: &mut DomainState,
     model: &mut BoardModel,
     keep_open: bool,
+    exit_editing: bool,
 ) -> Result<IntentOutcome, DomainError> {
+    if model.form.as_ref().is_some_and(|form| !form.is_task()) {
+        return stage_capture_step(model, keep_open);
+    }
     let Some(form) = model.form.as_ref().filter(|form| form.is_task()) else {
         return Ok(IntentOutcome::None);
     };
@@ -2649,6 +2750,7 @@ fn confirm_step_editor(
         step: touched,
         text: text.trim().to_string(),
         reopen: keep_open,
+        exit_editing,
     });
     Ok(IntentOutcome::Persist)
 }

--- a/src/ui/board/chrome.rs
+++ b/src/ui/board/chrome.rs
@@ -63,8 +63,12 @@ fn edit_chrome_legends(mode: BoardInputMode) -> [&'static str; 3] {
             "Enter close · Shift+Enter save · Esc",
             "Enter close · Esc",
         ],
-        BoardInputMode::EditStep
-        | BoardInputMode::QuickAdd
+        BoardInputMode::EditStep => [
+            "Enter next · Shift+Enter save · Esc cancel",
+            "Enter next · Shift+Enter save · Esc",
+            "Enter · Shift+Enter · Esc",
+        ],
+        BoardInputMode::QuickAdd
         | BoardInputMode::FormScopeDropdown
         | BoardInputMode::Normal
         | BoardInputMode::ProjectPicker

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -296,6 +296,15 @@ fn build_task_page_overlay<'a>(
                 .collect()
         })
         .unwrap_or_default();
+    for text in &form.steps.pending_adds {
+        step_views.push(render::StepView {
+            done: false,
+            rows: crate::ui::edit::wrap_text(text, step_text_width)
+                .into_iter()
+                .map(|row| row.text)
+                .collect(),
+        });
+    }
     let stored_step_count = step_views.len();
     // Existing-step edits are task-session drafts. Paint every parked draft first, then the
     // active row over it. Only the active EditStep mode receives cursor metadata, so moving to
@@ -555,7 +564,7 @@ fn build_task_page_overlay<'a>(
     // present). The identifier belongs in the header, so it never competes with scope hits.
     // A wide column moves the project up into its header slot: the scope footer paints only
     // while the edit session can change it, so its control stays reachable by mouse.
-    let editing_session = form.is_task() && form.editing || model.open_field_edit().is_some();
+    let editing_session = !form.is_task() || form.editing || model.open_field_edit().is_some();
     let show_scope = !column || editing_session;
     let meta_scope = if show_scope {
         match &form.scope {
@@ -570,18 +579,21 @@ fn build_task_page_overlay<'a>(
     let meta_scope_x = 0;
     meta.push_str(&meta_scope);
     let mut thread_slot = None;
-    if let Some(task) = bound_task {
-        let shown_thread = if form.is_task() && form.editing {
-            Some(form.thread.value())
-        } else {
-            task.thread.as_deref()
-        };
+    let capture_form = !form.is_task();
+    let shown_thread = if capture_form || (form.is_task() && form.editing) {
+        Some(form.thread.value())
+    } else {
+        bound_task.and_then(|task| task.thread.as_deref())
+    };
+    if bound_task.is_some() || capture_form {
+        let task = bound_task;
         // Without a scope ahead of it (a wide column outside an edit session) the thread
         // leads the footer and drops its separator.
         let separator = if meta.is_empty() { "" } else { " · " };
         thread_slot = if let Some(thread) = shown_thread.filter(|thread| !thread.is_empty()) {
             Some(format!("{separator}#{}", terminal_text(thread)))
-        } else if (form.is_task() && form.editing)
+        } else if capture_form
+            || (form.is_task() && form.editing)
             || matches!(
                 model.input_mode(),
                 BoardInputMode::EditTitle
@@ -601,17 +613,19 @@ fn build_task_page_overlay<'a>(
         if let Some(slot) = &thread_slot {
             meta.push_str(slot);
         }
-        let now = SystemTime::now();
-        let ages = format!(
-            "created {} ago · updated {} ago",
-            render::format_age(now, task.created_at),
-            render::format_age(now, task.updated_at)
-        );
-        if meta.is_empty() {
-            meta.push_str(&ages);
-        } else {
-            meta.push_str(" · ");
-            meta.push_str(&ages);
+        if let Some(task) = task {
+            let now = SystemTime::now();
+            let ages = format!(
+                "created {} ago · updated {} ago",
+                render::format_age(now, task.created_at),
+                render::format_age(now, task.updated_at),
+            );
+            if meta.is_empty() {
+                meta.push_str(&ages);
+            } else {
+                meta.push_str(" · ");
+                meta.push_str(&ages);
+            }
         }
     }
     let thread_slot_width = thread_slot

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -486,6 +486,8 @@ pub(super) struct StepEditorSave {
     pub(super) step: Uuid,
     pub(super) text: String,
     pub(super) reopen: bool,
+    /// Leave the task-edit session after this add lands (Shift+Enter on a new step).
+    pub(super) exit_editing: bool,
 }
 
 /// Page-session steps state for the task page, never persisted.
@@ -516,6 +518,8 @@ pub(super) struct StepsPageState {
     pub(super) drafts: BTreeMap<Uuid, EditBuffer>,
     /// Existing steps removed only when the enclosing task form saves. Esc drops this set.
     pub(super) removals: BTreeSet<Uuid>,
+    /// Capture-form steps staged until the create saves. Task pages persist adds immediately.
+    pub(super) pending_adds: Vec<String>,
     /// An editor apply the save boundary has not confirmed yet (AC-14). While it is
     /// set, the editor and its input mode are held exactly as the user left them.
     pub(super) pending_save: Option<StepEditorSave>,
@@ -648,6 +652,8 @@ pub struct BoardModel {
     /// it; but Retry can still make it durable, and then the way back has to come with it.
     /// See [`BoardModel::begin_save_recovery`] and [`BoardModel::end_save_recovery`].
     pub(super) suspended_delete_notice: Option<String>,
+    /// First ctrl+x on a task arms this id; a second press on the same task deletes it.
+    pub(super) pending_delete: Option<Uuid>,
     /// Open project-picker or save-recovery presentation.
     pub(super) popup: BoardPopup,
     /// Open session project selector; never persisted.
@@ -727,6 +733,7 @@ impl BoardModel {
             message: None,
             delete_notice: None,
             suspended_delete_notice: None,
+            pending_delete: None,
             popup: BoardPopup::None,
             project_picker: None,
             surface: CommandSurface::None,
@@ -1825,7 +1832,12 @@ impl BoardModel {
         let form = self.form.as_mut().expect("task form checked above");
         form.steps.pending_save = None;
         form.task_snapshot = saved_snapshot.map(Box::new);
-        if pending.reopen {
+        if pending.exit_editing {
+            form.editing = false;
+            form.steps.editor = None;
+            form.steps.add_selected = false;
+            self.input_mode = BoardInputMode::TaskPage;
+        } else if pending.reopen {
             // The rapid-capture loop: the in-place row reopens empty for the next step, its
             // mode never having left it.
             form.steps.add_selected = false;
@@ -1909,13 +1921,24 @@ impl BoardModel {
         self.input_mode = form.parent_mode();
     }
 
-    /// Park an existing-step draft before another task field becomes active. New-step add keeps
-    /// its focused save-and-next workflow, so it deliberately cannot leave its inline row.
+    /// Park an existing-step draft before another task field becomes active. An empty new-step
+    /// add is discarded so a click or Tab can leave it. A typed add stays on its row.
     pub(super) fn park_rename_step_draft(&mut self) -> bool {
         if self.input_mode != BoardInputMode::EditStep {
             return true;
         }
-        let Some(form) = self.form.as_mut().filter(|form| form.is_task()) else {
+        if self.empty_add_step_editor() {
+            if let Some(form) = self.form.as_mut() {
+                form.steps.editor = None;
+            }
+            self.input_mode = match self.form.as_ref() {
+                Some(form) if form.is_task() => BoardInputMode::TaskPage,
+                Some(form) => form.parent_mode(),
+                None => BoardInputMode::TaskPage,
+            };
+            return true;
+        }
+        let Some(form) = self.form.as_mut() else {
             return false;
         };
         let Some(editor) = form.steps.editor.take() else {
@@ -1925,8 +1948,22 @@ impl BoardModel {
             form.steps.editor = Some(editor);
             return false;
         };
+        if !form.is_task() {
+            form.steps.editor = Some(editor);
+            return false;
+        }
         form.steps.drafts.insert(step_id, editor.buffer);
         true
+    }
+
+    /// True when the inline add row is open and still empty after trim.
+    pub fn empty_add_step_editor(&self) -> bool {
+        self.input_mode == BoardInputMode::EditStep
+            && self.form.as_ref().is_some_and(|form| {
+                form.steps.editor.as_ref().is_some_and(|editor| {
+                    editor.rename.is_none() && editor.buffer.value().trim().is_empty()
+                })
+            })
     }
 
     /// Copy the active existing-step buffer into the task session without releasing its row.

--- a/src/ui/capture.rs
+++ b/src/ui/capture.rs
@@ -598,8 +598,8 @@ pub fn apply_capture_intent(
             } else {
                 match crate::domain::normalize_thread(thread_value) {
                     Ok(thread) => Some(thread),
-                    Err(_) => {
-                        model.thread_refusal = Some("invalid thread name".into());
+                    Err(error) => {
+                        model.thread_refusal = Some(crate::domain::thread_refusal_message(error));
                         model.message = None;
                         return Ok(CaptureOutcome::None);
                     }
@@ -2541,8 +2541,9 @@ mod tests {
             CaptureOutcome::None
         );
         assert!(domain.tasks().is_empty());
-        assert_eq!(model.thread_refusal.as_deref(), Some("invalid thread name"));
-        assert!(render_plain(&model, 80, 16).contains("invalid thread name"));
+        let refusal = model.thread_refusal.as_deref().expect("thread refusal");
+        assert!(refusal.contains("hyphens"), "{refusal}");
+        assert!(render_plain(&model, 80, 16).contains("hyphens"));
     }
 
     #[test]

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -781,6 +781,17 @@ pub fn map_board_mouse(
             Some(QueueHitTarget::Step(index)) => Some(BoardIntent::SelectStep(index)),
             Some(QueueHitTarget::StepAdd) => Some(BoardIntent::BeginAddStep),
             Some(QueueHitTarget::Verb(index)) => verb_intent(model, index),
+            Some(QueueHitTarget::TaskNumber(id)) if model.empty_add_step_editor() => {
+                Some(BoardIntent::CopyTaskNumber(id))
+            }
+            Some(QueueHitTarget::Task(id)) if model.empty_add_step_editor() => model
+                .visible_ids()
+                .iter()
+                .position(|&visible| visible == id)
+                .map(BoardIntent::SelectIndex),
+            Some(QueueHitTarget::PageScroll(offset)) if model.empty_add_step_editor() => {
+                Some(BoardIntent::PageScrollTo(offset))
+            }
             _ => None,
         },
         BoardInputMode::SaveRecovery => None,

--- a/tests/f6_save_recovery.rs
+++ b/tests/f6_save_recovery.rs
@@ -999,6 +999,7 @@ fn a_failed_delete_save_reports_exactly_what_a_failed_complete_save_reports() {
         let (mut domain, mut model, doomed) = board_with_two_tasks();
         let baseline = snapshot_of(&domain);
         assert_eq!(model.selected_id(), Some(doomed));
+        apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("arm delete");
         let mut recovery = SaveRecovery::new();
         let mut saves = 0;
 
@@ -1385,7 +1386,7 @@ fn cancelled_failed_step_editor_save_leaves_no_orphan_edit_mode() {
     )
     .expect("fresh editor save");
     assert_eq!(saved, IntentOutcome::Persisted);
-    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+    assert_eq!(model.input_mode(), BoardInputMode::EditStep);
     let texts: Vec<&str> = domain
         .get(id)
         .expect("task")
@@ -1448,14 +1449,10 @@ fn retried_step_editor_save_applies_and_closes() {
     assert_eq!(texts, vec!["alpha step", "zed step"], "the step lands");
     assert_eq!(
         model.input_mode(),
-        BoardInputMode::TaskPage,
-        "the editor closes cleanly once the boundary confirms"
+        BoardInputMode::EditStep,
+        "Enter reopens the empty next row once the boundary confirms"
     );
     let page = board_painted(&model);
-    assert!(
-        !page.lines().any(|row| row.contains("▎")),
-        "the editor line is gone after the retried save:\n{page}"
-    );
     assert!(
         page.contains("zed step"),
         "the retried step paints on the page:\n{page}"

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -911,6 +911,50 @@ fn page_thread_field_refuses_invalid_name_without_persisting() {
 }
 
 #[test]
+fn page_thread_field_accepts_version_dots() {
+    let mut domain = DomainState::new();
+    let id = domain
+        .create(
+            "Task",
+            None,
+            project(THIS_REPO),
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("create");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(&mut domain, &mut model, BoardIntent::BeginEditTitle, None).expect("open");
+    for _ in 0..4 {
+        apply_intent(&mut domain, &mut model, BoardIntent::FormFocusNext, None).expect("focus");
+    }
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ToggleThreadEditing,
+        None,
+    )
+    .expect("activate thread editor");
+    for character in "V0.0.6".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+        )
+        .expect("type");
+    }
+    assert_eq!(
+        apply_intent(&mut domain, &mut model, BoardIntent::ConfirmEdit, None).expect("save"),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+    assert_eq!(
+        domain.get(id).expect("task").thread.as_deref(),
+        Some("v0.0.6")
+    );
+}
+
+#[test]
 fn canceling_thread_edit_keeps_the_task_page_and_resets_the_thread_draft() {
     let mut domain = DomainState::new();
     domain
@@ -1117,7 +1161,7 @@ fn thread_refusal_paints_inline_and_clears_without_status_leak() {
         .map(|cell| cell.symbol())
         .collect();
     assert!(
-        painted.contains("invalid thread name"),
+        painted.contains("start with a letter"),
         "missing inline refusal: {painted}"
     );
     assert_eq!(
@@ -1277,7 +1321,7 @@ fn long_invalid_thread_refusal_remains_visible_at_40x10() {
         .map(|cell| cell.symbol())
         .collect();
     assert!(
-        painted.contains("invalid thread name"),
+        painted.contains("hyphens") || painted.contains("dots"),
         "thread refusal vanished at 40x10: {painted}"
     );
 }

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -1289,6 +1289,7 @@ fn wheel_scrolls_the_open_command_surface_so_every_command_becomes_reachable() {
 #[test]
 fn delete_notice_undo_control_is_clickable_and_matches_the_keyboard() {
     let (mut domain, mut model, id) = board_with_task("doomed", HumanStatus::Ready);
+    apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("arm delete");
     apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("soft delete");
     assert!(
         model.delete_notice().is_some(),
@@ -1323,6 +1324,7 @@ fn delete_notice_undo_control_is_clickable_and_matches_the_keyboard() {
 #[test]
 fn delete_notice_undo_region_survives_a_title_containing_the_literal_u_undo() {
     let (mut domain, mut model, id) = board_with_task("u Undo now", HumanStatus::Ready);
+    apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("arm delete");
     apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("soft delete");
     assert!(
         model.delete_notice().is_some(),

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -4268,3 +4268,36 @@ fn shift_enter_on_a_typed_add_saves_and_exits_task_editing() {
         .collect();
     assert_eq!(texts, vec!["alpha", "bravo"]);
 }
+
+#[test]
+fn shift_enter_on_add_keeps_a_dirty_title() {
+    let (mut domain, mut model, id) = board_with_steps("Dirty title", None, &["alpha"]);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Title),
+        None,
+    )
+    .expect("title");
+    apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('!'), None).expect("type");
+    apply_intent(&mut domain, &mut model, BoardIntent::BeginAddStep, None).expect("add");
+    for character in "bravo".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+        )
+        .expect("type step");
+    }
+    assert_eq!(
+        apply_intent(&mut domain, &mut model, BoardIntent::ConfirmEditNext, None).expect("save"),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+    let task = domain.get(id).expect("task");
+    assert_eq!(task.title, "Dirty title!");
+    let texts: Vec<&str> = task.steps.iter().map(|step| step.text.as_str()).collect();
+    assert_eq!(texts, vec!["alpha", "bravo"]);
+    assert!(!model.task_editing());
+}

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -1036,6 +1036,7 @@ fn x_soft_deletes_and_status_line_names_task_with_undo_hint() {
     }
     assert_eq!(model.selected_id(), Some(id));
 
+    apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("arm delete");
     let outcome =
         apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("soft delete");
     assert_eq!(outcome, IntentOutcome::Persist);
@@ -1070,6 +1071,7 @@ fn u_undoes_with_domain_coverage_and_stale_undo_refused_visibly() {
         )
         .expect("create");
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("arm delete");
     apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("delete");
     assert!(domain.get(id).expect("task").soft_deleted);
     assert!(!model.visible_ids().contains(&id));
@@ -1084,6 +1086,7 @@ fn u_undoes_with_domain_coverage_and_stale_undo_refused_visibly() {
 
     // stale undo: delete again (records entry with current rev), then direct-restore (advances rev
     // without popping the entry). Next undo must refuse visibly.
+    apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("arm delete2");
     apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("delete2");
     assert!(domain.get(id).expect("task").soft_deleted);
     let _ = domain.restore(id);
@@ -1208,6 +1211,7 @@ fn deleting_from_the_page_closes_it_and_undo_restores() {
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
     let delete = map_key(BoardInputMode::TaskPage, ctrl(KeyCode::Char('x'))).expect("x");
     assert_eq!(delete, BoardIntent::SoftDelete);
+    apply_intent(&mut domain, &mut model, delete.clone(), None).expect("arm delete");
     apply_intent(&mut domain, &mut model, delete, None).expect("delete");
     assert!(domain.get(id).expect("task").soft_deleted);
     assert_eq!(
@@ -1422,12 +1426,12 @@ fn task_edit_save_uses_shift_enter_with_alt_enter_as_the_legacy_fallback() {
     assert_eq!(
         map_key(BoardInputMode::EditStep, press(KeyCode::Enter)),
         Some(BoardIntent::ConfirmEdit),
-        "plain Enter saves one inline step and returns to the target"
+        "plain Enter saves a new step and opens the next empty row"
     );
     assert_eq!(
         map_key(BoardInputMode::EditStep, alt(KeyCode::Enter)),
         Some(BoardIntent::ConfirmEditNext),
-        "Alt+Enter must exactly match the inline editor's Shift+Enter save-next route"
+        "Alt+Enter must exactly match the inline editor's Shift+Enter save-and-exit route"
     );
     assert_eq!(
         map_key(BoardInputMode::EditNotes, shift(KeyCode::Enter)),
@@ -1994,7 +1998,7 @@ fn view_step_target_tabs_to_an_independent_plain_enter_editor() {
         IntentOutcome::Persist
     );
     model.sync_from_domain(&domain);
-    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+    assert_eq!(model.input_mode(), BoardInputMode::EditStep);
     assert!(
         !model.task_editing(),
         "saving an add must not save a task session"
@@ -2084,8 +2088,8 @@ fn ctrl_a_opens_step_add_from_task_view_and_every_task_edit_state() {
     apply_intent(&mut domain, &mut model, BoardIntent::ConfirmEdit, None).expect("save view add");
     model.sync_from_domain(&domain);
     assert!(
-        rendered_board(&model, 80, 24).contains("▸ ▪ view add"),
-        "plain Enter selects the independently saved stored step"
+        rendered_board(&model, 80, 24).contains("▪ view add"),
+        "plain Enter saves the step and opens the next empty row"
     );
 
     apply_intent(&mut domain, &mut model, BoardIntent::BeginEditTitle, None).expect("title");
@@ -2563,8 +2567,8 @@ fn add_verb_opens_editor_shift_enter_applies_esc_cancels() {
     for ch in "zed step".chars() {
         apply_intent(&mut domain, &mut model, BoardIntent::EditInsert(ch), None).expect("type");
     }
-    let save = map_key(model.input_mode(), shift(KeyCode::Enter)).expect("shift+enter");
-    assert_eq!(save, BoardIntent::ConfirmEditNext);
+    let save = map_key(model.input_mode(), press(KeyCode::Enter)).expect("enter");
+    assert_eq!(save, BoardIntent::ConfirmEdit);
     let outcome = apply_intent(&mut domain, &mut model, save, None).expect("add step");
     assert_eq!(outcome, IntentOutcome::Persist);
     // The app boundary persisted; add mode keeps an empty next inline row open (T-4).
@@ -2574,7 +2578,7 @@ fn add_verb_opens_editor_shift_enter_applies_esc_cancels() {
     assert_eq!(
         texts,
         vec!["alpha step", "zed step"],
-        "Shift+Enter must append the typed step"
+        "Enter must append the typed step"
     );
     assert_eq!(
         task.history.last().expect("event").kind,
@@ -2619,16 +2623,16 @@ fn step_editor_shift_enter_reopens_and_retains_task_editing() {
         apply_intent(&mut domain, &mut model, BoardIntent::EditInsert(ch), None)
             .expect("type first step");
     }
-    let shift_enter = map_key(model.input_mode(), shift(KeyCode::Enter))
-        .expect("shift+enter maps in the step editor");
-    let outcome = apply_intent(&mut domain, &mut model, shift_enter, None)
-        .expect("save and reopen the inline row");
+    let enter =
+        map_key(model.input_mode(), press(KeyCode::Enter)).expect("enter maps in the step editor");
+    let outcome =
+        apply_intent(&mut domain, &mut model, enter, None).expect("save and reopen the inline row");
     assert_eq!(outcome, IntentOutcome::Persist);
     model.sync_from_domain(&domain);
     assert_eq!(
         model.input_mode(),
         BoardInputMode::EditStep,
-        "Shift+Enter in add mode reopens the inline row for the next step"
+        "Enter in add mode reopens the inline row for the next step"
     );
     let reopened = rendered_board(&model, 80, 24);
     assert!(
@@ -2641,16 +2645,15 @@ fn step_editor_shift_enter_reopens_and_retains_task_editing() {
         apply_intent(&mut domain, &mut model, BoardIntent::EditInsert(ch), None)
             .expect("type second step");
     }
-    let shift_enter = map_key(model.input_mode(), shift(KeyCode::Enter))
-        .expect("shift+enter saves the second step");
-    let outcome =
-        apply_intent(&mut domain, &mut model, shift_enter, None).expect("save and reopen");
+    let enter =
+        map_key(model.input_mode(), press(KeyCode::Enter)).expect("enter saves the second step");
+    let outcome = apply_intent(&mut domain, &mut model, enter, None).expect("save and reopen");
     assert_eq!(outcome, IntentOutcome::Persist);
     model.sync_from_domain(&domain);
     assert_eq!(
         model.input_mode(),
         BoardInputMode::EditStep,
-        "Shift+Enter keeps the next inline add row open"
+        "Enter keeps the next inline add row open"
     );
     apply_intent(&mut domain, &mut model, BoardIntent::CancelEdit, None)
         .expect("close the empty next row");
@@ -2835,7 +2838,7 @@ fn empty_step_text_refusal_paints_on_line_and_clears_on_close() {
         "the refusal clears when the line closes:\n{closed}"
     );
 
-    // A successful save clears it too: refuse once, type valid text, Shift+Enter saves.
+    // A successful save clears it too: refuse once, type valid text, Enter saves.
     apply_intent(&mut domain, &mut model, BoardIntent::BeginAddStep, None)
         .expect("reopen add editor");
     apply_intent(&mut domain, &mut model, shift_enter.clone(), None)
@@ -2844,8 +2847,8 @@ fn empty_step_text_refusal_paints_on_line_and_clears_on_close() {
         apply_intent(&mut domain, &mut model, BoardIntent::EditInsert(ch), None)
             .expect("type valid text");
     }
-    let outcome =
-        apply_intent(&mut domain, &mut model, shift_enter, None).expect("save the valid text");
+    let enter = map_key(model.input_mode(), press(KeyCode::Enter)).expect("enter");
+    let outcome = apply_intent(&mut domain, &mut model, enter, None).expect("save the valid text");
     assert_eq!(outcome, IntentOutcome::Persist);
     model.sync_from_domain(&domain);
     assert_eq!(model.input_mode(), BoardInputMode::EditStep);
@@ -2881,9 +2884,9 @@ fn step_input_is_inline_and_shift_enter_reopens_an_empty_next_row() {
         "the editor must not occupy the footer:\n{open}"
     );
 
-    let save_next = map_key(model.input_mode(), shift(KeyCode::Enter))
-        .expect("Shift+Enter saves the current step and starts the next");
-    assert_eq!(save_next, BoardIntent::ConfirmEditNext);
+    let save_next = map_key(model.input_mode(), press(KeyCode::Enter))
+        .expect("Enter saves the current step and starts the next");
+    assert_eq!(save_next, BoardIntent::ConfirmEdit);
     assert_eq!(
         apply_intent(&mut domain, &mut model, save_next, None).expect("save and continue"),
         IntentOutcome::Persist
@@ -4208,4 +4211,60 @@ fn toggle_all_groups_folds_and_unfolds_the_archived_group_with_the_others_when_t
         model.visible_ids().contains(&filed),
         "the archived group is still expanded, untouched while the drawer was shut"
     );
+}
+
+#[test]
+fn first_delete_asks_and_second_deletes() {
+    let (mut domain, mut model, id) = board_with_noted_task();
+    apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("arm");
+    assert!(!domain.get(id).expect("task").soft_deleted);
+    assert_eq!(model.message(), Some("press ctrl+x again to delete"));
+    apply_intent(&mut domain, &mut model, BoardIntent::SoftDelete, None).expect("confirm");
+    assert!(domain.get(id).expect("task").soft_deleted);
+}
+
+#[test]
+fn empty_add_click_on_title_discards_the_row() {
+    let (mut domain, mut model, _) = board_with_steps("Click away", None, &["alpha"]);
+    apply_intent(&mut domain, &mut model, BoardIntent::BeginAddStep, None).expect("open add");
+    assert_eq!(model.input_mode(), BoardInputMode::EditStep);
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusFormField(CaptureField::Title),
+        None,
+    )
+    .expect("click title");
+    assert_ne!(model.input_mode(), BoardInputMode::EditStep);
+    assert!(!rendered_board(&model, 80, 24).contains("step…"));
+}
+
+#[test]
+fn shift_enter_on_a_typed_add_saves_and_exits_task_editing() {
+    let (mut domain, mut model, id) = board_with_steps("Save exit", None, &["alpha"]);
+    apply_intent(&mut domain, &mut model, BoardIntent::BeginAddStep, None).expect("open add");
+    for character in "bravo".chars() {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+        )
+        .expect("type");
+    }
+    assert_eq!(
+        apply_intent(&mut domain, &mut model, BoardIntent::ConfirmEditNext, None).expect("save"),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+    assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+    assert!(!model.task_editing());
+    let texts: Vec<&str> = domain
+        .get(id)
+        .expect("task")
+        .steps
+        .iter()
+        .map(|step| step.text.as_str())
+        .collect();
+    assert_eq!(texts, vec!["alpha", "bravo"]);
 }

--- a/tests/quick_add_capture.rs
+++ b/tests/quick_add_capture.rs
@@ -99,15 +99,25 @@ fn plus_opens_focused_bar_regardless_of_shift_and_legacy_chord_is_unbound() {
 }
 
 #[test]
-fn expanded_capture_keeps_ctrl_a_as_line_start() {
+fn expanded_capture_ctrl_a_opens_step_add() {
     assert_eq!(
-        tsk_tui::ui::input::map_board_form_key(
+        tsk_tui::ui::input::map_task_form_key(
             tsk_tui::ui::capture::CaptureField::Title,
             false,
             KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL),
         ),
-        Some(BoardIntent::EditMoveLineStart)
+        Some(BoardIntent::BeginAddStep)
     );
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let snap = snapshot();
+    open(&mut domain, &mut model, &snap);
+    type_title(&mut domain, &mut model, "ctrl a step");
+    apply(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None);
+    apply(&mut domain, &mut model, BoardIntent::BeginAddStep, None);
+    assert_eq!(model.input_mode(), BoardInputMode::EditStep);
+    apply(&mut domain, &mut model, BoardIntent::CancelEdit, None);
+    assert_ne!(model.input_mode(), BoardInputMode::EditStep);
 }
 
 #[test]

--- a/tests/quick_add_capture.rs
+++ b/tests/quick_add_capture.rs
@@ -1200,3 +1200,52 @@ fn expanded_quick_add_scope_omits_archived_projects() {
         "desk stays on offer: {options:?}"
     );
 }
+
+#[test]
+fn expanded_quick_add_sets_thread_and_steps() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, None);
+    let snap = snapshot();
+    open(&mut domain, &mut model, &snap);
+    type_title(&mut domain, &mut model, "capture with extras");
+    apply(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None);
+    let page = render_text(&model, 80, 24);
+    assert!(
+        page.contains("thread"),
+        "expanded capture paints a thread slot:\n{page}"
+    );
+    assert!(
+        page.contains("+ step"),
+        "expanded capture paints + step:\n{page}"
+    );
+    apply(&mut domain, &mut model, BoardIntent::FormFocusNext, None);
+    assert_eq!(model.input_mode(), BoardInputMode::EditThread);
+    for character in "V0.0.6".chars() {
+        apply(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+        );
+    }
+    apply(&mut domain, &mut model, BoardIntent::BeginAddStep, None);
+    assert_eq!(model.input_mode(), BoardInputMode::EditStep);
+    for character in "first step".chars() {
+        apply(
+            &mut domain,
+            &mut model,
+            BoardIntent::EditInsert(character),
+            None,
+        );
+    }
+    assert_eq!(
+        apply(&mut domain, &mut model, BoardIntent::ConfirmEditNext, None),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
+    let task = domain.tasks().last().expect("created");
+    assert_eq!(task.title, "capture with extras");
+    assert_eq!(task.thread.as_deref(), Some("v0.0.6"));
+    assert_eq!(task.steps.len(), 1);
+    assert_eq!(task.steps[0].text, "first step");
+}

--- a/tests/wide_task_split.rs
+++ b/tests/wide_task_split.rs
@@ -2260,6 +2260,7 @@ fn soft_delete_from_a_task_stage_returns_the_board_to_a_board_stage() {
         to_stage(&mut domain, &mut model, stage);
         let deleted = model.selected_id().unwrap();
         go(&mut domain, &mut model, BoardIntent::SoftDelete);
+        go(&mut domain, &mut model, BoardIntent::SoftDelete);
         assert!(!model.visible_ids().contains(&deleted));
         assert_eq!(
             model.wide_stage(),
@@ -2282,6 +2283,7 @@ fn soft_delete_from_a_task_stage_returns_the_board_to_a_board_stage() {
     let (mut domain, mut model) = fixture();
     go(&mut domain, &mut model, BoardIntent::OpenTaskPage);
     assert_eq!(model.wide_stage(), WideStage::FullTask);
+    go(&mut domain, &mut model, BoardIntent::SoftDelete);
     go(&mut domain, &mut model, BoardIntent::SoftDelete);
     assert_eq!(model.wide_stage(), WideStage::FullBoard);
 }


### PR DESCRIPTION
## Summary

Board task T16 (bugs/improvements):

- Thread names accept dots (`V0.0.6` → `v0.0.6`). Refusals name the rule instead of `invalid thread name`.
- Expanded quick-add (`Tab` from `+`) can set thread and add steps.
- Enter on a new step saves it and opens the next empty row. Shift+Enter saves that step and leaves task editing.
- An empty new-step row discards if you click elsewhere.
- `ctrl+x` asks once (`press ctrl+x again to delete`) before deleting a task.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Live herdr smoke with isolated store: `#v0.0.6` painted, delete prompt on first `ctrl+x`
- [x] `cd site && npm test && npm run build`