### PR TITLE
Project-context navigation and cleaner board controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ For scriptable board work, use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, 
   The done drawer ends with a collapsible `▾ archived · n` group (closed by default,
   session-only): its header is the one selectable header (`Enter`/click toggles it, the word
   paints bold when selected, never reverse), its rows paint dim, and it folds with `ctrl+g`
-  toggle-all like any other group while the drawer is open. Visible tab labels are `desk` ·
+  while the drawer is open; other board surfaces have no collapsible groups. Visible tab labels are `desk` ·
   selected project · `projects`; shortcuts `1`/`2`/`3` remain keyboard-only. Projects Overview
   search opens in the shared footer slot with `/`, keeps the table visible, filters live, opens
   the selected project on Enter, and clears/closes on Esc; the closed footer advertises `/ search`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,20 +28,25 @@ For scriptable board work, use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, 
 
 ### Board
 
-- Home is a tabbed board: **desk** · **projects** · **threads** (`1`/`2`/`3`). Tabs
-  show only at home; project focus (`P` → project) hides them and paints the project
-  name chip (`P ▾` on the right). At home the chip is hidden — tabs already say where
-  you are; `P` still opens the scope picker from the keyboard. **desk**: NEEDS YOU (desk
-  blocked and review), global IN MOTION, then desk/global ON DECK (ready). **projects**: one collapsible group per project (single-click
-  collapse, double-click → project focus); in motion under each project, then review,
-  blocked, open. **threads**: cross-project thread names with collapsible project
-  sub-groups; same status order. Collapse state is session-only. NEEDS YOU · IN MOTION · ON DECK when
-  project-scoped · done drawer (`z`). Scoped ON DECK thread blocks paint dim `#name`
-  headers with open counts; headers consume row budget but are not selectable or
-  hit-testable. The done drawer ends with a collapsible `▾ archived · n` group (closed by
-  default, session-only): its header is the one selectable header (`Enter`/click toggles it, the
-  word paints bold when selected, never reverse), its rows paint dim, and it folds with `ctrl+g`
-  toggle-all like any other group while the drawer is open.
+- The board keeps persistent destinations **desk** · **selected project** · **projects**
+  (`1`/`2`/`3`) in every normal board surface. `P` opens the project picker; selecting a
+  project fills slot 2 and opens its board. **desk**: NEEDS YOU across live scopes, global
+  IN MOTION, then desk-only ON DECK. **projects**: one selectable overview row per project,
+  with needs-you, in-motion, and ready counts. Its View can show a flat cross-project thread
+  board. Project focus remains available through `P` and the index. NEEDS YOU · IN MOTION ·
+  ON DECK when project-scoped · done drawer (`z`). Project rows are navigation, never task
+  rows. Scoped project boards show thread labels beside tasks and a local thread filter,
+  without a separate filtered-task count. Cross-project thread views also omit the task/project
+  summary. A selector wrapped below the tabs has one blank row above it.
+  The done drawer ends with a collapsible `▾ archived · n` group (closed by default,
+  session-only): its header is the one selectable header (`Enter`/click toggles it, the word
+  paints bold when selected, never reverse), its rows paint dim, and it folds with `ctrl+g`
+  toggle-all like any other group while the drawer is open. Visible tab labels are `desk` ·
+  selected project · `projects`; shortcuts `1`/`2`/`3` remain keyboard-only. Projects Overview
+  search opens in the shared footer slot with `/`, keeps the table visible, filters live, opens
+  the selected project on Enter, and clears/closes on Esc; the closed footer advertises `/ search`.
+  Task rows show project attribution on global rows or `#thread` on project rows, never relative
+  ages; task-page informational dates remain intact.
 - Archive is a flag, not a place. `archived` on a task, and a lazy project record
   (`projects` map keyed by scope path, present only while archived) for projects. Neither leaves
   `tsk.json`. A *hidden* task (archived, or in an archived project) paints in no working lens;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ refused rather than chmodding their targets. Other platforms claim no mode.
 
 Archive for tasks and projects: `ctrl+f` on a board row toggles a task's
 archived flag (no undo entry), and archived tasks keep their human status while
-leaving every working lens — desk, projects, threads, project focus, and the
+leaving every working lens — desk, selected project, projects, and project focus,
 default `tsk list` views. The done drawer gains a collapsible `archived · n`
 group (closed on launch, dim rows) that a click or `Enter` on its header toggles
 and that `ctrl+g` folds with every other group while the drawer is open, the project picker gains main/archived tabs with in-place archive and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,20 +27,19 @@ Canonical terms for this repo. No implementation detail.
 - **step short id**: an unambiguous prefix of a step's stable identity, used to address a step within one task from the CLI.
 - **thread**: an optional single name a task carries, grouping it with same-named tasks in the same scope. Not an entity: no identity beyond the name, no status, no lifecycle. It presents on the board exactly while at least one open task in its scope carries it; the field itself persists on the task regardless of status.
 - **thread token**: the `!t name` capture directive, sibling of `!p`; bare `!t` means unthreaded. Stripped from the saved title.
-- **thread header**: a derived, non-selectable board row above a thread's open tasks in a scoped deck group, showing the thread name and open count. Chrome, not a task.
-- **unthreaded**: carrying no thread. Unthreaded tasks list after thread groups within their deck group.
+- **thread label**: the thread name painted beside a project-board task row. It is chrome, not a task; selecting a local thread filter hides redundant labels.
+- **unthreaded**: carrying no thread. Unthreaded tasks remain in the project's flat task board.
 - **wide stage**: the session-only slider position of a wide (≥110 column) board: 0 `FullBoard`, A `Split`, G `Rail`, F `FullTask` (`ui::tier::WideStage`). Focus and geometry derive from the stage; it is never persisted and survives resizes.
 - **rail**: the 32-column dim board column of stage G: tabs, section rules, and wrapped task rows, without the meta column or the done drawer.
 - **single-pane view**: a presentation that shows only the focused board or task surface.
 - **focused surface**: the board or task view that currently owns interaction; at wide widths it derives from the wide stage (0/A board-owned, G/F task-owned), below 110 from the single-pane presentation.
-- **open task**: human status ready, blocked, or review, not soft-deleted, and not archived. The tasks a thread header groups and counts.
+- **open task**: human status ready, blocked, or review, not soft-deleted, and not archived.
 - **archived**: a flag on a task meaning "kept, off the radar". The task keeps its human status and leaves every working lens; it is visible only in the archived group of the done drawer. Not a status, not a place, nothing expires.
-- **archived project**: a project whose project record carries the archived flag. It leaves the projects tab, the threads tab, desk IN MOTION and the picker's main list; it is visible only on the picker's archived tab. Its tasks' own archived flags are independent of it.
+- **archived project**: a project whose project record carries the archived flag. It leaves the projects index, desk IN MOTION and the picker's main list; it is visible only on the picker's archived tab. Its tasks' own archived flags are independent of it.
 - **project record**: the per-project entry in the store, keyed by the project's scope path. Lazy: exists only while the project is archived. The set of projects the board shows is still derived from tasks.
 - **archived group**: the collapsible `archived · n` header and its rows inside the done drawer, closed by default, session-only collapse state. Chrome plus dimmed task rows.
 - **file**: the `ctrl+f` verb. On a task row it toggles the task's archived flag; in the picker it archives the project, on the picker's archived tab it unarchives it. Has no undo entry. `ctrl+u` on an archived selection also unarchives; on anything else it stays undo.
-- **thread block**: the derived unit of one thread's header plus its ordered open tasks inside a deck section. Exists only in query output, never in the store.
-- **working lens**: any board or CLI view meant for current work: desk tab, projects tab, threads tab, project focus, NEEDS YOU, IN MOTION, ON DECK, thread headers and counts, the rail, and default `tsk list` views. Archived tasks and archived projects never paint in one.
+- **working lens**: any board or CLI view meant for current work: desk, selected project, projects index, cross-project thread View, project focus, NEEDS YOU, IN MOTION, ON DECK, the rail, and default `tsk list` views. Archived tasks and archived projects never paint in one.
 - **NEEDS YOU**: queue section for non-deleted, non-archived blocked and review tasks. Desk shows desk/global ones; project focus shows that project's. Omitted when empty. Sits above IN MOTION.
 - **session**: one board process from launch to quit. Session-only state (collapse, wide stage, the launch card having been shown) resets on relaunch.
 - **hidden**: a task that is archived, or whose project is archived. The single predicate every working lens filters on; distinct from soft-deleted.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ready, started, blocked, review, done. Agents reach the board through the CLI.
 It ships as a [herdr](https://herdr.dev) plugin, and the `tsk` binary also runs
 standalone against `~/.tsk`.
 
-- Queue board with desk · projects · threads
+- Queue board with desk, a selected project, a projects index, and cross-project thread views
 - Quick-add on the board, plus a herdr capture overlay
 - Task page for notes, thread, scope, and steps
 - Headless `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`

--- a/scripts/open-board.sh
+++ b/scripts/open-board.sh
@@ -23,16 +23,6 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Same relative layout as other herdr plugins: scripts/ next to target/release/.
 plugin_bin="${TSK_BIN:-$script_dir/../target/release/tsk}"
 
-# A focused existing pane keeps its process environment, so hand the fresh host
-# context to the board through the private one-shot request file before focusing it.
-# A new pane still receives HERDR_PLUGIN_CONTEXT_JSON directly from herdr.
-if [ -x "$plugin_bin" ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
-  if ! printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | "$plugin_bin" --resolve-context; then
-    printf 'tsk: could not hand off the board context, existing pane was not focused\n' >&2
-    exit 1
-  fi
-fi
-
 open_board() {
   exec "$herdr_bin" plugin pane open \
     --plugin "$plugin_id" \
@@ -57,6 +47,14 @@ find_board_pane_id() {
 
 pane_id="$(find_board_pane_id || true)"
 if [ -n "${pane_id:-}" ]; then
+  # A focused existing pane keeps its process environment, so hand the fresh host
+  # context to the board through the private one-shot request file before focusing it.
+  if [ -x "$plugin_bin" ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
+    if ! printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | "$plugin_bin" --resolve-context; then
+      printf 'tsk: could not hand off the board context, existing pane was not focused\n' >&2
+      exit 1
+    fi
+  fi
   # Prefer the plugin-pane focus API (herdr >= 0.7). Fall back to open if focus fails
   # (stale list race) so the keypress is never a silent no-op.
   if "$herdr_bin" plugin pane focus "$pane_id"; then
@@ -64,4 +62,5 @@ if [ -n "${pane_id:-}" ]; then
   fi
 fi
 
+# A new pane receives HERDR_PLUGIN_CONTEXT_JSON directly from herdr.
 open_board

--- a/scripts/open-board.sh
+++ b/scripts/open-board.sh
@@ -23,6 +23,16 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Same relative layout as other herdr plugins: scripts/ next to target/release/.
 plugin_bin="${TSK_BIN:-$script_dir/../target/release/tsk}"
 
+# A focused existing pane keeps its process environment, so hand the fresh host
+# context to the board through the private one-shot request file before focusing it.
+# A new pane still receives HERDR_PLUGIN_CONTEXT_JSON directly from herdr.
+if [ -x "$plugin_bin" ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
+  if ! printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | "$plugin_bin" --resolve-context; then
+    printf 'tsk: could not hand off the board context, existing pane was not focused\n' >&2
+    exit 1
+  fi
+fi
+
 open_board() {
   exec "$herdr_bin" plugin pane open \
     --plugin "$plugin_id" \

--- a/site/public/board-demo.js
+++ b/site/public/board-demo.js
@@ -15,7 +15,11 @@ import { parseCapture } from "./capture.js";
     done: "✓",
   };
 
-  const TABS = ["desk", "projects", "threads"];
+  const TABS = [
+    ["desk", "desk"],
+    ["project", "selected project"],
+    ["projects", "projects"],
+  ];
   const NOW = Date.now();
   const MIN = 60 * 1000;
   const HOUR = 60 * MIN;
@@ -127,7 +131,10 @@ import { parseCapture } from "./capture.js";
   const state = {
     tasks: seed(),
     tab: "desk",
+    // The focused scope is transient, while this is the project selected by tab 2.
+    selectedProject: "tsk",
     focusProject: null,
+    projectQuery: "",
     collapsed: new Set(),
     selectedId: "t1",
     peekId: null,
@@ -213,6 +220,22 @@ import { parseCapture } from "./capture.js";
     return ["desk", ...[...set].sort()];
   }
 
+  function projectNames() {
+    const names = new Set(
+      state.tasks.filter((t) => t.project && !t.archived).map((t) => t.project),
+    );
+    return [...names].sort((a, b) => {
+      if (a === "tsk") return -1;
+      if (b === "tsk") return 1;
+      return a.localeCompare(b);
+    });
+  }
+
+  function matchingProjectNames() {
+    const query = state.projectQuery.trim().toLowerCase();
+    return projectNames().filter((name) => !query || name.toLowerCase().includes(query));
+  }
+
   function selectedTask() {
     return taskById(state.selectedId) || null;
   }
@@ -260,10 +283,7 @@ import { parseCapture } from "./capture.js";
       return {
         started: open.filter((t) => t.status === "started").sort(byUpdated),
         need: open
-          .filter(
-            (t) =>
-              !t.project && (t.status === "blocked" || t.status === "review"),
-          )
+          .filter((t) => t.status === "blocked" || t.status === "review")
           .sort(byUpdated),
         desk: open
           .filter((t) => !t.project && t.status === "ready")
@@ -298,7 +318,7 @@ import { parseCapture } from "./capture.js";
         v.done.forEach((t) => pushTask(t));
         const archived = archivedInScope();
         if (archived.length) {
-          rows.push({ kind: "archived", label: "archived", count: archived.length, selectable: true });
+          rows.push({ kind: "archived", label: "archived", count: archived.length, selectable: true, id: "nav:archived" });
           if (state.archivedOpen) archived.forEach((t) => rows.push({ kind: "task", task: t, indent: 0, selectable: true, id: t.id, dim: true }));
         }
       }
@@ -321,7 +341,7 @@ import { parseCapture } from "./capture.js";
         v.done.forEach((t) => pushTask(t));
         const archived = archivedInScope();
         if (archived.length) {
-          rows.push({ kind: "archived", label: "archived", count: archived.length, selectable: true });
+          rows.push({ kind: "archived", label: "archived", count: archived.length, selectable: true, id: "nav:archived" });
           if (state.archivedOpen) archived.forEach((t) => rows.push({ kind: "task", task: t, indent: 0, selectable: true, id: t.id, dim: true }));
         }
       }
@@ -329,37 +349,23 @@ import { parseCapture } from "./capture.js";
     }
 
     if (state.tab === "projects") {
-      const names = [...new Set(state.tasks.map((t) => t.project || "desk"))].sort((a, b) => {
-        if (a === "desk") return 1;
-        if (b === "desk") return -1;
-        return a.localeCompare(b);
-      });
-      for (const name of names) {
-        const key = `p:${name}`;
-        const collapsed = state.collapsed.has(key);
+      for (const name of matchingProjectNames()) {
         const group = state.tasks.filter((t) => (t.project || "desk") === name && t.status !== "done" && !t.archived);
         const started = group.filter((t) => t.status === "started").sort(byUpdated);
         const review = group.filter((t) => t.status === "review").sort(byUpdated);
         const blocked = group.filter((t) => t.status === "blocked").sort(byUpdated);
         const ready = group.filter((t) => t.status === "ready").sort(byUpdated);
-        pushHeader("group", name, group.length, { collapseKey: key, collapsed, project: name });
-        if (collapsed) continue;
-        if (started.length) {
-          pushHeader("sub", "in motion", started.length);
-          started.forEach((t) => pushTask(t, 1));
-        }
-        if (review.length) {
-          pushHeader("sub", "review", review.length);
-          review.forEach((t) => pushTask(t, 1));
-        }
-        if (blocked.length) {
-          pushHeader("sub", "blocked", blocked.length);
-          blocked.forEach((t) => pushTask(t, 1));
-        }
-        if (ready.length) {
-          pushHeader("sub", "open", ready.length);
-          ready.forEach((t) => pushTask(t, 1));
-        }
+        rows.push({
+          kind: "project",
+          label: name,
+          project: name,
+          needs: review.length + blocked.length,
+          motion: started.length,
+          ready: ready.length,
+          selectable: true,
+          id: `project:${name}`,
+        });
+        // Project index rows are navigation, not collapsible task groups.
       }
       if (state.drawer) {
         const done = state.tasks.filter((t) => t.status === "done" && !t.archived).sort(byUpdated);
@@ -367,57 +373,20 @@ import { parseCapture } from "./capture.js";
         done.forEach((t) => pushTask(t));
         const archived = archivedInScope();
         if (archived.length) {
-          rows.push({ kind: "archived", label: "archived", count: archived.length, selectable: true });
+          rows.push({ kind: "archived", label: "archived", count: archived.length, selectable: true, id: "nav:archived" });
           if (state.archivedOpen) archived.forEach((t) => rows.push({ kind: "task", task: t, indent: 0, selectable: true, id: t.id, dim: true }));
         }
       }
       return rows;
     }
 
-    const threads = new Map();
-    for (const t of state.tasks.filter((x) => x.status !== "done" && !x.archived && x.thread)) {
-      if (!threads.has(t.thread)) threads.set(t.thread, []);
-      threads.get(t.thread).push(t);
-    }
-    const names = [...threads.keys()].sort();
-    for (const thread of names) {
-      const tKey = `t:${thread}`;
-      const tCollapsed = state.collapsed.has(tKey);
-      const members = threads.get(thread);
-      pushHeader("group", `#${thread}`, members.length, { collapseKey: tKey, collapsed: tCollapsed, thread });
-      if (tCollapsed) continue;
-      const byProj = new Map();
-      for (const t of members) {
-        const p = t.project || "desk";
-        if (!byProj.has(p)) byProj.set(p, []);
-        byProj.get(p).push(t);
-      }
-      for (const [proj, list] of [...byProj.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-        const pKey = `t:${thread}:${proj}`;
-        const pCollapsed = state.collapsed.has(pKey);
-        pushHeader("group", proj, list.length, { collapseKey: pKey, collapsed: pCollapsed, indent: 1 });
-        if (pCollapsed) continue;
-        const order = ["started", "review", "blocked", "ready"];
-        for (const st of order) {
-          const slice = list.filter((t) => t.status === st).sort(byUpdated);
-          slice.forEach((t) => pushTask(t, 2));
-        }
-      }
-    }
-    const unthreaded = state.tasks.filter((t) => t.status !== "done" && !t.archived && !t.thread);
-    if (unthreaded.length) {
-      const key = "t:unthreaded";
-      const collapsed = state.collapsed.has(key);
-      pushHeader("group", "unthreaded", unthreaded.length, { collapseKey: key, collapsed });
-      if (!collapsed) unthreaded.sort(byUpdated).forEach((t) => pushTask(t, 1));
-    }
     if (state.drawer) {
       const done = state.tasks.filter((t) => t.status === "done" && !t.archived).sort(byUpdated);
       pushHeader("section", "DONE", done.length);
       done.forEach((t) => pushTask(t));
       const archived = archivedInScope();
       if (archived.length) {
-        rows.push({ kind: "archived", label: "archived", count: archived.length, selectable: true });
+        rows.push({ kind: "archived", label: "archived", count: archived.length, selectable: true, id: "nav:archived" });
         if (state.archivedOpen) archived.forEach((t) => rows.push({ kind: "task", task: t, indent: 0, selectable: true, id: t.id, dim: true }));
       }
     }
@@ -439,8 +408,8 @@ import { parseCapture } from "./capture.js";
 
   function metaFor(task) {
     const bits = [];
-    if (state.tab === "desk" && task.project) bits.push(task.project);
-    bits.push(age(task.updatedAt));
+    if (state.tab === "desk") bits.push(projectName(task));
+    if (state.focusProject && task.thread) bits.push(`#${task.thread}`);
     return bits.join(" · ");
   }
 
@@ -469,6 +438,15 @@ import { parseCapture } from "./capture.js";
 
   function verbItems(task) {
     if (!task) {
+      if (state.tab === "projects" && !state.focusProject) {
+        return [
+          { id: "search", label: "/ search projects" },
+          { id: "open", label: "enter open" },
+          { id: "view", label: "v view" },
+          { id: "help", label: "? help" },
+          { id: "palette", label: ": palette" },
+        ];
+      }
       return [
         { id: "open", label: "enter open" },
         { id: "capture", label: "+ capture" },
@@ -491,6 +469,7 @@ import { parseCapture } from "./capture.js";
   }
 
   function runVerb(id) {
+    if (id === "search") state.overlay = "search";
     if (id === "open" && state.selectedId) openFullPage();
     if (id === "capture") openQuickAdd();
     if (id === "help") state.overlay = "help";
@@ -543,12 +522,12 @@ import { parseCapture } from "./capture.js";
       { id: "done", label: "set status: done", run: () => setStatus("done") },
       { id: "desk", label: "go desk", run: () => goTab("desk") },
       { id: "projects", label: "go projects", run: () => goTab("projects") },
-      { id: "threads", label: "go threads", run: () => goTab("threads") },
+      { id: "project", label: "go selected project", run: () => goTab("project") },
       { id: "capture", label: "capture", run: () => openQuickAdd() },
       { id: "help", label: "help", run: () => (state.overlay = "help") },
       { id: "reset", label: "reset demo", run: resetDemo },
     ];
-    if (!state.focusProject && ["projects", "threads"].includes(state.tab)) {
+    if (!state.focusProject && state.tab === "projects") {
       all.push({ id: "groups", label: "toggle groups", run: toggleAllGroups });
     }
     return all.filter((c) => !q || c.label.includes(q) || c.id.includes(q));
@@ -571,15 +550,35 @@ import { parseCapture } from "./capture.js";
 
   function goTab(tab) {
     state.tab = tab;
-    state.focusProject = null;
+    state.focusProject = tab === "project" ? state.selectedProject : null;
+    state.projectQuery = "";
     state.peekId = null;
     state.overlay = null;
     state.stage = "board";
     state.stageOrigin = null;
   }
 
+  function openProject(name) {
+    if (!name || name === "desk") {
+      goTab("desk");
+      return;
+    }
+    state.selectedProject = name;
+    state.focusProject = name;
+    state.tab = "project";
+    state.projectQuery = "";
+    state.peekId = null;
+    state.overlay = null;
+    state.stage = "board";
+    state.stageOrigin = null;
+  }
+
+  function selectedRow() {
+    return buildRows().find((row) => row.selectable && row.id === state.selectedId) || null;
+  }
+
   function toggleAllGroups() {
-    if (state.focusProject || !["projects", "threads"].includes(state.tab)) return;
+    if (state.focusProject || state.tab !== "projects") return;
     const groups = buildRows().filter((row) => row.kind === "group" && !row.indent);
     const collapse = groups.some((row) => !state.collapsed.has(row.collapseKey));
     for (const row of groups) {
@@ -591,7 +590,9 @@ import { parseCapture } from "./capture.js";
   function resetDemo() {
     state.tasks = seed();
     state.tab = "desk";
+    state.selectedProject = "tsk";
     state.focusProject = null;
+    state.projectQuery = "";
     state.collapsed = new Set();
     state.selectedId = "t1";
     state.peekId = null;
@@ -662,7 +663,7 @@ import { parseCapture } from "./capture.js";
   }
 
   function undoDelete() {
-    if (!state.undo) return;
+    if (selectedRow()?.kind !== "task" || !state.undo) return;
     const { task, index } = state.undo;
     state.tasks.splice(Math.min(index, state.tasks.length), 0, task);
     state.selectedId = task.id;
@@ -693,7 +694,7 @@ import { parseCapture } from "./capture.js";
           <div>enter open | →/← peek or slide | + capture</div>
           <div>e title | n notes | x delete | u undo</div>
           <div>z drawer | : palette | ? help</div>
-          <div>P project | 1 2 3 tabs | g groups (projects/threads)</div>
+          <div>P project | 1 2 3 navigation | / search projects | g groups</div>
           <div class="dim">app needs ctrl on verbs · demo also accepts bare keys</div>
         </div>
         <div class="tsk-box-foot">any key close</div>
@@ -726,7 +727,9 @@ import { parseCapture } from "./capture.js";
       .map((name, i) => {
         const mark = i === state.pickerI ? "▸" : " ";
         const cls = i === state.pickerI ? "sel-text" : "";
-        const current = state.focusProject === name || (!state.focusProject && name === "desk" && state.tab === "desk");
+        const current = name === "desk"
+          ? !state.focusProject && state.tab === "desk"
+          : state.selectedProject === name;
         return `<div class="tsk-pal-row ${cls}" data-pick="${esc(name)}">${mark} ${esc(name)}${current ? "  ·" : ""}</div>`;
       })
       .join("");
@@ -801,9 +804,10 @@ import { parseCapture } from "./capture.js";
   }
 
   function renderBoard(rows, rail = false, bare = false) {
-    const tabs = TABS.map((tab) => {
-      const on = !state.focusProject && state.tab === tab;
-      return `<button type="button" class="tsk-tab ${on ? "is-on" : ""}" data-tab="${tab}">${tab}</button>`;
+    const tabs = TABS.map(([tab, label]) => {
+      const on = state.tab === tab;
+      const text = tab === "project" ? state.selectedProject : label;
+      return `<button type="button" class="tsk-tab ${on ? "is-on" : ""}" data-tab="${tab}">${esc(text)}</button>`;
     }).join(`<span class="dim">  ·  </span>`);
 
     const chip = state.focusProject
@@ -816,6 +820,10 @@ import { parseCapture } from "./capture.js";
           const cls = row.kind === "sub" ? "tsk-sub" : "tsk-sec";
           return `<div class="${cls}"><span class="sec">${esc(row.label)}</span><span class="rule" aria-hidden="true"></span><span class="count">${row.count}</span></div>`;
         }
+        if (row.kind === "project") {
+          const selected = row.id === state.selectedId;
+          return `<button type="button" class="tsk-group ${selected ? "sel-text" : ""}" data-project-row="${esc(row.project)}" data-nav-id="${esc(row.id)}"><span class="sec">${selected ? "▸" : " "} ${esc(row.label)}</span><span class="count">${row.needs} needs · ${row.motion} motion · ${row.ready} ready</span></button>`;
+        }
         if (row.kind === "group") {
           const mark = row.collapsed ? "▸" : "▾";
           const pad = row.indent ? "  " : "";
@@ -823,7 +831,8 @@ import { parseCapture } from "./capture.js";
         }
         if (row.kind === "archived") {
           const mark = state.archivedOpen ? "▾" : "▸";
-          return `<button type="button" class="tsk-group" data-archived-header="1"><span class="dim">${mark}</span> <span class="sec">archived</span><span class="rule" aria-hidden="true"></span><span class="count dim">${row.count}</span></button>`;
+          const selected = row.id === state.selectedId;
+          return `<button type="button" class="tsk-group" data-archived-header="1"><span class="dim">${mark}</span> <span class="sec">${selected ? "<strong>archived</strong>" : "archived"}</span><span class="rule" aria-hidden="true"></span><span class="count dim">${row.count}</span></button>`;
         }
         const task = row.task;
         if (rail && task.status === "done") return "";
@@ -889,7 +898,10 @@ import { parseCapture } from "./capture.js";
       state.overlay === "quick"
         ? `<div class="tsk-input-row"><span class="tsk-prompt">+</span><input class="tsk-field" id="tsk-add" value="${esc(state.draft)}" placeholder="title  ·  !p project  ·  !t thread" autocomplete="off" /><span class="cursor">█</span></div>
            <div class="foot dim">${state.refuse ? esc(state.refuse) : "enter save · shift+enter stay · tab page · esc close"}</div>`
-        : `<div class="tsk-status-row"><button type="button" class="tsk-done-count foot" data-drawer="1">${doneN} done</button><span class="foot dim tsk-stage-hint">${esc(stageHint())}</span></div>
+        : state.overlay === "search"
+          ? `<div class="tsk-input-row"><span class="tsk-prompt">/</span><input class="tsk-field" id="tsk-project-search" value="${esc(state.projectQuery)}" placeholder="search projects" autocomplete="off" /><span class="cursor">█</span></div>
+             <div class="foot dim">enter open · esc close</div>`
+          : `<div class="tsk-status-row"><button type="button" class="tsk-done-count foot" data-drawer="1">${doneN} done</button><span class="foot dim tsk-stage-hint">${esc(stageHint())}</span></div>
            <div class="foot dim tsk-verbs">${verbs}</div>
            ${state.copyNotice ? `<div class="foot dim">${esc(state.copyNotice)}</div>` : ""}`;
     return `
@@ -925,11 +937,19 @@ import { parseCapture } from "./capture.js";
     if (state.overlay === "help") html += renderHelp();
     if (state.overlay === "palette") html += renderPalette();
     if (state.overlay === "picker") html += renderPicker();
+    const activeSearch = document.activeElement?.id === "tsk-project-search";
     const keepKeys =
       document.activeElement === frame || frame.contains(document.activeElement);
     root.innerHTML = html;
     const add = document.getElementById("tsk-add");
     const edit = document.getElementById("tsk-edit");
+    const search = document.getElementById("tsk-project-search");
+    if (search) {
+      search.addEventListener("input", () => {
+        state.projectQuery = search.value;
+        render();
+      });
+    }
     if (add) {
       add.focus();
       add.selectionStart = add.value.length;
@@ -942,6 +962,10 @@ import { parseCapture } from "./capture.js";
       edit.addEventListener("input", () => {
         state.editDraft = edit.value;
       });
+    } else if (search && activeSearch) {
+      search.focus();
+      search.selectionStart = search.value.length;
+      search.selectionEnd = search.value.length;
     } else if (keepKeys) {
       frame.focus({ preventScroll: true });
     }
@@ -959,6 +983,12 @@ import { parseCapture } from "./capture.js";
     i = (i + delta + ids.length) % ids.length;
     state.selectedId = ids[i];
     state.peekId = state.peekId && state.peekId === state.selectedId ? state.peekId : null;
+  }
+
+  function openProjectSearchMatch() {
+    const row = selectedRow();
+    const match = row?.kind === "project" ? row.project : matchingProjectNames()[0];
+    if (match) openProject(match);
   }
 
   function commitEdit() {
@@ -985,6 +1015,22 @@ import { parseCapture } from "./capture.js";
     if (el !== frame) {
       if (el.closest(".pane-bar, .layout-toggle, [data-divider]")) return;
       if (state.overlay !== "quick" && el.closest("button")) return;
+    }
+    if (el.id === "tsk-project-search") {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        state.projectQuery = "";
+        render();
+        frame.focus({ preventScroll: true });
+        return;
+      }
+      if (e.key === "Enter" && !e.ctrlKey && !e.altKey && !e.metaKey) {
+        e.preventDefault();
+        openProjectSearchMatch();
+        render();
+        return;
+      }
+      return;
     }
     const wide = isWideSplit();
     const taskPageActive = taskFocus();
@@ -1088,6 +1134,35 @@ import { parseCapture } from "./capture.js";
       return;
     }
 
+    if (state.overlay === "search") {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        state.projectQuery = "";
+        state.overlay = null;
+        render();
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        openProjectSearchMatch();
+        state.overlay = null;
+        render();
+        return;
+      }
+      if (e.key === "Backspace") {
+        e.preventDefault();
+        state.projectQuery = state.projectQuery.slice(0, -1);
+        render();
+        return;
+      }
+      if (e.key.length === 1 && !e.altKey && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        state.projectQuery += e.key;
+        render();
+      }
+      return;
+    }
+
     if (state.overlay === "picker") {
       const opts = knownProjects();
       if (e.key === "Escape") {
@@ -1099,8 +1174,8 @@ import { parseCapture } from "./capture.js";
       if (e.key === "Enter") {
         e.preventDefault();
         const name = opts[state.pickerI];
-        state.focusProject = name === "desk" ? null : name;
-        if (name === "desk") state.tab = "desk";
+        if (name === "desk") goTab("desk");
+        else openProject(name);
         state.overlay = null;
         render();
         return;
@@ -1130,8 +1205,14 @@ import { parseCapture } from "./capture.js";
         state.overlay = null;
         leaveTaskPage();
       } else if (state.peekId) state.peekId = null;
-      else if (state.focusProject) state.focusProject = null;
+      else if (state.focusProject) goTab("desk");
       else frame.blur();
+      render();
+      return;
+    }
+    if (e.key === "/" && state.tab === "projects" && !state.focusProject) {
+      e.preventDefault();
+      state.overlay = "search";
       render();
       return;
     }
@@ -1157,7 +1238,7 @@ import { parseCapture } from "./capture.js";
     }
     if (e.key === "1" || e.key === "2" || e.key === "3") {
       e.preventDefault();
-      goTab(TABS[Number(e.key) - 1]);
+      goTab(TABS[Number(e.key) - 1][0]);
       render();
       return;
     }
@@ -1213,7 +1294,12 @@ import { parseCapture } from "./capture.js";
     if (e.key === "Enter") {
       e.preventDefault();
       if (taskPageActive && state.stage === "page") leaveTaskPage();
-      else openFullPage();
+      else {
+        const row = selectedRow();
+        if (row?.kind === "project") openProject(row.project);
+        else if (row?.kind === "archived") state.archivedOpen = !state.archivedOpen;
+        else openFullPage();
+      }
       render();
       return;
     }
@@ -1329,14 +1415,20 @@ import { parseCapture } from "./capture.js";
       render();
       return;
     }
+    const projectRow = e.target.closest("[data-project-row]");
+    if (projectRow) {
+      openProject(projectRow.getAttribute("data-project"));
+      render();
+      return;
+    }
     const group = e.target.closest("[data-collapse]");
     if (group) {
       const now = Date.now();
       const key = group.getAttribute("data-collapse");
       const project = group.getAttribute("data-project");
       if (lastClick.id === key && now - lastClick.at < 350 && project) {
-        state.focusProject = project === "desk" ? null : project;
-        if (project === "desk") state.tab = "desk";
+        if (project === "desk") goTab("desk");
+        else openProject(project);
       } else if (state.collapsed.has(key)) state.collapsed.delete(key);
       else state.collapsed.add(key);
       lastClick = { id: key, at: now };
@@ -1393,8 +1485,8 @@ import { parseCapture } from "./capture.js";
     const pick = e.target.closest("[data-pick]");
     if (pick) {
       const name = pick.getAttribute("data-pick");
-      state.focusProject = name === "desk" ? null : name;
-      if (name === "desk") state.tab = "desk";
+      if (name === "desk") goTab("desk");
+      else openProject(name);
       state.overlay = null;
       render();
     }

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,6 +2,10 @@
 
 > A task board for you and your agents, in your terminal. Both put work on one board and move it through ready, started, blocked, review, done. Agents reach it through the CLI.
 
+Open or reopen from a repository to view that project. Persistent navigation is Desk, selected project, Projects. Desk shows global attention and active work plus its own backlog. Projects offers a searchable index and an Overview selector for threads across projects; project boards have their own thread filter.
+
+On Projects, `/` opens the live project search in the shared footer slot, Enter opens the selected match, and Esc clears and closes it. Task rows show project or thread attribution without relative ages; task-page dates remain informational. Thread selectors accept typing and paste, including j/k as query text; unmatched queries stay visible. Wrapped selectors have one blank line below the tabs before the selected value. Project and cross-project thread views omit a separate task-count summary.
+
 User guide: https://gettsk.sh/docs/
 
 - [Overview](https://gettsk.sh/docs/)

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -69,10 +69,9 @@ projects, project focus, and default `tsk list` views). The done
 drawer lists archived tasks in its scope under an `▾ archived · n` group below
 DONE: closed on every launch, one click or `Enter` on the header toggles it on its
 own, and expanded rows paint dim with their status glyph and `T<n>`. The header
-paints the word bold when it holds the selection, never a reverse block. It is one
-of the board's groups: while the drawer is open, `ctrl+g` (toggle all groups) folds
-and unfolds it along with the project and thread groups; with the drawer closed
-`ctrl+g` leaves it alone. `ctrl+f` on a row
+paints the word bold when it holds the selection, never a reverse block. It is the
+done drawer's only collapsible group: while the drawer is open, `ctrl+g` folds and
+unfolds it; with the drawer closed `ctrl+g` leaves it alone. `ctrl+f` on a row
 files it, and `ctrl+f` or `ctrl+u` on an archived
 selection brings it back; neither writes an undo entry.
 
@@ -215,7 +214,6 @@ letters appear in order anywhere in a label, so `ssr` finds `set status: review`
 | `delete` | a task is selected |
 | `reopen` | the selected task is done |
 | `undo` · `done drawer` | always |
-| `toggle groups` | on the projects index |
 | `help` · `quit` | always |
 | `Retry save` · `Cancel save` | a save is waiting on you (the only two entries then) |
 

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -3,46 +3,69 @@ title: Board
 description: Tabs, sections, status, peek, and the done drawer.
 ---
 
-Home is a tabbed board: **desk** · **projects** · **threads**. Tabs show only at
-home (`1` / `2` / `3`). `P` opens the project picker from the keyboard.
+The board keeps three navigation destinations visible: **desk** · **selected project** ·
+**projects**. Use `1` / `2` / `3` from normal board mode. `P` opens the project picker
+from the keyboard.
 
 ## Tabs
 
-- **desk**: your own planning space. NEEDS YOU is desk work that is blocked or
-  review. IN MOTION is every started task, from any project. ON DECK is desk work
+- **desk**: your overview. NEEDS YOU is blocked or review work across all live
+  projects and your desk. IN MOTION is every started task, from any project. ON DECK is desk work
   that is ready: general to-dos, future projects, anything that belongs to no
-  repository. Thread headers sit above those open ready desk tasks.
-- **projects**: one collapsible group per project. Single-click a header to
-  collapse it. Double-click a header to focus that project. Inside a group:
-  started, then review, blocked, ready.
-- **threads**: thread names across projects, with collapsible project sub-groups
-  under each name. Same status order.
+  repository, with project attribution on other work.
+- **selected project**: the project board for slot 2. Its local thread filter (shown as
+  `all` or `#name`) can narrow every status section.
+- **projects**: one selectable overview row per live project, with needs-you,
+  in-motion, and ready counts. Enter or clicking a row opens that project in slot 2.
+  Press `/` or click the footer's `/ search projects` affordance, type a project name
+  (paste works too), then press Enter to open the match. Esc clears the query and
+  returns to navigation. The `Overview` selector (`v`) can replace the index with a
+  flat cross-project thread board, with project attribution (including `desk`).
 
-The board opens on desk. If desk would be empty while open tasks exist elsewhere,
-it opens on projects instead, then threads.
+At startup, a pane inside a repository opens that project, including when it is
+empty. Outside a repository it opens Desk. Reopening tsk from another project
+updates the existing board to that invocation project, or Desk outside a repository.
 
-Project focus (`P` → a project) hides the tabs and paints the project name chip
-on the right (`P ▾`). At home the chip is hidden. Collapse state is session-only.
-It does not persist.
+The three navigation slots stay visible everywhere as **desk** · **selected project** ·
+**projects**. Their keyboard shortcuts remain `1`, `2`, and `3`. The selected-project
+slot keeps its identity while Desk or Projects is active; if it is empty, `2` opens the
+project picker. The active destination's chip shows only its selected value, such as
+`all ▾`, `#release ▾`, or `Overview ▾`, and opens its picker. A selector that wraps below
+the tabs has one blank line above it. Both project and cross-project thread views go
+straight to the status sections, without a separate task-count summary.
+Collapse state is session-only.
+
+Thread selectors (`t` within a project, `v` on Projects) accept typing and paste.
+All letters, including `j` and `k`, are search text; use arrows or Tab to move between
+options. An unmatched query stays visible with `no matching options` so you can edit
+it or press Esc to close.
+
+The projects search opens in the shared footer slot: closed it reads `/ search projects`,
+while focused it shows the query and caret there. Letters, digits, Backspace, and
+bracketed paste edit the query, while Enter opens the selected match and Esc clears and
+closes it. No search row appears above the project table.
 
 Each persisted row begins with a dim store-global identifier such as
 `T30`. Click the identifier to copy it (`copy sent: T30`). At standard size a row
-ends with `project · age`, where age reads `40s`, `12m`, `3h`, or `5d`. A scoped
+ends with its project name on global rows, or its `#thread` attribution on project
+rows. Task-page informational dates remain in the footer. A scoped
 group with nothing open reads `no open tasks here — P rescope or + capture`.
 
 ## Sections
 
-One urgency-ordered list. Sections are computed, not navigated.
+One urgency-ordered list. Sections are computed, not navigated. Desk NEEDS YOU contains
+blocked and review tasks from all live projects and the desk; project boards contain
+only that project's tasks.
 
 - **NEEDS YOU**: blocked and review, on desk (desk/global tasks) and on a project
   board (that project). Omitted when empty. Sits above IN MOTION.
 - **IN MOTION**: work you have started
 - **ON DECK** when you are on a project board: that project's ready tasks, with
-  thread headers above their open rows
+  thread labels beside their rows
 - **z** opens the done drawer
 
 An archived task keeps its human status and leaves every working lens (desk,
-projects, threads, project focus, and default `tsk list` views). The done
+projects, project focus, and default `tsk list` views). The done
 drawer lists archived tasks in its scope under an `▾ archived · n` group below
 DONE: closed on every launch, one click or `Enter` on the header toggles it on its
 own, and expanded rows paint dim with their status glyph and `T<n>`. The header
@@ -121,14 +144,12 @@ to peek, and click the same row again to close. At wide widths a board or rail r
 click selects it in place and a fast double-click opens the
 [task page](/docs/task-page/). The wheel scrolls the list.
 
-Everything painted as a control is clickable: the tabs, the project chip, the
-verb-bar entries, `u Undo` on a delete notice, and the DONE header (which closes
-the drawer). Group headers collapse on click and focus their project on a fast
-double-click; a project sub-header under a thread does the same. When the list
-overflows, a scrollbar appears on the right: click the track to jump, drag the thumb
-to scroll. Dragging across text selects it and copies on release (`copied`), using
-the terminal's clipboard protocol. With the quick-add line open, clicking a task row
-discards the draft and selects that row.
+Everything painted as a control is clickable: the tabs, destination chips, picker
+options, verb-bar entries, `u Undo` on a delete notice, and the DONE header (which
+closes the drawer). When the list overflows, a scrollbar appears on the right: click
+the track to jump, drag the thumb to scroll. Dragging across text selects it and copies
+on release (`copied`), using the terminal's clipboard protocol. With the quick-add line
+open, clicking a task row discards the draft and selects that row.
 
 ## Project picker
 
@@ -136,7 +157,7 @@ discards the draft and selects that row.
 Home) and archived. `Tab` or the arrows flip tabs; the archived tab lists every
 archived project and reads `no archived projects` when empty. `ctrl+f` on a
 main-tab project archives it in place — the picker stays open and the project
-leaves the main list, the projects tab, threads, desk IN MOTION, and the rail.
+leaves the main list, the projects index, desk IN MOTION, and the rail.
 `ctrl+f` or `ctrl+u` on an archived-tab entry unarchives it, and every task
 returns in the status it had. A dim rule sits under the tabs row, and the
 archived tab's footer reads `ctrl+u unarchive · enter open · esc close`.
@@ -174,7 +195,7 @@ shows at most once per session, and launching anywhere else paints nothing.
 | --- | --- |
 | at least 110 columns | wide stage slider: board, board beside page, rail beside page, or page. The rail paints no meta, done drawer, or peek |
 | at least 78×24 and below 110 columns | standard single-pane board: section headers, row meta, full verb legend |
-| smaller | compact: glyph, `T<number>` identifier, and title; help, palette, and the task page take the full pane |
+| smaller | compact: glyph, `T<number>` identifier, and wrapped title; short panes still show project/thread attribution when at least 78 columns wide; help, palette, and the task page take the full pane |
 | down to 40×10 | still operable |
 
 A typical herdr split is 78 columns, which is the standard board.
@@ -194,7 +215,7 @@ letters appear in order anywhere in a label, so `ssr` finds `set status: review`
 | `delete` | a task is selected |
 | `reopen` | the selected task is done |
 | `undo` · `done drawer` | always |
-| `toggle groups` | on the projects or threads tab |
+| `toggle groups` | on the projects index |
 | `help` · `quit` | always |
 | `Retry save` · `Cancel save` | a save is waiting on you (the only two entries then) |
 

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -28,8 +28,9 @@ progress. They are not in the current build.
 
 ## What you can do
 
-- Keep a queue with **desk**, **projects**, and **threads**. The desk is your own
-  planning space: general to-dos, future projects, anything outside a repository.
+- Keep a queue with **desk**, a selected project board, and a **projects** index.
+  The desk is your own planning space: general to-dos, future projects, anything outside
+  a repository. The projects index can show a flat cross-project thread.
 - Capture with `+` on the board, or a herdr overlay
 - Open a task page for title, notes, thread, scope, and steps
 - Script the same store with `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`

--- a/site/src/content/docs/docs/keys.md
+++ b/site/src/content/docs/docs/keys.md
@@ -10,8 +10,8 @@ Nav, peek, `Enter`, `P`, `1` / `2` / `3`, `z`, `:`, `?`, `+`, and `Esc` stay
 bare.
 
 The web demo on the landing page uses bare verb letters on purpose. Browsers
-steal control chords. On its projects and threads tabs, bare `g` toggles groups
-and the palette offers the same command.
+steal control chords. On its projects index, bare `g` toggles groups and the
+palette offers the same command.
 
 ## Wide stage slider
 
@@ -54,7 +54,10 @@ moves to G, then runs the control you clicked.
 | `:` | command palette |
 | `?` | help |
 | `P` | project picker |
-| `1` `2` `3` | home tabs: desk · projects · threads |
+| `t` on a project | open its thread filter |
+| `v` on Projects | choose Overview or a thread across projects |
+| `1` `2` `3` | navigation: desk · selected project · projects |
+| `/` on Projects | focus the footer's `/ search projects` affordance; type or paste, then Enter opens the selected match and Esc clears and closes |
 | `ctrl+g` | expand or collapse all visible groups; while the done drawer is open the `archived` group folds and unfolds with them |
 | `Esc` | close one layer |
 | `ctrl+q` or `ctrl+c` | quit |
@@ -89,7 +92,9 @@ selects, then opens or closes its text editor on a second click.
 ## Any text field
 
 Title, notes, thread, step, and quick-add share one editor. The palette query takes
-only typing, arrows, Tab, Enter, Esc, and Backspace.
+only typing, arrows, Tab, Enter, Esc, and Backspace. The Projects overview search is focused with `/` or by clicking the footer's `/ search`
+affordance, shows its query and caret in that shared slot, and accepts letters, digits,
+Backspace, and paste.
 
 | Key | Does |
 | --- | --- |
@@ -105,6 +110,7 @@ only typing, arrows, Tab, Enter, Esc, and Backspace.
 | Surface | Keys |
 | --- | --- |
 | `:` palette | type to filter · `↑` `↓` or `Tab` / `Shift+Tab` move · `Enter` run · `Esc` close |
+| `t` / `v` thread selectors | type or paste to filter (`j` and `k` are text) · arrows or `Tab` / `Shift+Tab` move · `Enter` choose · `Esc` close |
 | `P` project picker | `j` `k` or arrows · `Tab` main/archived tabs · `Enter` choose · `ctrl+f` archive (archived tab: unarchive) · `Esc` or `q` cancel |
 | launch card | `y` unarchive · `n` or `Esc` keep archived |
 | `?` help | any key closes |

--- a/site/src/content/docs/docs/keys.md
+++ b/site/src/content/docs/docs/keys.md
@@ -10,8 +10,8 @@ Nav, peek, `Enter`, `P`, `1` / `2` / `3`, `z`, `:`, `?`, `+`, and `Esc` stay
 bare.
 
 The web demo on the landing page uses bare verb letters on purpose. Browsers
-steal control chords. On its projects index, bare `g` toggles groups and the
-palette offers the same command.
+steal control chords. `ctrl+g` only answers when the done drawer has a visible
+archived group.
 
 ## Wide stage slider
 
@@ -58,7 +58,7 @@ moves to G, then runs the control you clicked.
 | `v` on Projects | choose Overview or a thread across projects |
 | `1` `2` `3` | navigation: desk · selected project · projects |
 | `/` on Projects | focus the footer's `/ search projects` affordance; type or paste, then Enter opens the selected match and Esc clears and closes |
-| `ctrl+g` | expand or collapse all visible groups; while the done drawer is open the `archived` group folds and unfolds with them |
+| `ctrl+g` | fold or unfold the done drawer's `archived` group when it is visible |
 | `Esc` | close one layer |
 | `ctrl+q` or `ctrl+c` | quit |
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -272,7 +272,7 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
               <span class="cycle-glyph" data-cycle-glyph aria-hidden="true">○</span>
               <span class="tid">T14</span>
               <span class="cycle-title">Ship the landing page</span>
-              <span class="cycle-meta">tsk · 2m</span>
+              <span class="cycle-meta">tsk</span>
             </div>
             <div class="cycle-foot">
               <span class="dim">you press</span>
@@ -350,9 +350,11 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
             <span class="index">03 <span class="index-label">board</span></span>
             <h2 id="board-heading">One list, ordered by urgency.</h2>
             <p class="band-lede">
-              Sections are computed, never navigated. Home is three tabs. <b>desk</b> is your
-              own space for planning, loose ends, and future projects. <b>projects</b> holds the
-              repos you and your agents work in. <b>threads</b> follows work that crosses them.
+              Open in a repository and start on its project board. <b>desk</b> shows what
+              needs you across projects, active work, and your loose backlog. The selected
+              <b>project</b> stays one key away; <b>projects</b> is a searchable index with
+              a View selector for cross-project threads. Filter threads within a project
+              with <kbd>t</kbd>, or across projects with <kbd>v</kbd> on the index.
               Give the board 110 columns and it becomes a slider.
             </p>
           </header>
@@ -360,46 +362,47 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
           <div class="anatomy">
             <div class="screen" role="img" aria-label="A tsk board at 78 columns, annotated with seven callouts">
               <div class="s-row s-tabs">
-                <span class="l"><span class="on">desk</span><span class="dim">  ·  </span>projects<span class="dim">  ·  </span>threads</span>
+                <span class="l"><span class="on">desk</span><span class="dim">  ·  </span>tsk ▾<span class="dim">  ·  </span>projects</span>
                 <span class="pin">1</span>
               </div>
               <div class="s-gap"></div>
               <div class="s-row s-sec">
-                <span class="sec">IN MOTION</span><span class="rule"></span><span class="count">2</span>
+                <span class="sec">NEEDS YOU</span><span class="rule"></span><span class="count">2</span>
                 <span class="pin">2</span>
               </div>
               <div class="s-gap"></div>
               <div class="s-row s-task is-sel">
-                <span class="l"><span class="sel">▸</span> <span class="tid">T31</span> <span class="sel-text">Wire the release checklist</span></span>
-                <span class="r meta">tsk · 3m</span>
+                <span class="l"><span class="sel">▲</span> <span class="tid">T31</span> <span class="sel-text">Review the release checklist</span></span>
+                <span class="r meta">#release</span>
                 <span class="pin">3</span>
               </div>
               <div class="s-row s-peek"><span class="l dim">  │ Steps live on the task page. Notes wrap, never truncate.</span></div>
               <div class="s-row s-peek"><span class="l dim">  └</span><span class="pin">4</span></div>
               <div class="s-row s-task">
-                <span class="l"><span class="glyph">▸</span> <span class="tid">T29</span> Pin the edit target on save</span>
-                <span class="r meta">herdr · 12m</span>
+                <span class="l"><span class="glyph">■</span> <span class="tid">T29</span> Waiting on the pane label</span>
+                <span class="r meta">herdr</span>
               </div>
               <div class="s-gap"></div>
               <div class="s-row s-sec">
-                <span class="sec">desk</span><span class="rule"></span><span class="count">3</span>
+                <span class="sec">IN MOTION</span><span class="rule"></span><span class="count">1</span>
               </div>
               <div class="s-gap"></div>
-              <div class="s-row s-thread">
-                <span class="l dim">#site 2</span>
+              <div class="s-row s-task">
+                <span class="l"><span class="glyph">▸</span> <span class="tid">T27</span> Proof the landing copy once more</span>
+                <span class="r meta">tsk</span>
+              </div>
+              <div class="s-gap"></div>
+              <div class="s-row s-sec">
+                <span class="sec">ON DECK · desk</span><span class="rule"></span><span class="count">2</span>
                 <span class="pin">5</span>
               </div>
               <div class="s-row s-task">
-                <span class="l"><span class="glyph">▲</span> <span class="tid">T27</span> Proof the landing copy once more</span>
-                <span class="r meta">20m</span>
-              </div>
-              <div class="s-row s-task">
-                <span class="l"><span class="glyph">■</span> <span class="tid">T25</span> Waiting on the pane label</span>
-                <span class="r meta">50m</span>
+                <span class="l"><span class="glyph">○</span> <span class="tid">T25</span> Draft the announcement</span>
+                <span class="r meta">desk</span>
               </div>
               <div class="s-row s-task">
                 <span class="l"><span class="glyph">○</span> <span class="tid">T18</span> Global backlog note</span>
-                <span class="r meta">2d</span>
+                <span class="r meta">desk</span>
               </div>
               <div class="s-fill"></div>
               <div class="s-row s-footrule"><span class="rule"></span></div>
@@ -416,15 +419,15 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
             <ol class="legend">
               <li>
                 <span class="legend-n">1</span>
-                <div><b>Home tabs.</b> <kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd> switch desk, projects, threads. <kbd>P</kbd> focuses one project and hides them.</div>
+                <div><b>Persistent navigation.</b> <kbd>1</kbd> opens Desk, <kbd>2</kbd> returns to the selected project, and <kbd>3</kbd> opens Projects. <kbd>P</kbd> changes the selected project without hiding the tabs.</div>
               </li>
               <li>
                 <span class="legend-n">2</span>
-                <div><b>NEEDS YOU.</b> Blocked and review, on desk and on a project board, above IN MOTION.</div>
+                <div><b>NEEDS YOU.</b> Blocked and review across all projects on Desk, or within the selected project on its board, above IN MOTION.</div>
               </li>
               <li>
                 <span class="legend-n">3</span>
-                <div><b>A row.</b> Status glyph, a dim <code>T</code>-number you can click to copy, the title, then project and age.</div>
+                <div><b>A row.</b> Status glyph, a dim <code>T</code>-number you can click to copy, the title, then project or thread attribution.</div>
               </li>
               <li>
                 <span class="legend-n">4</span>
@@ -432,7 +435,7 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
               </li>
               <li>
                 <span class="legend-n">5</span>
-                <div><b>Thread headers.</b> Open desk work groups under dim <code>#name</code> headers with a count. Unthreaded rows follow.</div>
+                <div><b>Your loose backlog.</b> Desk's ON DECK contains only tasks without a project. Project backlogs live on their own boards, with thread filters across every status.</div>
               </li>
               <li>
                 <span class="legend-n">6</span>
@@ -508,7 +511,7 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
             <div class="key" role="listitem"><span class="caps"><kbd>:</kbd></span><span>command palette</span></div>
             <div class="key" role="listitem"><span class="caps"><kbd>?</kbd></span><span>help card</span></div>
             <div class="key" role="listitem"><span class="caps"><kbd>z</kbd></span><span>done drawer</span></div>
-            <div class="key" role="listitem"><span class="caps"><kbd>1</kbd><kbd>2</kbd><kbd>3</kbd></span><span>desk · projects · threads</span></div>
+            <div class="key" role="listitem"><span class="caps"><kbd>1</kbd><kbd>2</kbd><kbd>3</kbd></span><span>desk · selected project · projects</span></div>
             <div class="key" role="listitem"><span class="caps"><kbd>P</kbd></span><span>project picker</span></div>
             <div class="key" role="listitem"><span class="caps"><kbd>Esc</kbd></span><span>close one layer</span></div>
           </div>

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -112,6 +112,26 @@ test("docs and demo describe the wide stage slider and threshold", async () => {
   assert.match(styles, /\.tsk-wide-split\.is-rail \{\s*grid-template-columns: 32ch 1px/);
 });
 
+test("demo keeps project navigation, attribution, and search contracts", async () => {
+  const demo = await read("../public/board-demo.js");
+  assert.match(demo, /selectedProject: "tsk",/);
+  assert.match(demo, /need: open/);
+  assert.doesNotMatch(demo, /!t\.project && \(t\.status === "blocked" \|\| t\.status === "review"\)/);
+  assert.match(demo, /state\.selectedProject = name;/);
+  assert.match(demo, /const text = tab === "project" \? state\.selectedProject : label/);
+  assert.match(demo, /state\.tasks\.filter\(\(t\) => t\.project && !t\.archived\)/);
+  assert.match(demo, /if \(a === "tsk"\) return -1/);
+  assert.match(demo, /id: `project:\${name}`/);
+  assert.match(demo, /id: "nav:archived"/);
+  assert.match(demo, /const row = selectedRow\(\);/);
+  assert.match(demo, /row\?\.kind === "project"/);
+  assert.match(demo, /selectedRow\(\)\?\.kind !== "task"/);
+  assert.match(demo, /id="tsk-project-search"/);
+  assert.ok(demo.includes('e.key === "/"'));
+  assert.match(demo, /state\.projectQuery/);
+  assert.match(demo, /data-project-row=/);
+});
+
 test("demo matches the quick-add, peek, and group-toggle contracts", async () => {
   const demo = await read("../public/board-demo.js");
   assert.match(demo, /if \(e\.key === "Enter" && !e\.ctrlKey && !e\.altKey && !e\.metaKey\)/);

--- a/src/app.rs
+++ b/src/app.rs
@@ -794,6 +794,12 @@ pub fn apply_reopen_request(
     let Some(request) = watch.poll() else {
         return false;
     };
+    if model.has_unsaved_work() {
+        if watch.mark_deferred_notice() {
+            model.set_message("save or cancel edits before reopening tsk");
+        }
+        return false;
+    }
     if !model.apply_reopen_project(request.project.clone()) {
         return false;
     }
@@ -992,27 +998,12 @@ fn board_keyboard_intent(
             if let Some(tab) = tab {
                 return Some(BoardIntent::SelectNavTab(tab));
             }
-            // The projects index takes free typing as its search: unbound normal-mode
-            // characters narrow the row list, Backspace unwinds it. Bound keys (nav,
-            // verbs, pickers, `+`, `:`, `?`) keep their routes.
             if model.nav_tab() == NavTab::Projects
                 && matches!(model.projects_view(), ProjectsView::Overview)
                 && c == '/'
             {
                 return Some(BoardIntent::FocusProjectsSearch);
             }
-            if model.nav_tab() == NavTab::Projects
-                && key.modifiers.is_empty()
-                && crate::ui::input::is_unbound_normal_char(c)
-                && !c.is_control()
-            {
-                return Some(BoardIntent::ProjectsQueryInsert(c));
-            }
-        } else if key.code == KeyCode::Backspace
-            && key.modifiers.is_empty()
-            && model.nav_tab() == NavTab::Projects
-        {
-            return Some(BoardIntent::ProjectsQueryBackspace);
         }
     }
 
@@ -1641,7 +1632,7 @@ fn capture_form_loop(
 }
 #[cfg(test)]
 mod save_recovery_tests {
-    use super::board_background_work_allowed;
+    use super::{apply_reopen_request, board_background_work_allowed};
     use crate::domain::DomainState;
     use crate::save_recovery::SaveRecovery;
 
@@ -1653,6 +1644,105 @@ mod save_recovery_tests {
         assert!(!board_background_work_allowed(&recovery));
         let _ = recovery.cancel();
         assert!(board_background_work_allowed(&recovery));
+    }
+
+    #[test]
+    fn reopen_deferred_request_does_not_overwrite_new_editor_feedback() {
+        use crate::domain::{ProvenanceOrigin, TaskScope};
+        use crate::reopen::{ReopenRequest, ReopenWatch};
+        use crate::store::TaskStore;
+        use crate::ui::board::BoardModel;
+        use crate::ui::input::BoardIntent;
+        use std::fs;
+        use std::path::PathBuf;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-dirty-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let store = TaskStore::new(&dir);
+        let mut domain = DomainState::new();
+        domain
+            .create(
+                "draft",
+                None,
+                TaskScope::Global,
+                ProvenanceOrigin::Manual,
+                None,
+            )
+            .expect("task");
+        let mut model = BoardModel::from_domain(&domain, None);
+        crate::ui::board::apply_intent(&mut domain, &mut model, BoardIntent::BeginEditTitle, None)
+            .expect("edit");
+        crate::ui::board::apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('x'), None)
+            .expect("type");
+        let mut watch = ReopenWatch::seeded(&store);
+        ReopenRequest::new(Some(PathBuf::from("/repo/deferred")))
+            .write(&dir)
+            .expect("request");
+        let recovery = SaveRecovery::new();
+        assert!(!apply_reopen_request(&mut model, &mut watch, &recovery));
+        assert!(model
+            .message()
+            .is_some_and(|message| message.contains("save or cancel")));
+        model.set_message("title is required");
+        assert!(!apply_reopen_request(&mut model, &mut watch, &recovery));
+        assert_eq!(model.message(), Some("title is required"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn reopen_idle_bridge_applies_and_acknowledges_or_defers_behind_recovery() {
+        use crate::reopen::{ReopenRequest, ReopenWatch};
+        use crate::store::TaskStore;
+        use crate::ui::board::BoardModel;
+        use std::fs;
+        use std::path::PathBuf;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-app-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let store = TaskStore::new(&dir);
+        let mut watch = ReopenWatch::seeded(&store);
+        let mut model = BoardModel::from_domain(&DomainState::new(), None);
+        let recovery = SaveRecovery::new();
+        ReopenRequest::new(Some(PathBuf::from("/repo/new")))
+            .write(&dir)
+            .expect("request");
+        assert!(apply_reopen_request(&mut model, &mut watch, &recovery));
+        assert_eq!(
+            model.selected_project(),
+            Some(std::path::Path::new("/repo/new"))
+        );
+        assert!(!dir.join("reopen.json").exists());
+
+        let mut pending = SaveRecovery::new();
+        pending.fail(DomainState::new(), DomainState::new(), "save failed");
+        ReopenRequest::new(Some(PathBuf::from("/repo/deferred")))
+            .write(&dir)
+            .expect("request");
+        assert!(!apply_reopen_request(&mut model, &mut watch, &pending));
+        assert!(
+            dir.join("reopen.json").exists(),
+            "deferred request remains pending"
+        );
+        model.set_message("editor feedback");
+        assert!(!apply_reopen_request(&mut model, &mut watch, &pending));
+        assert_eq!(model.message(), Some("editor feedback"));
+        let _ = pending.cancel();
+        assert!(apply_reopen_request(&mut model, &mut watch, &pending));
+        assert_eq!(
+            model.selected_project(),
+            Some(std::path::Path::new("/repo/deferred"))
+        );
+        let _ = fs::remove_dir_all(dir);
     }
 }
 
@@ -3754,6 +3844,30 @@ mod tests {
     }
 
     #[test]
+    fn navigation_digits_route_from_project_focus_and_preserve_input_interception() {
+        let (mut domain, mut model) = board_fixture("digits", None);
+        model.apply_reopen_project(Some(PathBuf::from("/repos/alpha")));
+        let key = |code| KeyEvent::new(code, KeyModifiers::NONE);
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('1'))),
+            Some(BoardIntent::SelectNavTab(NavTab::Desk))
+        );
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('2'))),
+            Some(BoardIntent::SelectNavTab(NavTab::ProjectBoard))
+        );
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('3'))),
+            Some(BoardIntent::SelectNavTab(NavTab::Projects))
+        );
+        apply_intent(&mut domain, &mut model, BoardIntent::BeginEditTitle, None).expect("edit");
+        assert!(matches!(
+            board_keyboard_intent(&model, BoardInputMode::EditTitle, key(KeyCode::Char('1'))),
+            Some(BoardIntent::EditInsert('1'))
+        ));
+    }
+
+    #[test]
     fn projects_search_owns_bound_keys_paste_and_mouse_focus() {
         let (mut domain, mut model) = board_fixture("search", None);
         model.apply_reopen_project(Some(PathBuf::from("/repos/beta")));
@@ -3783,6 +3897,20 @@ mod tests {
         assert_eq!(
             board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('/'))),
             Some(BoardIntent::FocusProjectsSearch)
+        );
+        // Normal mode does not own an implicit query. Bound and unbound letters
+        // retain their ordinary routes or are inert until slash/footer search focus.
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('e'))),
+            None
+        );
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('w'))),
+            None
+        );
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Backspace)),
+            None
         );
         assert_eq!(
             board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('v'))),

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,11 +13,12 @@ use ratatui::DefaultTerminal;
 use crate::config::{default_config_dir, WalkthroughRecord};
 use crate::context::{build_snapshot, InvocationSnapshot, RawHostContext};
 use crate::domain::{DomainError, DomainState};
+use crate::reopen::ReopenWatch;
 use crate::save_recovery::SaveRecovery;
 use crate::store::{default_state_dir, StoreError, StoreSignature, TaskStore};
 use crate::ui::board::{
     apply_intent, board_intent_may_persist, draw_board, resolve_board_command, BoardInputMode,
-    BoardModel, IntentOutcome, SaveResolution, WalkthroughOutcome,
+    BoardModel, IntentOutcome, ProjectsView, SaveResolution, WalkthroughOutcome,
 };
 use crate::ui::capture::{
     apply_capture_intent, draw_capture, CaptureModel, CaptureOutcome, TITLE_REQUIRED_MESSAGE,
@@ -32,7 +33,7 @@ use crate::ui::mouse::{
     map_scrollbar_mouse, press_on_focused_surface, scrollbar_hit_at, wide_mouse_focus_intent,
     ScrollbarMouse,
 };
-use crate::ui::queue::BoardTab;
+use crate::ui::queue::NavTab;
 use crate::ui::scheduler;
 use crate::ui::text_select::{
     copy_to_clipboard, copyable_line_at, frame_text_rows, selection_text,
@@ -296,6 +297,9 @@ fn run_board() -> Result<(), Box<dyn Error>> {
     // `load_board` just read the store, so seed the watch from that snapshot: the first idle
     // tick must not immediately re-merge what is already loaded.
     let mut store_watch = StoreWatch::seeded(&store);
+    // Focusing an existing plugin pane cannot refresh its inherited host environment. The
+    // launcher publishes a one-shot request in the state dir, consumed only on idle ticks.
+    let mut reopen_watch = ReopenWatch::seeded(&store);
     // the board frame path does no host polling and does not
     // auto-open the walkthrough on launch. `load_board` is the whole open path; the first
     // paint below is of that model, unrefreshed. attention polling (removed),
@@ -368,6 +372,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                     drag_gesture.has_autoscroll(),
                 )?;
                 if poll == FramePoll::Idle {
+                    apply_reopen_request(&mut model, &mut reopen_watch, &save_recovery);
                     if let Some(auto) = drag_gesture.autoscroll() {
                         let area = terminal_area(terminal)?;
                         let content = drag_content_area(&model, area);
@@ -776,6 +781,26 @@ pub fn tick_drag_autoscroll(
     }
 }
 
+/// Apply a pending explicit launcher context once the board is not in save recovery.
+/// Returning `false` leaves a dirty editor's request pending for a later idle tick.
+pub fn apply_reopen_request(
+    model: &mut BoardModel,
+    watch: &mut ReopenWatch,
+    recovery: &SaveRecovery<DomainState>,
+) -> bool {
+    if recovery.is_pending() {
+        return false;
+    }
+    let Some(request) = watch.poll() else {
+        return false;
+    };
+    if !model.apply_reopen_project(request.project.clone()) {
+        return false;
+    }
+    watch.acknowledge();
+    true
+}
+
 /// Whether save recovery permits the board to apply background state changes.
 fn board_background_work_allowed(recovery: &SaveRecovery<DomainState>) -> bool {
     !recovery.is_pending()
@@ -948,7 +973,10 @@ fn board_keyboard_intent(
     // not worth an `expect` here: this runs on every keypress inside the raw-mode event loop, so
     // a panic would abort with the terminal still in raw mode and take the user's shell with it.
     // Falling through to `map_key` degrades to normal-mode routing instead of dying.
-    if mode == BoardInputMode::Normal && model.at_home() {
+    // Persistent navigation: `1` desk · `2` selected project · `3` projects, from
+    // every normal-mode surface. Tab 2 with no selected project opens the picker
+    // (the reducer answers the intent), so the digits never change meaning.
+    if mode == BoardInputMode::Normal {
         if key
             .modifiers
             .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
@@ -956,14 +984,35 @@ fn board_keyboard_intent(
             // fall through
         } else if let KeyCode::Char(c) = key.code {
             let tab = match c {
-                '1' => Some(BoardTab::Desk),
-                '2' => Some(BoardTab::Projects),
-                '3' => Some(BoardTab::Threads),
+                '1' => Some(NavTab::Desk),
+                '2' => Some(NavTab::ProjectBoard),
+                '3' => Some(NavTab::Projects),
                 _ => None,
             };
             if let Some(tab) = tab {
-                return Some(BoardIntent::SelectHomeTab(tab));
+                return Some(BoardIntent::SelectNavTab(tab));
             }
+            // The projects index takes free typing as its search: unbound normal-mode
+            // characters narrow the row list, Backspace unwinds it. Bound keys (nav,
+            // verbs, pickers, `+`, `:`, `?`) keep their routes.
+            if model.nav_tab() == NavTab::Projects
+                && matches!(model.projects_view(), ProjectsView::Overview)
+                && c == '/'
+            {
+                return Some(BoardIntent::FocusProjectsSearch);
+            }
+            if model.nav_tab() == NavTab::Projects
+                && key.modifiers.is_empty()
+                && crate::ui::input::is_unbound_normal_char(c)
+                && !c.is_control()
+            {
+                return Some(BoardIntent::ProjectsQueryInsert(c));
+            }
+        } else if key.code == KeyCode::Backspace
+            && key.modifiers.is_empty()
+            && model.nav_tab() == NavTab::Projects
+        {
+            return Some(BoardIntent::ProjectsQueryBackspace);
         }
     }
 
@@ -1300,17 +1349,9 @@ fn board_mouse_intent(
         crate::ui::render::QueueHitMap::default()
     };
     let intent = map_responsive_board_mouse(model, &hits, area, mouse);
-    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
-        && !matches!(
-            intent,
-            Some(BoardIntent::SelectSectionProject(_))
-                | Some(BoardIntent::SelectSectionThreadProject { .. })
-        )
-    {
-        // A double-click is two consecutive clicks on the same project header (a
-        // projects-tab group header, or a threads-tab project sub-group header). Any other
-        // pointer target, including inert board space, cancels the armed first click before
-        // the next event can be mistaken for its second half.
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) && intent.is_none() {
+        // Any pointer target that is not a named row is inert; nothing arms a
+        // double-click on the index (rows open on a single click).
         model.cancel_project_header_double_click();
     }
     let intent = intent?;
@@ -2146,14 +2187,14 @@ mod tests {
 
     use crate::context::InvocationSnapshot;
     use crate::domain::{HumanStatus, ProvenanceOrigin, TaskScope};
-    use crate::ui::board::CommandSurface;
+    use crate::ui::board::{board_hit_map, CommandSurface};
     use crate::ui::capture::CaptureField;
     use crate::ui::input::{map_key, CaptureIntent};
     use crate::ui::mouse::{
         focused_mouse_area, left_click, map_board_mouse, map_responsive_board_mouse,
         press_on_focused_surface,
     };
-    use crate::ui::queue::BoardTab;
+    use crate::ui::queue::NavTab;
 
     static TEMP_DIR_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
@@ -2729,15 +2770,15 @@ mod tests {
     }
 
     #[test]
-    fn intervening_task_click_cancels_an_armed_project_header_double_click() {
+    fn projects_index_row_click_opens_that_project_in_slot_2() {
         use crate::ui::board::{apply_intent, board_hit_map};
         use crate::ui::mouse::left_click;
         use crate::ui::render::QueueHitTarget;
 
         let mut domain = DomainState::new();
-        let id = domain
+        domain
             .create(
-                "click between headers",
+                "alpha task",
                 None,
                 TaskScope::Project {
                     path: "/repos/alpha".into(),
@@ -2748,7 +2789,7 @@ mod tests {
             .expect("create task");
         domain
             .create(
-                "other project task",
+                "beta task",
                 None,
                 TaskScope::Project {
                     path: "/repos/beta".into(),
@@ -2761,89 +2802,57 @@ mod tests {
         apply_intent(
             &mut domain,
             &mut model,
-            BoardIntent::SelectHomeTab(BoardTab::Projects),
+            BoardIntent::SelectNavTab(NavTab::Projects),
             None,
         )
-        .expect("projects tab");
+        .expect("projects index");
+        assert_eq!(
+            model.selected_project(),
+            Some(Path::new("/repos/alpha")),
+            "slot 2 retains the invocation project while Projects is active"
+        );
+
         let area = Rect::new(0, 0, 80, 24);
-
-        fn header_for<'a>(
-            hits: &'a crate::ui::render::QueueHitMap,
-            view: &crate::ui::queue::QueueView,
-            path: &str,
-        ) -> &'a crate::ui::render::QueueHit {
-            hits.regions
-                .iter()
-                .find(|hit| {
-                    matches!(hit.target, QueueHitTarget::SectionProject(index) if view
-                    .sections
-                    .get(index)
-                    .and_then(|section| section.project_label.as_deref())
-                    == Some(path))
-                })
-                .unwrap_or_else(|| panic!("missing header for {path} in {hits:?}"))
-        }
-
-        fn target_mouse(
-            area: Rect,
-            model: &BoardModel,
-            target: impl Fn(QueueHitTarget) -> bool,
-        ) -> crossterm::event::MouseEvent {
+        let row_click = |model: &BoardModel, path: &str| {
             let hits = board_hit_map(area, model);
             let hit = hits
                 .regions
                 .iter()
-                .find(|hit| target(hit.target))
-                .unwrap_or_else(|| panic!("missing target in {hits:?}"));
+                .find(|hit| {
+                    matches!(hit.target, QueueHitTarget::ProjectRow(index) if model
+                        .project_rows()
+                        .get(index)
+                        .is_some_and(|row| row.path == path))
+                })
+                .unwrap_or_else(|| panic!("missing index row for {path} in {hits:?}"));
             left_click(hit.area.x, hit.area.y)
-        }
-        let drive_click = |domain: &mut DomainState,
-                           model: &mut BoardModel,
-                           mouse: crossterm::event::MouseEvent| {
+        };
+        let drive = |domain: &mut DomainState,
+                     model: &mut BoardModel,
+                     mouse: crossterm::event::MouseEvent| {
             let intent = board_mouse_intent(area, model, mouse).expect("click maps to intent");
             apply_intent(domain, model, intent, None).expect("click applies");
         };
 
-        let mouse = {
-            let hits = board_hit_map(area, &model);
-            let hit = header_for(&hits, &model.queue_view(), "/repos/beta");
-            left_click(hit.area.x, hit.area.y)
-        };
-        drive_click(&mut domain, &mut model, mouse);
-        assert_eq!(
-            model.selected_project(),
-            None,
-            "first header click collapses/arm only"
-        );
-
-        let mouse = target_mouse(
-            area,
-            &model,
-            |target| matches!(target, QueueHitTarget::Task(task_id) if task_id == id),
-        );
-        drive_click(&mut domain, &mut model, mouse);
-        let mouse = {
-            let hits = board_hit_map(area, &model);
-            let hit = header_for(&hits, &model.queue_view(), "/repos/beta");
-            left_click(hit.area.x, hit.area.y)
-        };
-        drive_click(&mut domain, &mut model, mouse);
-        assert_eq!(
-            model.selected_project(),
-            None,
-            "header click after an intervening task click must be a new first click"
-        );
-
-        let mouse = {
-            let hits = board_hit_map(area, &model);
-            let hit = header_for(&hits, &model.queue_view(), "/repos/beta");
-            left_click(hit.area.x, hit.area.y)
-        };
-        drive_click(&mut domain, &mut model, mouse);
+        let mouse = row_click(&model, "/repos/beta");
+        drive(&mut domain, &mut model, mouse);
         assert_eq!(
             model.selected_project(),
             Some(Path::new("/repos/beta")),
-            "only two consecutive header clicks scope the board"
+            "a direct index-row click opens that project in slot 2"
+        );
+
+        // Index rows are navigation: the click mutated no task, and the pin reanchors
+        // onto the opened project's own rows.
+        let pinned = model
+            .selected_id()
+            .and_then(|id| domain.get(id).map(|task| task.scope.clone()));
+        assert_eq!(
+            pinned,
+            Some(TaskScope::Project {
+                path: "/repos/beta".into()
+            }),
+            "the pin lands on a row of the project it opened"
         );
     }
 
@@ -2876,25 +2885,31 @@ mod tests {
             Rect::new(0, 0, 49, 18),
             Rect::new(0, 0, 40, 10),
         ] {
+            // Clicking slot 2 while its project is open opens the picker, the way the
+            // old chip did.
             let hits = board_hit_map(area, &model);
-            let chip = hits
+            let tab2 = hits
                 .regions
                 .iter()
-                .find(|hit| matches!(hit.target, QueueHitTarget::ProjectChip))
-                .unwrap_or_else(|| panic!("no project chip hit region at {area:?}"));
+                .find(|hit| matches!(hit.target, QueueHitTarget::NavTab(NavTab::ProjectBoard)))
+                .unwrap_or_else(|| panic!("no slot-2 tab hit region at {area:?}"));
             let mouse_intent =
-                map_board_mouse(&model, &hits, left_click(chip.area.x + 1, chip.area.y))
-                    .expect("project chip hit");
-            assert_eq!(mouse_intent, BoardIntent::OpenProjectSelector);
-            // `P` gives the keyboard the identical route to the same intent.
+                map_board_mouse(&model, &hits, left_click(tab2.area.x + 1, tab2.area.y))
+                    .expect("slot-2 tab hit");
+            assert_eq!(
+                mouse_intent,
+                BoardIntent::SelectNavTab(NavTab::ProjectBoard),
+                "slot-2's click is the tab intent; the reducer opens the picker from it"
+            );
+            // `P` gives the keyboard the same destination by direct intent.
             let keyboard_intent = map_key(
                 board_input_mode_for_area(area, model.input_mode()),
                 KeyEvent::new(KeyCode::Char('P'), KeyModifiers::NONE),
             );
             assert_eq!(
                 keyboard_intent,
-                Some(mouse_intent.clone()),
-                "`P` must dispatch the same intent as the project chip click at {area:?}"
+                Some(BoardIntent::OpenProjectSelector),
+                "`P` must open the project selector at {area:?}"
             );
             assert_eq!(
                 board_intent_for_area(area, mouse_intent.clone()),
@@ -3170,8 +3185,10 @@ mod tests {
             "board `+` must create exactly one task through the real app intent path, not zero"
         );
         assert!(
-            model.visible_ids().contains(&created[0].id),
-            "board model must show the task it just created"
+            model.visible_ids().contains(&created[0].id)
+                || model.nav_tab() == crate::ui::queue::NavTab::Desk,
+            "the board either shows the saved task or keeps the user's destination: \
+             a save must not switch tabs to prove where a row went"
         );
     }
 
@@ -3373,19 +3390,23 @@ mod tests {
             Some(&snapshot),
         )
         .expect("focus scope");
+        // Startup inside a repo opens that project's board, so quick-add starts
+        // scoped to it; cycling moves to the next option (the desk).
+        assert_eq!(
+            model.form_scope(),
+            Some(&TaskScope::Project {
+                path: "/repos/chosen".into()
+            }),
+            "quick-add inherits the invocation project as its destination"
+        );
         apply_intent(
             &mut domain,
             &mut model,
             BoardIntent::FormCycleScope,
             Some(&snapshot),
         )
-        .expect("choose project scope");
-        assert_eq!(
-            model.form_scope(),
-            Some(&TaskScope::Project {
-                path: "/repos/chosen".into()
-            })
-        );
+        .expect("cycle scope");
+        assert_eq!(model.form_scope(), Some(&TaskScope::Global));
 
         let outcome = apply_board_intent_with_save_recovery(
             &mut domain,
@@ -3427,9 +3448,8 @@ mod tests {
         );
         assert_eq!(
             model.form_scope(),
-            Some(&TaskScope::Project {
-                path: "/repos/chosen".into()
-            })
+            Some(&TaskScope::Global),
+            "the stashed draft keeps the scope the user chose"
         );
         apply_intent(
             &mut domain,
@@ -3733,22 +3753,129 @@ mod tests {
         }
     }
 
-    /// `BoardMode` is now purely a layout classification (the compact tier vs the
-    /// standard tier,); it no longer changes which input mode a key resolves to or
-    /// which intents reach the reducer. Every surface the board can have open must resolve
-    /// the identical input mode, and route the identical intent for every primary action key
-    /// and for quit, at the legacy Resize band as at a wide size.
-    ///
-    /// Formerly two tests asserting the opposite, now-removed contract
-    /// (`resize_guidance_keeps_keyboard_quit_reachable_from_every_open_surface`,
-    /// `resize_guidance_blocks_task_mutation_from_every_open_surface`): every open surface was
-    /// force-closed and forced to `Normal`, and every intent but quit/close-layer was
-    /// swallowed below 50x18.
-    /// a bracketed paste reaches the board's edit route, and only that route.
-    ///
-    /// The board loop's paste arm is exactly this resolution followed by the same
-    /// `handle_board_intent` call the key arm makes, so a paste cannot reach a route a key
-    /// press could not.
+    #[test]
+    fn projects_search_owns_bound_keys_paste_and_mouse_focus() {
+        let (mut domain, mut model) = board_fixture("search", None);
+        model.apply_reopen_project(Some(PathBuf::from("/repos/beta")));
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::SelectNavTab(NavTab::Projects),
+            None,
+        )
+        .expect("projects index");
+        let key = |code| KeyEvent::new(code, KeyModifiers::NONE);
+        let hits = board_hit_map(Rect::new(0, 0, 80, 24), &model);
+        let search = hits
+            .regions
+            .iter()
+            .find(|hit| hit.target == crate::ui::render::QueueHitTarget::Verb(0))
+            .expect("closed footer search affordance");
+        assert!(
+            search.area.y >= 20,
+            "projects search belongs in the footer slot, got hit at y={}",
+            search.area.y
+        );
+        assert_eq!(
+            map_board_mouse(&model, &hits, click_at(search.area)),
+            Some(BoardIntent::FocusProjectsSearch)
+        );
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('/'))),
+            Some(BoardIntent::FocusProjectsSearch)
+        );
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('v'))),
+            Some(BoardIntent::OpenProjectsViewPicker)
+        );
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::Normal, key(KeyCode::Char('3'))),
+            Some(BoardIntent::SelectNavTab(NavTab::Projects))
+        );
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::FocusProjectsSearch,
+            None,
+        )
+        .expect("focus search");
+        let compact_hits = board_hit_map(Rect::new(0, 0, 40, 10), &model);
+        let compact_search = compact_hits
+            .regions
+            .iter()
+            .find(|hit| hit.target == crate::ui::render::QueueHitTarget::ProjectsSearch)
+            .expect("compact footer search input");
+        assert!(
+            compact_search.area.y >= 7,
+            "compact search must stay in the footer slot"
+        );
+        for c in ['b', 'e', 't', 'a', 'j', 'k', 'v', '1', '2', '3'] {
+            assert_eq!(
+                board_keyboard_intent(
+                    &model,
+                    BoardInputMode::ProjectsSearch,
+                    key(KeyCode::Char(c))
+                ),
+                Some(BoardIntent::ProjectsQueryInsert(c)),
+                "bound search character should be text: {c}"
+            );
+        }
+        let intent = board_paste_intent(Rect::new(0, 0, 80, 24), &mut model, "beta")
+            .expect("paste search query");
+        assert_eq!(intent, BoardIntent::ProjectsQueryInsertText("beta".into()));
+        apply_intent(&mut domain, &mut model, intent, None).expect("insert query");
+        assert_eq!(model.projects_query(), "beta");
+        assert_eq!(model.project_rows().len(), 1);
+        assert_eq!(
+            board_keyboard_intent(
+                &model,
+                BoardInputMode::ProjectsSearch,
+                key(KeyCode::Backspace)
+            ),
+            Some(BoardIntent::ProjectsQueryBackspace)
+        );
+        let hits = board_hit_map(Rect::new(0, 0, 80, 24), &model);
+        let search = hits
+            .regions
+            .iter()
+            .find(|hit| hit.target == crate::ui::render::QueueHitTarget::ProjectsSearch)
+            .expect("open footer search input");
+        assert!(
+            search.area.y >= 20,
+            "open projects search must remain in the footer slot, got y={}",
+            search.area.y
+        );
+        assert_eq!(
+            map_board_mouse(&model, &hits, click_at(search.area)),
+            Some(BoardIntent::FocusProjectsSearch)
+        );
+        apply_intent(&mut domain, &mut model, BoardIntent::CloseLayer, None).expect("clear search");
+        assert_eq!(model.projects_query(), "");
+        assert_eq!(model.input_mode(), BoardInputMode::Normal);
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::FocusProjectsSearch,
+            None,
+        )
+        .expect("refocus search");
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::ProjectsQueryInsertText("beta".into()),
+            None,
+        )
+        .expect("restore query");
+        apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None)
+            .expect("open selected search match");
+        assert_eq!(model.nav_tab(), NavTab::ProjectBoard);
+        assert_eq!(model.input_mode(), BoardInputMode::Normal);
+        assert_eq!(
+            board_keyboard_intent(&model, BoardInputMode::ProjectsSearch, key(KeyCode::Esc)),
+            Some(BoardIntent::CloseLayer)
+        );
+    }
+
     #[test]
     fn a_board_paste_routes_to_the_edit_buffer_and_is_inert_outside_an_edit_mode() {
         let area = Rect::new(0, 0, 120, 40);
@@ -4129,21 +4256,17 @@ mod tests {
 }
 
 #[cfg(test)]
-mod thread_project_double_click_tests {
-    use super::board_mouse_intent;
-    use crate::domain::{DomainState, ProvenanceOrigin};
-    use crate::ui::board::{apply_intent, board_hit_map, BoardTab};
-    use crate::ui::input::BoardIntent;
-    use crate::ui::mouse::left_click;
-    use crate::ui::render::QueueHitTarget;
-    use std::path::{Path, PathBuf};
+mod projects_view_tests {
+    use super::{apply_intent, BoardIntent, DomainState, NavTab};
+    use crate::domain::ProvenanceOrigin;
+    use std::path::PathBuf;
 
-    /// A threads-tab project sub-header must adopt its second click into project focus.
-    /// The router cancels the armed first click for any pointer target that is not a
-    /// scope control, and `SelectSectionThreadProject` is one, so the armed state has to
-    /// survive it exactly as it does `SelectSectionProject`.
+    /// The projects index's View selector replaces the index with one thread's flat
+    /// cross-project task board.
     #[test]
-    fn thread_project_header_double_click_scopes_the_board_to_that_project() {
+    fn projects_view_thread_renders_cross_project_matches() {
+        use crate::ui::queue::SectionKind;
+
         let mut domain = DomainState::new();
         for (title, path) in [
             ("alpha release task", "/repos/alpha"),
@@ -4164,51 +4287,46 @@ mod thread_project_double_click_tests {
         apply_intent(
             &mut domain,
             &mut model,
-            BoardIntent::SelectHomeTab(BoardTab::Threads),
+            BoardIntent::SelectNavTab(NavTab::Projects),
             None,
         )
-        .expect("open threads tab");
-
-        let area = ratatui::layout::Rect::new(0, 0, 80, 24);
-        // Whichever project paints first under the thread group is the header we drive.
-        let targeted_path = model.queue_view().sections[0].thread_subgroups[0]
-            .project_path
-            .clone()
-            .expect("subgroup names a project");
-        let sub_header = |model: &crate::ui::board::BoardModel| {
-            let hits = board_hit_map(area, model);
-            let hit = hits
-                .regions
-                .iter()
-                .find(|hit| {
-                    matches!(
-                        hit.target,
-                        QueueHitTarget::SectionThreadProject {
-                            section_idx: 0,
-                            subgroup_idx: 0,
-                        }
-                    )
-                })
-                .unwrap_or_else(|| panic!("no thread project sub-header hit region: {hits:?}"));
-            left_click(hit.area.x, hit.area.y)
-        };
-
-        let first = sub_header(&model);
-        let intent = board_mouse_intent(area, &mut model, first).expect("first click maps");
-        apply_intent(&mut domain, &mut model, intent.clone(), None).expect("apply first click");
-        assert_eq!(
-            model.selected_project(),
+        .expect("projects index");
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::OpenProjectsViewPicker,
             None,
-            "one sub-header click collapses the subgroup but stays at home"
-        );
+        )
+        .expect("open view picker");
+        assert!(model.list_picker_open(), "the View picker opens");
+        // The picker's first row is Overview; move once to the first thread, then confirm.
+        apply_intent(&mut domain, &mut model, BoardIntent::ListPickerNext, None)
+            .expect("move to first thread");
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::ConfirmListPicker,
+            None,
+        )
+        .expect("apply thread view");
 
-        let second = sub_header(&model);
-        let intent = board_mouse_intent(area, &mut model, second).expect("second click maps");
-        apply_intent(&mut domain, &mut model, intent, None).expect("apply second click");
-        assert_eq!(
-            model.selected_project().map(Path::to_path_buf),
-            Some(PathBuf::from(&targeted_path)),
-            "sub-header double-click must narrow the session to the clicked project"
+        let view = model.queue_view();
+        assert!(
+            view.projects.is_empty(),
+            "the thread view replaces the project index rows"
         );
+        let listed: Vec<_> = view
+            .sections
+            .iter()
+            .flat_map(|section| section.task_ids.iter().copied())
+            .collect();
+        assert_eq!(listed.len(), 2, "both projects' release tasks list flat");
+        assert!(
+            view.sections
+                .iter()
+                .all(|section| section.project_label.is_none()),
+            "no thread/project nesting"
+        );
+        let _ = SectionKind::NeedsYou;
     }
 }

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -15,6 +15,7 @@ pub enum Surface {
     Unarchive,
     Project,
     FindBoardPane,
+    ResolveContext,
     GlobalHelp,
     Usage,
 }
@@ -37,6 +38,7 @@ pub fn route<S: AsRef<str>>(
         if arg.starts_with('-') {
             let surface = match arg {
                 "--find-board-pane" => Surface::FindBoardPane,
+                "--resolve-context" => Surface::ResolveContext,
                 "--help" => Surface::GlobalHelp,
                 _ => return Surface::Usage,
             };
@@ -107,6 +109,18 @@ mod tests {
     fn find_board_pane_with_extra_argument_is_usage() {
         assert_eq!(
             route(["tsk", "--find-board-pane", "extra"], None),
+            Surface::Usage
+        );
+    }
+
+    #[test]
+    fn resolve_context_is_a_hidden_global_surface() {
+        assert_eq!(
+            route(["tsk", "--resolve-context"], None),
+            Surface::ResolveContext
+        );
+        assert_eq!(
+            route(["tsk", "--resolve-context", "extra"], None),
             Surface::Usage
         );
     }

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::{ProvenanceOrigin, TaskEvent, TaskEventKind, UndoEntry, UNDO_CAP};
+use crate::scope::paths_equivalent;
 
 /// Human-facing task progress. Source of truth for board state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -223,8 +224,8 @@ impl DomainState {
     /// Whether the project record for `path` carries the archived flag.
     pub fn is_project_archived(&self, path: &str) -> bool {
         self.projects
-            .get(path)
-            .is_some_and(|record| record.archived)
+            .iter()
+            .any(|(stored, record)| record.archived && paths_equivalent(stored, path))
     }
 
     /// Scope paths of every archived project, sorted.
@@ -259,17 +260,29 @@ impl DomainState {
         if !self.has_project_task(path) && !self.projects.contains_key(path) {
             return Err(DomainError::UnknownProject(path.to_string()));
         }
+        let stored_path = self
+            .projects
+            .keys()
+            .find(|stored| paths_equivalent(stored, path))
+            .cloned()
+            .unwrap_or_else(|| path.to_string());
         self.projects
-            .insert(path.to_string(), ProjectRecord { archived: true });
-        self.project_intents.insert(path.to_string(), true);
+            .insert(stored_path.clone(), ProjectRecord { archived: true });
+        self.project_intents.insert(stored_path, true);
         Ok(true)
     }
 
     /// Unarchive a project: remove its record. `Ok(false)` when no record exists but
     /// tasks carry the scope (already unarchived); unknown when neither.
     pub fn unarchive_project(&mut self, path: &str) -> Result<bool, DomainError> {
-        if self.projects.remove(path).is_some() {
-            self.project_intents.insert(path.to_string(), false);
+        if let Some(stored_path) = self
+            .projects
+            .keys()
+            .find(|stored| paths_equivalent(stored, path))
+            .cloned()
+        {
+            self.projects.remove(&stored_path);
+            self.project_intents.insert(stored_path, false);
             return Ok(true);
         }
         if self.has_project_task(path) {
@@ -280,7 +293,7 @@ impl DomainState {
 
     fn has_project_task(&self, path: &str) -> bool {
         self.tasks.iter().any(|task| {
-            matches!(&task.scope, TaskScope::Project { path: task_path } if task_path == path)
+            matches!(&task.scope, TaskScope::Project { path: task_path } if paths_equivalent(task_path, path))
         })
     }
 

--- a/src/fsperm.rs
+++ b/src/fsperm.rs
@@ -13,6 +13,21 @@ use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::Path;
 
+#[cfg(test)]
+thread_local! {
+    static BEFORE_LOCK_OPEN: std::cell::RefCell<Option<Box<dyn FnOnce()>>> = const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn run_before_lock_open_hook() {
+    if let Some(hook) = BEFORE_LOCK_OPEN.with(|slot| slot.borrow_mut().take()) {
+        hook();
+    }
+}
+
+#[cfg(not(test))]
+fn run_before_lock_open_hook() {}
+
 /// Create `path` (recursively) as a user-private directory (`0700` on Unix),
 /// stripping any group/other access from one that already exists. Stricter
 /// existing modes are kept.
@@ -82,14 +97,80 @@ pub fn create_private_file(path: &Path) -> io::Result<File> {
 /// Open (or create) a lock file without truncating it, `0600` on Unix when
 /// created. Existing files are tightened by the caller after open.
 pub fn open_lock_file(path: &Path) -> io::Result<File> {
+    // An absent entry is created atomically. If another process wins that race, retry
+    // through the existing-file path, which never creates through a newly planted link.
+    for _ in 0..3 {
+        let before = match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => Some(metadata),
+            Ok(_) => return invalid_lock_path(),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error),
+        };
+        run_before_lock_open_hook();
+        let result = match before.as_ref() {
+            Some(_) => lock_open_options(false).open(path),
+            None => lock_open_options(true).open(path),
+        };
+        let file = match result {
+            Ok(file) => file,
+            Err(error) if before.is_none() && error.kind() == io::ErrorKind::AlreadyExists => {
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        let opened = file.metadata()?;
+        let current = match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => metadata,
+            Ok(_) => return invalid_lock_path(),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
+        if opened.file_type().is_file()
+            && same_file_identity(&opened, &current)
+            && before
+                .as_ref()
+                .is_none_or(|before| same_file_identity(before, &opened))
+        {
+            return Ok(file);
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::WouldBlock,
+        "lock path changed repeatedly while opening",
+    ))
+}
+
+fn lock_open_options(create_new: bool) -> OpenOptions {
     let mut options = OpenOptions::new();
-    options.read(true).write(true).create(true).truncate(false);
+    options
+        .read(true)
+        .write(true)
+        .create_new(create_new)
+        .truncate(false);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
-    options.open(path)
+    options
+}
+
+fn invalid_lock_path<T>() -> io::Result<T> {
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "lock path must be a regular file, not a symlink",
+    ))
+}
+
+#[cfg(unix)]
+fn same_file_identity(a: &fs::Metadata, b: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    a.dev() == b.dev() && a.ino() == b.ino()
+}
+
+#[cfg(not(unix))]
+fn same_file_identity(a: &fs::Metadata, b: &fs::Metadata) -> bool {
+    a.file_type().is_file() && b.file_type().is_file()
 }
 
 /// Tighten an existing file to owner-only (`0600`) on Unix by stripping
@@ -143,6 +224,53 @@ mod tests {
             let _ = fs::set_permissions(self.0.join("target"), fs::Permissions::from_mode(0o700));
             let _ = fs::remove_dir_all(&self.0);
         }
+    }
+
+    #[test]
+    fn open_lock_file_does_not_follow_an_absent_path_symlink_race() {
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("tsk-fsperm-lock-race-{}-{seq}", std::process::id()));
+        fs::create_dir_all(&root).expect("mkdir root");
+        let _guard = TempDirGuard(root.clone());
+        let lock = root.join("lock");
+        let target = root.join("outside-target");
+        let hook_lock = lock.clone();
+        let hook_target = target.clone();
+        BEFORE_LOCK_OPEN.with(|slot| {
+            *slot.borrow_mut() = Some(Box::new(move || {
+                symlink(&hook_target, &hook_lock).expect("publish symlink");
+            }));
+        });
+
+        open_lock_file(&lock).expect_err("a raced symlink must be rejected");
+        assert!(
+            !target.exists(),
+            "the raced symlink target must not be created"
+        );
+    }
+
+    #[test]
+    fn open_lock_file_reuses_regular_inode_and_rejects_nonfiles() {
+        use std::os::unix::fs::MetadataExt;
+
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "tsk-fsperm-lock-inode-{}-{seq}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("mkdir root");
+        let _guard = TempDirGuard(root.clone());
+        let lock = root.join("lock");
+        let first = open_lock_file(&lock).expect("first opener");
+        let second = open_lock_file(&lock).expect("second opener");
+        let first_metadata = first.metadata().expect("first metadata");
+        let second_metadata = second.metadata().expect("second metadata");
+        assert_eq!(first_metadata.dev(), second_metadata.dev());
+        assert_eq!(first_metadata.ino(), second_metadata.ino());
+
+        fs::create_dir(root.join("not-a-file")).expect("non-file entry");
+        open_lock_file(&root.join("not-a-file")).expect_err("non-file lock path must fail");
     }
 
     #[test]

--- a/src/fsperm.rs
+++ b/src/fsperm.rs
@@ -113,7 +113,10 @@ pub fn open_lock_file(path: &Path) -> io::Result<File> {
         };
         let file = match result {
             Ok(file) => file,
-            Err(error) if before.is_none() && error.kind() == io::ErrorKind::AlreadyExists => {
+            Err(error)
+                if (before.is_none() && error.kind() == io::ErrorKind::AlreadyExists)
+                    || (before.is_some() && error.kind() == io::ErrorKind::NotFound) =>
+            {
                 continue;
             }
             Err(error) => return Err(error),
@@ -248,6 +251,29 @@ mod tests {
             !target.exists(),
             "the raced symlink target must not be created"
         );
+    }
+
+    #[test]
+    fn open_lock_file_retries_when_existing_inode_disappears_before_open() {
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "tsk-fsperm-lock-removed-{}-{seq}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("mkdir root");
+        let _guard = TempDirGuard(root.clone());
+        let lock = root.join("lock");
+        fs::write(&lock, "old lock").expect("existing lock");
+        let hook_lock = lock.clone();
+        BEFORE_LOCK_OPEN.with(|slot| {
+            *slot.borrow_mut() = Some(Box::new(move || {
+                fs::remove_file(hook_lock).expect("remove between stat and open");
+            }));
+        });
+        let file = open_lock_file(&lock).expect("retry the disappearing inode");
+        assert!(file.metadata().expect("opened lock").is_file());
+        assert!(lock.is_file());
+        file.try_lock().expect("replacement inode is lockable");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod context;
 pub mod domain;
 pub(crate) mod fsperm;
+pub mod reopen;
 pub mod save_recovery;
 pub mod scope;
 pub mod store;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 //! tsk binary entry.
 
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, IsTerminal, Read, Write};
 use std::process::ExitCode;
 
 use tsk_tui::cli::router::{route, Surface};
@@ -9,6 +9,7 @@ fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
     match route(&args, std::env::var(tsk_tui::app::MODE_ENV).ok().as_deref()) {
         Surface::FindBoardPane => find_board_pane_main(),
+        Surface::ResolveContext => resolve_context_main(),
         Surface::GlobalHelp => {
             println!(
                 "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | --find-board-pane | --help\n\nCommands:\n  add    create one task or apply a JSON plan\n  steps  add, toggle, rename, or remove one step on a task\n  list   inspect tasks\n  status set a task's human status\n  edit   update a task's title or notes\n  trash  restore a trashed task\n  archive    keep a task off the working views\n  unarchive  put an archived task back\n  project    archive or unarchive a project\n\nRun `tsk add --help`, `tsk steps --help`, `tsk list --help`, `tsk status --help`, `tsk edit --help`, `tsk trash --help`, `tsk archive --help`, `tsk unarchive --help`, or `tsk project --help` for command details."
@@ -40,6 +41,41 @@ fn usage_exit() -> ExitCode {
         "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | --find-board-pane | --help"
     );
     ExitCode::from(2)
+}
+
+/// Internal launcher helper: turn the host's invocation JSON into a one-shot
+/// request for an already-running board, then print the resolved repository.
+fn resolve_context_main() -> ExitCode {
+    const MAX_CONTEXT_BYTES: usize = 64 * 1024;
+    let mut json = String::new();
+    if io::stdin()
+        .take((MAX_CONTEXT_BYTES + 1) as u64)
+        .read_to_string(&mut json)
+        .is_err()
+        || json.len() > MAX_CONTEXT_BYTES
+    {
+        eprintln!("tsk --resolve-context: invalid context payload");
+        return ExitCode::from(1);
+    }
+    let raw = match serde_json::from_str::<tsk_tui::context::RawHostContext>(&json) {
+        Ok(raw) => raw,
+        Err(error) => {
+            eprintln!("tsk --resolve-context: invalid context JSON: {error}");
+            return ExitCode::from(1);
+        }
+    };
+    let snapshot = tsk_tui::context::build_snapshot(&raw, std::path::PathBuf::new());
+    let project = snapshot.this_repo.clone();
+    if let Err(error) = tsk_tui::reopen::ReopenRequest::new(project.clone())
+        .write(&tsk_tui::store::default_state_dir())
+    {
+        eprintln!("tsk --resolve-context: {error}");
+        return ExitCode::from(1);
+    }
+    if let Some(project) = project {
+        println!("{}", project.display());
+    }
+    ExitCode::SUCCESS
 }
 
 fn headless_main(args: Vec<String>) -> ExitCode {

--- a/src/reopen.rs
+++ b/src/reopen.rs
@@ -1,0 +1,341 @@
+//! One-shot context handoff from the board launcher to an existing board pane.
+//!
+//! Herdr injects invocation context when a pane is created, but focusing an existing
+//! plugin pane cannot change that process environment. The launcher therefore writes a
+//! short-lived, private request in the normal tsk state directory before focusing the
+//! pane. The board consumes it during its idle tick.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::fsperm;
+use crate::store::{StoreSignature, TaskStore};
+
+const REQUEST_FILE: &str = "reopen.json";
+const LOCK_FILE: &str = "reopen.json.lock";
+const MAX_REQUEST_BYTES: usize = 8 * 1024;
+const MAX_PROJECT_BYTES: usize = 4096;
+const FORMAT_VERSION: u32 = 1;
+static REQUEST_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A validated invocation context handoff. `project: None` means the invoking
+/// directory was outside a repository and the board should select Desk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReopenRequest {
+    pub project: Option<PathBuf>,
+    id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireRequest {
+    version: u32,
+    id: String,
+    project: Option<String>,
+}
+
+impl ReopenRequest {
+    /// Build a request with a process-unique id. Validation is repeated at write time,
+    /// because callers may construct the value directly in tests or future adapters.
+    pub fn new(project: Option<PathBuf>) -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos().to_string())
+            .unwrap_or_else(|_| "0".to_string());
+        let seq = REQUEST_SEQ.fetch_add(1, Ordering::Relaxed);
+        Self {
+            project,
+            id: format!("{}-{}-{}", std::process::id(), now, seq),
+        }
+    }
+
+    /// Atomically publish this request under `state_dir`, using the same private-directory
+    /// policy as the store. A target symlink is replaced, never followed.
+    pub fn write(&self, state_dir: &Path) -> io::Result<()> {
+        let wire = self.to_wire()?;
+        let data = serde_json::to_vec(&wire)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        if data.len() > MAX_REQUEST_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "reopen request is too large",
+            ));
+        }
+        fsperm::ensure_private_dir(state_dir)?;
+        let _lock = RequestLock::acquire(state_dir)?;
+        let sequence = REQUEST_SEQ.fetch_add(1, Ordering::Relaxed);
+        let temp = state_dir.join(format!(
+            ".{REQUEST_FILE}.tmp.{}.{}",
+            std::process::id(),
+            sequence
+        ));
+        let target = state_dir.join(REQUEST_FILE);
+        let result = (|| {
+            let mut file = fsperm::create_private_file(&temp)?;
+            file.write_all(&data)?;
+            file.sync_all()?;
+            drop(file);
+            fs::rename(&temp, &target)?;
+            sync_directory(state_dir)
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temp);
+        }
+        result
+    }
+
+    fn to_wire(&self) -> io::Result<WireRequest> {
+        if self.id.is_empty() || self.id.len() > 128 || !valid_id(&self.id) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid reopen request id",
+            ));
+        }
+        let project = self
+            .project
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned());
+        if project.as_deref().is_some_and(|path| {
+            path.is_empty() || path.len() > MAX_PROJECT_BYTES || path.contains('\0')
+        }) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid reopen project path",
+            ));
+        }
+        Ok(WireRequest {
+            version: FORMAT_VERSION,
+            id: self.id.clone(),
+            project,
+        })
+    }
+
+    fn from_wire(wire: WireRequest) -> io::Result<Self> {
+        if wire.version != FORMAT_VERSION
+            || wire.id.is_empty()
+            || wire.id.len() > 128
+            || !valid_id(&wire.id)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid reopen request",
+            ));
+        }
+        let project = wire.project.map(PathBuf::from);
+        let request = Self {
+            project,
+            id: wire.id,
+        };
+        request.to_wire().map(|_| request)
+    }
+}
+
+fn valid_id(id: &str) -> bool {
+    id.bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+}
+
+fn sync_directory(path: &Path) -> io::Result<()> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        File::open(path)?.sync_all()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+struct RequestLock {
+    path: PathBuf,
+}
+
+impl RequestLock {
+    fn acquire(state_dir: &Path) -> io::Result<Self> {
+        let path = state_dir.join(LOCK_FILE);
+        for _ in 0..100 {
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            match options.open(&path) {
+                Ok(file) => {
+                    file.sync_all()?;
+                    return Ok(Self { path });
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    // A lock may belong to a live launcher or board. Never infer staleness
+                    // from its mtime: waiting is safe, deleting it can interleave two writers.
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "reopen request is busy",
+        ))
+    }
+}
+
+impl Drop for RequestLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Idle watcher for the one-shot reopen request.
+#[derive(Debug, Default)]
+pub struct ReopenWatch {
+    state_dir: PathBuf,
+    last_seen: Option<StoreSignature>,
+    pending: Option<ReopenRequest>,
+    pending_signature: Option<StoreSignature>,
+}
+
+impl ReopenWatch {
+    /// Start a board watcher and retire any request left by a prior board process.
+    /// A request present before startup is stale, not a new invocation.
+    pub fn seeded(store: &TaskStore) -> Self {
+        let path = store.path().join(REQUEST_FILE);
+        if let Ok(_lock) = RequestLock::acquire(store.path()) {
+            let _ = fs::remove_file(path);
+        }
+        Self {
+            state_dir: store.path().to_path_buf(),
+            ..Self::default()
+        }
+    }
+
+    /// Poll without consuming. The same request remains pending until `acknowledge`,
+    /// which lets a save-recovery or dirty editor defer the context switch safely.
+    pub fn poll(&mut self) -> Option<ReopenRequest> {
+        let Ok(_lock) = RequestLock::acquire(&self.state_dir) else {
+            return self.pending.clone();
+        };
+        let path = self.request_path();
+        let signature = request_signature(&path);
+        if self.pending.is_some() {
+            if signature != self.pending_signature {
+                self.pending = self.read_request(&path);
+                self.pending_signature = self.pending.as_ref().and(signature);
+            }
+            return self.pending.clone();
+        }
+        if signature == self.last_seen {
+            return None;
+        }
+        self.last_seen = signature;
+        self.pending = self.read_request(&path);
+        self.pending_signature = self.pending.as_ref().and(signature);
+        self.pending.clone()
+    }
+
+    /// Mark the currently applied request handled and remove its file. If another
+    /// invocation replaced it meanwhile, leave that newer request for the next poll.
+    pub fn acknowledge(&mut self) {
+        let Ok(_lock) = RequestLock::acquire(&self.state_dir) else {
+            return;
+        };
+        let path = self.request_path();
+        if self
+            .pending_signature
+            .is_some_and(|signature| request_signature(&path) == Some(signature))
+        {
+            let _ = fs::remove_file(path);
+            self.last_seen = None;
+        }
+        self.pending = None;
+        self.pending_signature = None;
+    }
+
+    fn request_path(&self) -> PathBuf {
+        self.state_dir.join(REQUEST_FILE)
+    }
+
+    fn read_request(&self, path: &Path) -> Option<ReopenRequest> {
+        let metadata = fs::symlink_metadata(path).ok()?;
+        if !metadata.file_type().is_file() || metadata.len() as usize > MAX_REQUEST_BYTES {
+            let _ = fs::remove_file(path);
+            return None;
+        }
+        let mut file = fs::File::open(path).ok()?;
+        let mut bytes = Vec::new();
+        Read::by_ref(&mut file)
+            .take((MAX_REQUEST_BYTES + 1) as u64)
+            .read_to_end(&mut bytes)
+            .ok()?;
+        if bytes.len() > MAX_REQUEST_BYTES {
+            let _ = fs::remove_file(path);
+            return None;
+        }
+        let wire = serde_json::from_slice::<WireRequest>(&bytes).ok();
+        let request = wire.and_then(|wire| ReopenRequest::from_wire(wire).ok());
+        if request.is_none() {
+            let _ = fs::remove_file(path);
+        }
+        request
+    }
+}
+
+fn request_signature(path: &Path) -> Option<StoreSignature> {
+    let metadata = fs::metadata(path).ok()?;
+    let modified = metadata.modified().ok()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Some(StoreSignature {
+            dev: metadata.dev(),
+            ino: metadata.ino(),
+            modified,
+            len: metadata.len(),
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        Some(StoreSignature {
+            modified,
+            len: metadata.len(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_ids_are_safe_and_unique() {
+        let a = ReopenRequest::new(None);
+        let b = ReopenRequest::new(None);
+        assert_ne!(a.id, b.id);
+        assert!(valid_id(&a.id));
+    }
+
+    #[test]
+    fn request_lock_serializes_claim_and_acknowledge_operations() {
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-lock-{}-{}",
+            std::process::id(),
+            REQUEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let lock = RequestLock::acquire(&dir).expect("first lock");
+        let second = RequestLock::acquire(&dir);
+        assert!(
+            second.is_err(),
+            "a concurrent writer cannot claim the request lock"
+        );
+        drop(lock);
+        assert!(RequestLock::acquire(&dir).is_ok());
+        let _ = fs::remove_dir_all(dir);
+    }
+}

--- a/src/reopen.rs
+++ b/src/reopen.rs
@@ -5,7 +5,7 @@
 //! short-lived, private request in the normal tsk state directory before focusing the
 //! pane. The board consumes it during its idle tick.
 
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -152,31 +152,23 @@ fn sync_directory(path: &Path) -> io::Result<()> {
 }
 
 struct RequestLock {
-    path: PathBuf,
+    _file: File,
 }
 
 impl RequestLock {
+    /// Acquire the persistent lock inode with a bounded wait. Ownership is the OS
+    /// advisory lock, not the inode, so a crash releases it without unlinking anything.
     fn acquire(state_dir: &Path) -> io::Result<Self> {
         let path = state_dir.join(LOCK_FILE);
+        let file = crate::fsperm::open_lock_file(&path)?;
+        crate::fsperm::tighten_file(&path);
         for _ in 0..100 {
-            let mut options = OpenOptions::new();
-            options.write(true).create_new(true);
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::OpenOptionsExt;
-                options.mode(0o600);
-            }
-            match options.open(&path) {
-                Ok(file) => {
-                    file.sync_all()?;
-                    return Ok(Self { path });
-                }
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                    // A lock may belong to a live launcher or board. Never infer staleness
-                    // from its mtime: waiting is safe, deleting it can interleave two writers.
+            match file.try_lock() {
+                Ok(()) => return Ok(Self { _file: file }),
+                Err(std::fs::TryLockError::WouldBlock) => {
                     std::thread::sleep(Duration::from_millis(5));
                 }
-                Err(error) => return Err(error),
+                Err(std::fs::TryLockError::Error(error)) => return Err(error),
             }
         }
         Err(io::Error::new(
@@ -184,11 +176,21 @@ impl RequestLock {
             "reopen request is busy",
         ))
     }
-}
 
-impl Drop for RequestLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+    /// One nonblocking claim for the board's idle path. A competing writer must
+    /// never stall the event loop.
+    fn try_acquire(state_dir: &Path) -> io::Result<Self> {
+        let path = state_dir.join(LOCK_FILE);
+        let file = crate::fsperm::open_lock_file(&path)?;
+        crate::fsperm::tighten_file(&path);
+        match file.try_lock() {
+            Ok(()) => Ok(Self { _file: file }),
+            Err(std::fs::TryLockError::WouldBlock) => Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "reopen request is busy",
+            )),
+            Err(std::fs::TryLockError::Error(error)) => Err(error),
+        }
     }
 }
 
@@ -199,6 +201,7 @@ pub struct ReopenWatch {
     last_seen: Option<StoreSignature>,
     pending: Option<ReopenRequest>,
     pending_signature: Option<StoreSignature>,
+    deferred_notice_sent: bool,
 }
 
 impl ReopenWatch {
@@ -218,43 +221,82 @@ impl ReopenWatch {
     /// Poll without consuming. The same request remains pending until `acknowledge`,
     /// which lets a save-recovery or dirty editor defer the context switch safely.
     pub fn poll(&mut self) -> Option<ReopenRequest> {
-        let Ok(_lock) = RequestLock::acquire(&self.state_dir) else {
-            return self.pending.clone();
-        };
+        self.poll_with_pre_lock(|| {})
+    }
+
+    fn poll_with_pre_lock(&mut self, before_lock: impl FnOnce()) -> Option<ReopenRequest> {
         let path = self.request_path();
-        let signature = request_signature(&path);
-        if self.pending.is_some() {
-            if signature != self.pending_signature {
-                self.pending = self.read_request(&path);
-                self.pending_signature = self.pending.as_ref().and(signature);
-            }
+        let preflight = request_signature(&path);
+        let Some(preflight) = preflight else {
+            // A removed pending request was withdrawn, so do not keep delivering a stale
+            // context switch or its one-shot deferred notice.
+            self.pending = None;
+            self.pending_signature = None;
+            self.deferred_notice_sent = false;
+            return None;
+        };
+        if self.pending_signature == Some(preflight) {
             return self.pending.clone();
         }
-        if signature == self.last_seen {
+        if self.pending.is_none() && self.last_seen == Some(preflight) {
             return None;
         }
-        self.last_seen = signature;
+        before_lock();
+        let Ok(_lock) = RequestLock::try_acquire(&self.state_dir) else {
+            return self.pending.clone();
+        };
+        // The preflight avoids lock-file work for unchanged requests only. Pair the
+        // bytes read while holding the writer lock with this authoritative signature.
+        let Some(signature) = request_signature(&path) else {
+            self.pending = None;
+            self.pending_signature = None;
+            self.deferred_notice_sent = false;
+            return None;
+        };
+        if self.pending_signature == Some(signature) {
+            return self.pending.clone();
+        }
+        if self.pending.is_none() && self.last_seen == Some(signature) {
+            return None;
+        }
+        self.last_seen = Some(signature);
         self.pending = self.read_request(&path);
-        self.pending_signature = self.pending.as_ref().and(signature);
+        self.pending_signature = self.pending.as_ref().map(|_| signature);
+        self.deferred_notice_sent = false;
         self.pending.clone()
+    }
+
+    /// Return true once per pending request when a dirty editor defers it.
+    pub fn mark_deferred_notice(&mut self) -> bool {
+        if self.deferred_notice_sent {
+            false
+        } else {
+            self.deferred_notice_sent = true;
+            true
+        }
     }
 
     /// Mark the currently applied request handled and remove its file. If another
     /// invocation replaced it meanwhile, leave that newer request for the next poll.
     pub fn acknowledge(&mut self) {
-        let Ok(_lock) = RequestLock::acquire(&self.state_dir) else {
+        let Some(signature) = self.pending_signature else {
+            return;
+        };
+        // Application already happened. Consume it before opportunistic cleanup so a
+        // busy lock cannot cause the same request to be applied on every idle tick.
+        self.pending = None;
+        self.pending_signature = None;
+        self.last_seen = Some(signature);
+        self.deferred_notice_sent = false;
+
+        let Ok(_lock) = RequestLock::try_acquire(&self.state_dir) else {
             return;
         };
         let path = self.request_path();
-        if self
-            .pending_signature
-            .is_some_and(|signature| request_signature(&path) == Some(signature))
-        {
+        if request_signature(&path) == Some(signature) {
             let _ = fs::remove_file(path);
             self.last_seen = None;
         }
-        self.pending = None;
-        self.pending_signature = None;
     }
 
     fn request_path(&self) -> PathBuf {
@@ -336,6 +378,169 @@ mod tests {
         );
         drop(lock);
         assert!(RequestLock::acquire(&dir).is_ok());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn request_lock_is_released_when_owner_process_exits() {
+        if std::env::var_os("TSK_REOPEN_LOCK_CHILD").is_some() {
+            let dir = PathBuf::from(std::env::var_os("TSK_REOPEN_LOCK_DIR").expect("lock dir"));
+            let _lock = RequestLock::acquire(&dir).expect("child lock");
+            std::process::exit(0);
+        }
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-crash-{}-{}",
+            std::process::id(),
+            REQUEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let output = std::process::Command::new(std::env::current_exe().expect("test binary"))
+            .args([
+                "--exact",
+                "reopen::tests::request_lock_is_released_when_owner_process_exits",
+                "--nocapture",
+            ])
+            .env("TSK_REOPEN_LOCK_CHILD", "1")
+            .env("TSK_REOPEN_LOCK_DIR", &dir)
+            .output()
+            .expect("child");
+        assert!(
+            output.status.success(),
+            "child lock owner failed: {output:?}"
+        );
+        assert!(
+            dir.join(LOCK_FILE).exists(),
+            "the persistent lock inode must outlive a crashing owner"
+        );
+        assert!(
+            RequestLock::acquire(&dir).is_ok(),
+            "crash-released lock remains held"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn idle_poll_without_a_request_does_not_create_or_touch_a_lock() {
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-idle-{}-{}",
+            std::process::id(),
+            REQUEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let store = TaskStore::new(&dir);
+        let mut watch = ReopenWatch::seeded(&store);
+        fs::remove_file(dir.join(LOCK_FILE)).expect("remove setup lock");
+        assert_eq!(watch.poll(), None);
+        assert!(
+            !dir.join(LOCK_FILE).exists(),
+            "idle poll created a lock file"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn idle_poll_does_not_wait_for_a_competing_lock() {
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-nonblocking-{}-{}",
+            std::process::id(),
+            REQUEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let store = TaskStore::new(&dir);
+        let mut watch = ReopenWatch::seeded(&store);
+        ReopenRequest::new(Some(PathBuf::from("/repo/pending")))
+            .write(&dir)
+            .expect("request");
+        let lock = RequestLock::acquire(&dir).expect("competing lock");
+        let started = std::time::Instant::now();
+        assert_eq!(watch.poll(), None);
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "idle poll must not wait for the writer's 500ms bounded acquisition"
+        );
+        drop(lock);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn unchanged_pending_request_does_not_reopen_or_tighten_the_lock() {
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-unchanged-{}-{}",
+            std::process::id(),
+            REQUEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let store = TaskStore::new(&dir);
+        let mut watch = ReopenWatch::seeded(&store);
+        ReopenRequest::new(Some(PathBuf::from("/repo/pending")))
+            .write(&dir)
+            .expect("request");
+        let request = watch.poll().expect("pending request");
+        fs::remove_file(dir.join(LOCK_FILE)).expect("remove lock");
+        assert_eq!(watch.poll(), Some(request));
+        assert!(
+            !dir.join(LOCK_FILE).exists(),
+            "unchanged pending request reopened the lock file"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn poll_pairs_the_post_lock_signature_with_the_request_bytes() {
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-signature-race-{}-{}",
+            std::process::id(),
+            REQUEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let store = TaskStore::new(&dir);
+        let mut watch = ReopenWatch::seeded(&store);
+        ReopenRequest::new(Some(PathBuf::from("/repo/a")))
+            .write(&dir)
+            .expect("request a");
+        let request = watch
+            .poll_with_pre_lock(|| {
+                ReopenRequest::new(Some(PathBuf::from("/repo/b")))
+                    .write(&dir)
+                    .expect("replace with b");
+            })
+            .expect("replacement request");
+        assert_eq!(request.project.as_deref(), Some(Path::new("/repo/b")));
+        watch.acknowledge();
+        assert_eq!(watch.poll(), None, "acknowledged b must not replay");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn acknowledge_is_nonblocking_and_consumes_a_request_when_cleanup_is_busy() {
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-ack-nonblocking-{}-{}",
+            std::process::id(),
+            REQUEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let store = TaskStore::new(&dir);
+        let mut watch = ReopenWatch::seeded(&store);
+        ReopenRequest::new(Some(PathBuf::from("/repo/a")))
+            .write(&dir)
+            .expect("request a");
+        assert!(watch.poll().is_some(), "request applied");
+        let lock = RequestLock::acquire(&dir).expect("competing cleanup lock");
+        let started = std::time::Instant::now();
+        watch.acknowledge();
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "acknowledgement must not wait for the writer's 500ms bounded acquisition"
+        );
+        drop(lock);
+        assert_eq!(watch.poll(), None, "handled request must not replay");
+        ReopenRequest::new(Some(PathBuf::from("/repo/b")))
+            .write(&dir)
+            .expect("newer request");
+        assert_eq!(
+            watch.poll().expect("newer request").project.as_deref(),
+            Some(Path::new("/repo/b"))
+        );
         let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,7 +1,8 @@
 //! Shared project-path resolution for board and headless capture.
 
-use std::collections::BTreeSet;
-use std::path::Path;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 
 use crate::context::InvocationSnapshot;
 use crate::domain::{DomainState, TaskScope};
@@ -31,8 +32,92 @@ pub fn archived_path_contains(paths: &BTreeSet<String>, path: &str) -> bool {
     paths.iter().any(|stored| paths_equivalent(stored, path))
 }
 
+/// Bounded path identity memo used by one board query. It is intentionally owned by
+/// the operation, never global, so aliases are refreshed on the next query and a
+/// missing path cannot become permanently stale.
+#[derive(Debug, Default)]
+pub(crate) struct PathIdentityCache {
+    canonical: RefCell<BTreeMap<String, Option<PathBuf>>>,
+}
+
+impl PathIdentityCache {
+    pub(crate) fn equivalent(&self, a: &str, b: &str) -> bool {
+        if trim(a) == trim(b) {
+            return true;
+        }
+        self.canonical_path(a) == self.canonical_path(b) && self.canonical_path(a).is_some()
+    }
+
+    fn canonical_path(&self, path: &str) -> Option<PathBuf> {
+        let key = trim(path).to_string();
+        if let Some(value) = self.canonical.borrow().get(&key) {
+            return value.clone();
+        }
+        let value = std::fs::canonicalize(Path::new(&key)).ok();
+        self.canonical.borrow_mut().insert(key, value.clone());
+        value
+    }
+
+    pub(crate) fn contains(&self, paths: &BTreeSet<String>, path: &str) -> bool {
+        paths.iter().any(|stored| self.equivalent(stored, path))
+    }
+}
+
 fn trim(path: &str) -> &str {
-    path.trim_end_matches('/')
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() && path.starts_with('/') {
+        "/"
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn path_identity_cache_preserves_root_and_refreshes_per_query() {
+        let root = std::env::temp_dir().join(format!(
+            "tsk-path-identities-{}-{}",
+            std::process::id(),
+            TEMP_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let first = root.join("first");
+        let second = root.join("second");
+        let alias = root.join("alias");
+        fs::create_dir_all(&first).expect("first directory");
+        fs::create_dir(&second).expect("second directory");
+        let root_alias = root.join("root-alias");
+        symlink("/", &root_alias).expect("root alias");
+        symlink(&first, &alias).expect("first alias");
+
+        let cache = PathIdentityCache::default();
+        assert!(cache.equivalent("/", &root_alias.to_string_lossy()));
+        assert!(!cache.equivalent(
+            &root.join("missing").to_string_lossy(),
+            &first.to_string_lossy()
+        ));
+        assert!(cache.equivalent(&alias.to_string_lossy(), &first.to_string_lossy()));
+
+        fs::remove_file(&alias).expect("remove old alias");
+        symlink(&second, &alias).expect("second alias");
+        assert!(
+            !cache.equivalent(&alias.to_string_lossy(), &second.to_string_lossy()),
+            "one query keeps its original identity snapshot"
+        );
+        assert!(
+            PathIdentityCache::default()
+                .equivalent(&alias.to_string_lossy(), &second.to_string_lossy()),
+            "a fresh query must observe the new alias target"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
 }
 
 /// Resolve command-line project/global scope flags with the same default and basename

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,9 +1,39 @@
 //! Shared project-path resolution for board and headless capture.
 
 use std::collections::BTreeSet;
+use std::path::Path;
 
 use crate::context::InvocationSnapshot;
 use crate::domain::{DomainState, TaskScope};
+
+/// Whether two project-path spellings name the same directory.
+///
+/// Comparison only: stored scope identity is never rewritten through this. When both
+/// sides exist on disk they are compared canonically, so the same repository reached
+/// as `/tmp/repo` and `/private/tmp/repo` (macOS) still matches. A missing or
+/// nonexistent side falls back to lexical equality, so a stored path whose directory
+/// has not been created yet behaves exactly as before.
+pub fn paths_equivalent(a: &str, b: &str) -> bool {
+    if trim(a) == trim(b) {
+        return true;
+    }
+    match (
+        std::fs::canonicalize(Path::new(a)),
+        std::fs::canonicalize(Path::new(b)),
+    ) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
+/// Whether a stored project-path set contains an equivalent spelling.
+pub fn archived_path_contains(paths: &BTreeSet<String>, path: &str) -> bool {
+    paths.iter().any(|stored| paths_equivalent(stored, path))
+}
+
+fn trim(path: &str) -> &str {
+    path.trim_end_matches('/')
+}
 
 /// Resolve command-line project/global scope flags with the same default and basename
 /// rules used by headless add.

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -14,13 +14,13 @@ use crate::ui::capture::{CaptureField, TITLE_REQUIRED_MESSAGE};
 use crate::ui::edit::{flatten_line_breaks, EditBuffer};
 use crate::ui::input::BoardIntent;
 use crate::ui::mouse::BoardPopup;
-use crate::ui::queue::{ThreadProjectCollapseKey, ARCHIVED_HEADER_ROW_ID};
+use crate::ui::queue::{NavTab, ARCHIVED_HEADER_ROW_ID};
 use crate::ui::tier::{FocusedSurface, WideStage};
 
 use super::commands::{resolve_board_command, CommandSurface};
 use super::model::{
     BoardForm, BoardInputMode, BoardLocation, BoardModel, IntentOutcome, PickerTab,
-    ProjectPickerState, ProjectScopeOption, StepEditor, StepEditorSave, TaskEditSave,
+    ProjectPickerState, ProjectScopeOption, ProjectsView, StepEditor, StepEditorSave, TaskEditSave,
 };
 
 /// What the row says when an action that aims at the selection is asked for on a board that
@@ -398,6 +398,7 @@ fn apply_board_intent(
             model.invalidate_quick_add_stash();
             if let Some(quick_add) = model.quick_add.as_mut() {
                 quick_add.title.insert_char(character);
+                refresh_quick_add_scope(model, domain);
                 model.clear_message();
             }
             return Ok(IntentOutcome::None);
@@ -406,6 +407,7 @@ fn apply_board_intent(
             model.invalidate_quick_add_stash();
             if let Some(quick_add) = model.quick_add.as_mut() {
                 quick_add.title.insert_text(&flatten_line_breaks(&text));
+                refresh_quick_add_scope(model, domain);
                 model.clear_message();
             }
             return Ok(IntentOutcome::None);
@@ -414,6 +416,7 @@ fn apply_board_intent(
             model.invalidate_quick_add_stash();
             if let Some(quick_add) = model.quick_add.as_mut() {
                 quick_add.title.backspace();
+                refresh_quick_add_scope(model, domain);
                 model.clear_message();
             }
             return Ok(IntentOutcome::None);
@@ -422,6 +425,7 @@ fn apply_board_intent(
             model.invalidate_quick_add_stash();
             if let Some(quick_add) = model.quick_add.as_mut() {
                 quick_add.title.delete_forward();
+                refresh_quick_add_scope(model, domain);
                 model.clear_message();
             }
             return Ok(IntentOutcome::None);
@@ -654,10 +658,24 @@ fn apply_board_intent(
         }
 
         BoardIntent::SelectNext => {
+            // The projects index is keyboard-navigable in place: its rows are project
+            // rows, never tasks, so the pin stays untouched while the cursor moves.
+            if model.nav_tab() == NavTab::Projects
+                && matches!(model.projects_view, ProjectsView::Overview)
+            {
+                model.move_projects_cursor(true);
+                return Ok(IntentOutcome::None);
+            }
             model.select_next();
             return Ok(IntentOutcome::None);
         }
         BoardIntent::SelectPrev => {
+            if model.nav_tab() == NavTab::Projects
+                && matches!(model.projects_view, ProjectsView::Overview)
+            {
+                model.move_projects_cursor(false);
+                return Ok(IntentOutcome::None);
+            }
             model.select_prev();
             return Ok(IntentOutcome::None);
         }
@@ -1047,9 +1065,9 @@ fn apply_board_intent(
                 model.leave_archived_focus();
             }
             let options = model.project_options();
-            // Highlight the option that matches the current deck scope (session filter).
+            // Highlight the option that matches the current destination.
             let selected = match &model.board_location {
-                BoardLocation::Home { .. } => 0,
+                BoardLocation::Desk | BoardLocation::Projects => 0,
                 BoardLocation::Project(path) | BoardLocation::ArchivedProject(path) => options
                     .iter()
                     .position(|option| option == &ProjectScopeOption::Project(path.clone()))
@@ -1140,8 +1158,131 @@ fn apply_board_intent(
             model.clear_message();
             return Ok(IntentOutcome::None);
         }
-        BoardIntent::SelectHomeTab(tab) => {
-            model.set_home_tab(tab);
+        BoardIntent::SelectNavTab(tab) => {
+            let switched = model.select_nav_tab(tab);
+            // Slot 2 never changes meaning: with no project selected it opens the
+            // picker, and picking it again while its project is open answers the
+            // painted `▾` with the same picker. From the read-only archived focus,
+            // `2` stays put (the focus already occupies slot 2).
+            if !switched && tab == NavTab::ProjectBoard && !model.focus_is_archived() {
+                return apply_board_intent(
+                    domain,
+                    model,
+                    BoardIntent::OpenProjectSelector,
+                    snapshot,
+                );
+            }
+            model.clear_message();
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::OpenThreadFilterPicker => {
+            if model.project_picker.is_some() || model.popup == BoardPopup::SaveRecovery {
+                return Ok(IntentOutcome::None);
+            }
+            model.close_command_surface();
+            model.close_popup();
+            model.close_help();
+            model.open_thread_filter_picker();
+            if model.list_picker.is_some() {
+                model.input_mode = BoardInputMode::ListPicker;
+            }
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::OpenProjectsViewPicker => {
+            if model.project_picker.is_some() || model.popup == BoardPopup::SaveRecovery {
+                return Ok(IntentOutcome::None);
+            }
+            model.close_command_surface();
+            model.close_popup();
+            model.close_help();
+            model.open_projects_view_picker();
+            if model.list_picker.is_some() {
+                model.input_mode = BoardInputMode::ListPicker;
+            }
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::ListPickerNext => {
+            model.move_list_picker(true);
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::ListPickerPrev => {
+            model.move_list_picker(false);
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::ListPickerQueryInsert(character) => {
+            model.list_picker_query_insert(character);
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::ListPickerQueryInsertText(text) => {
+            model.list_picker_query_insert_text(&flatten_line_breaks(&text));
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::ListPickerQueryBackspace => {
+            model.list_picker_query_backspace();
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::SelectListOption(index) => {
+            // Mouse-only jump onto a visible picker row, same discipline as
+            // `SelectCommand`/`SelectProjectOption`: name the row directly.
+            if let Some(picker) = model.list_picker.as_mut() {
+                picker.selected = index;
+            }
+            return apply_board_intent(domain, model, BoardIntent::ConfirmListPicker, snapshot);
+        }
+        BoardIntent::ConfirmListPicker => {
+            if model.confirm_list_picker().is_some() {
+                let previous = model.selection_id;
+                let previous_visible = model.visible_ids();
+                model.reanchor_selection(previous, &previous_visible);
+                model.input_mode = BoardInputMode::Normal;
+            }
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::CancelListPicker => {
+            model.cancel_list_picker();
+            model.input_mode = BoardInputMode::Normal;
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::FocusProjectsSearch => {
+            if model.nav_tab() == NavTab::Projects
+                && matches!(model.projects_view, ProjectsView::Overview)
+            {
+                model.input_mode = BoardInputMode::ProjectsSearch;
+            }
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::ProjectsQueryInsert(character) => {
+            if model.nav_tab() == NavTab::Projects
+                && matches!(model.projects_view, ProjectsView::Overview)
+            {
+                model.projects_query.push(character);
+                model.projects_selected = 0;
+            }
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::ProjectsQueryInsertText(text) => {
+            if model.nav_tab() == NavTab::Projects
+                && matches!(model.projects_view, ProjectsView::Overview)
+            {
+                model.projects_query.push_str(&text);
+                model.projects_selected = 0;
+            }
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::ProjectsQueryBackspace => {
+            model.projects_query.pop();
+            model.projects_selected = 0;
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::SelectProjectRow(index) => {
+            // Mouse route onto an index row: select it, and a direct click opens the
+            // project in slot 2. Index rows are navigation, never tasks: no task verb
+            // can reach them because `selected_id()` stays untouched.
+            let Some(row) = model.project_rows().into_iter().nth(index) else {
+                return Ok(IntentOutcome::None);
+            };
+            model.projects_selected = index;
+            model.set_board_scope(ProjectScopeOption::Project(PathBuf::from(row.path)));
             model.clear_message();
             return Ok(IntentOutcome::None);
         }
@@ -1149,99 +1290,6 @@ fn apply_board_intent(
             let previous_visible = model.visible_ids();
             let previous = model.selection_id;
             if model.toggle_all_groups() {
-                model.reanchor_selection(previous, &previous_visible);
-            }
-            model.clear_message();
-            return Ok(IntentOutcome::None);
-        }
-        BoardIntent::SelectSectionProject(index) => {
-            let Some(path) = model
-                .queue_view()
-                .sections
-                .get(index)
-                .and_then(|section| section.project_label.clone())
-            else {
-                return Ok(IntentOutcome::None);
-            };
-            let path_buf = PathBuf::from(path.clone());
-            let now = Instant::now();
-            let is_double = model
-                .last_project_header_click
-                .as_ref()
-                .is_some_and(|(at, last)| {
-                    last == &path_buf && now.duration_since(*at) <= ROW_DOUBLE_CLICK_WINDOW
-                });
-            if is_double {
-                model.last_project_header_click = None;
-                model.set_board_scope(ProjectScopeOption::Project(path_buf));
-            } else {
-                let previous_visible = model.visible_ids();
-                let previous = model.selection_id;
-                model.toggle_project_collapsed(&path);
-                model.last_project_header_click = Some((now, path_buf));
-                model.reanchor_selection(previous, &previous_visible);
-            }
-            model.clear_message();
-            return Ok(IntentOutcome::None);
-        }
-        BoardIntent::SelectSectionThread(index) => {
-            let Some(thread) = model
-                .queue_view()
-                .sections
-                .get(index)
-                .and_then(|section| section.thread_label.clone())
-            else {
-                return Ok(IntentOutcome::None);
-            };
-            let previous_visible = model.visible_ids();
-            let previous = model.selection_id;
-            model.toggle_thread_collapsed(&thread);
-            model.reanchor_selection(previous, &previous_visible);
-            model.clear_message();
-            return Ok(IntentOutcome::None);
-        }
-        BoardIntent::SelectSectionThreadProject {
-            section_idx,
-            subgroup_idx,
-        } => {
-            let view = model.queue_view();
-            let Some(section) = view.sections.get(section_idx) else {
-                return Ok(IntentOutcome::None);
-            };
-            let Some(subgroup) = section.thread_subgroups.get(subgroup_idx) else {
-                return Ok(IntentOutcome::None);
-            };
-            let Some(path) = subgroup.project_path.clone().map(PathBuf::from) else {
-                let previous_visible = model.visible_ids();
-                let previous = model.selection_id;
-                let key = ThreadProjectCollapseKey {
-                    thread: section.thread_label.clone().unwrap_or_default(),
-                    project_path: None,
-                };
-                model.toggle_thread_project_collapsed(key);
-                model.reanchor_selection(previous, &previous_visible);
-                model.clear_message();
-                return Ok(IntentOutcome::None);
-            };
-            let now = Instant::now();
-            let is_double = model
-                .last_project_header_click
-                .as_ref()
-                .is_some_and(|(at, last)| {
-                    last == &path && now.duration_since(*at) <= ROW_DOUBLE_CLICK_WINDOW
-                });
-            if is_double {
-                model.last_project_header_click = None;
-                model.set_board_scope(ProjectScopeOption::Project(path));
-            } else {
-                let previous_visible = model.visible_ids();
-                let previous = model.selection_id;
-                let key = ThreadProjectCollapseKey {
-                    thread: section.thread_label.clone().unwrap_or_default(),
-                    project_path: Some(path.to_string_lossy().into_owned()),
-                };
-                model.toggle_thread_project_collapsed(key);
-                model.last_project_header_click = Some((now, path));
                 model.reanchor_selection(previous, &previous_visible);
             }
             model.clear_message();
@@ -1309,6 +1357,17 @@ fn apply_board_intent(
             return Ok(IntentOutcome::None);
         }
         BoardIntent::OpenTaskPage => {
+            // The projects index: Enter opens the selected project in slot 2. Index
+            // rows are navigation; the task-page surface never opens from them.
+            if model.nav_tab() == NavTab::Projects
+                && matches!(model.projects_view, ProjectsView::Overview)
+            {
+                if let Some(row) = model.selected_project_row() {
+                    model.set_board_scope(ProjectScopeOption::Project(PathBuf::from(row.path)));
+                    model.clear_message();
+                }
+                return Ok(IntentOutcome::None);
+            }
             // Enter on the archived header toggles the group instead of opening a page:
             // the header is chrome, never a task.
             if model.archived_header_selected() {
@@ -1566,6 +1625,12 @@ fn apply_board_intent(
                 model.input_mode = BoardInputMode::Normal;
                 return Ok(IntentOutcome::None);
             }
+            if model.input_mode == BoardInputMode::ProjectsSearch {
+                model.projects_query.clear();
+                model.projects_selected = 0;
+                model.input_mode = BoardInputMode::Normal;
+                return Ok(IntentOutcome::None);
+            }
             if model.input_mode == BoardInputMode::FormScopeDropdown {
                 model.close_form_scope_dropdown(false);
                 return Ok(IntentOutcome::None);
@@ -1630,7 +1695,14 @@ fn apply_board_intent(
                 model.leave_archived_focus();
                 return Ok(IntentOutcome::None);
             }
-            return Ok(IntentOutcome::Quit);
+            // A typed index search goes before anything else: the first Esc clears it,
+            // and the board-level Esc never quits (ctrl+q is the explicit quit).
+            if !model.projects_query.is_empty() {
+                model.projects_query.clear();
+                model.projects_selected = 0;
+                return Ok(IntentOutcome::None);
+            }
+            return Ok(IntentOutcome::None);
         }
         // The five intents below aim at the selection, and an empty board has none. Each
         // says so rather than returning to a row that has just been cleared for an action
@@ -2039,6 +2111,28 @@ fn open_task_page_on(domain: &DomainState, model: &mut BoardModel, id: Uuid) {
 
 /// The row double-click window: a second click on the same row within it opens the page.
 const ROW_DOUBLE_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// Keep the quick-add line's visible destination truthful while `!p` tokens are typed.
+///
+/// The row names where Enter will save (`Add to desk` / `Add to <project>`), so every
+/// buffer change re-lifts the tokens: an override applies the moment it is typed and
+/// reverts the moment it is deleted. A malformed `!p` (an archived project) leaves the
+/// last good destination painted; the save itself refuses with the same words.
+fn refresh_quick_add_scope(model: &mut BoardModel, domain: &DomainState) {
+    let Some(quick_add) = model.quick_add.as_ref() else {
+        return;
+    };
+    let default = quick_add.default.clone();
+    let lifted = lift_quick_add_tokens(
+        quick_add.title.value(),
+        domain,
+        quick_add.snapshot.as_ref().as_ref(),
+    )
+    .ok();
+    if let Some(quick_add) = model.quick_add.as_mut() {
+        quick_add.scope = lifted.and_then(|lifted| lifted.scope).unwrap_or(default);
+    }
+}
 
 /// Save the line through the same capture pipeline the expanded form uses.
 fn quick_add_save(

--- a/src/ui/board/chrome.rs
+++ b/src/ui/board/chrome.rs
@@ -72,6 +72,8 @@ fn edit_chrome_legends(mode: BoardInputMode) -> [&'static str; 3] {
         | BoardInputMode::FormScopeDropdown
         | BoardInputMode::Normal
         | BoardInputMode::ProjectPicker
+        | BoardInputMode::ListPicker
+        | BoardInputMode::ProjectsSearch
         | BoardInputMode::SaveRecovery
         | BoardInputMode::LaunchCard
         | BoardInputMode::Palette

--- a/src/ui/board/commands.rs
+++ b/src/ui/board/commands.rs
@@ -4,7 +4,7 @@ use crate::domain::HumanStatus;
 use crate::ui::input::BoardIntent;
 use crate::ui::mouse::BoardPopup;
 
-use super::model::{BoardLocation, BoardModel, BoardTab};
+use super::model::BoardModel;
 
 /// Transient command surface open over the board, never durable state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -105,14 +105,6 @@ impl BoardModel {
             command("undo", BoardIntent::Undo),
             command("done drawer", BoardIntent::ToggleDoneDrawer),
         ]);
-        if matches!(
-            self.board_location,
-            BoardLocation::Home {
-                tab: BoardTab::Projects | BoardTab::Threads,
-            }
-        ) {
-            commands.push(command("toggle groups", BoardIntent::ToggleAllGroups));
-        }
         commands.extend_from_slice(&[
             command("help", BoardIntent::OpenHelp),
             command("quit", BoardIntent::Quit),

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -8,11 +8,15 @@ use ratatui::Frame;
 
 use crate::domain::{HumanStatus, TaskScope};
 use crate::ui::capture::CaptureField;
-use crate::ui::edit::{escaped_line_window, wrap_text, wrapped_draft_rows, wrapped_edit_rows};
+use crate::ui::edit::{
+    escaped_line_window, wrap_text, wrapped_draft_rows, wrapped_edit_rows, EditBuffer,
+};
 use crate::ui::input::{help_card_lines, keymap_help_label};
 use crate::ui::mouse::BoardPopup;
+use crate::ui::queue::ThreadFilter;
 use crate::ui::render::{
-    self, FormScopeDropdown, PaletteCommandRow, QueueFrameModel, QueueOverlay, VerbEntry,
+    self, BoardSurface, FormScopeDropdown, NavChipKind, NavChipPaint, NavPaint, PaletteCommandRow,
+    QueueFrameModel, QueueOverlay, VerbEntry,
 };
 use crate::ui::tier;
 use crate::ui::{present_line, terminal_text};
@@ -21,7 +25,7 @@ use super::chrome::{notice_framed, row_width, DELETE_NOTICE_UNDO};
 use super::commands::CommandSurface;
 use super::model::{
     project_option_label, project_scope_option_label, BoardForm, BoardInputMode, BoardLocation,
-    BoardModel, PickerTab, ProjectScopeOption,
+    BoardModel, PickerTab, ProjectScopeOption, ProjectsView,
 };
 
 /// Verb bar for the base board list: labels follow the selected task.
@@ -86,6 +90,45 @@ pub fn board_verb_items(model: &BoardModel) -> Vec<VerbEntry<'static>> {
     };
     if let Some(task) = page_task {
         return task_page_verb_items(model, task);
+    }
+
+    if model.nav_tab() == crate::ui::queue::NavTab::Projects
+        && matches!(model.projects_view(), ProjectsView::Overview)
+    {
+        if model.input_mode() == BoardInputMode::ProjectsSearch {
+            return vec![
+                VerbEntry {
+                    key: "esc",
+                    label: "clear search",
+                },
+                VerbEntry {
+                    key: "enter",
+                    label: "open",
+                },
+            ];
+        }
+        return vec![
+            VerbEntry {
+                key: "/",
+                label: "search projects",
+            },
+            VerbEntry {
+                key: "enter",
+                label: "open",
+            },
+            VerbEntry {
+                key: "v",
+                label: "view",
+            },
+            VerbEntry {
+                key: ":",
+                label: help(":", "palette"),
+            },
+            VerbEntry {
+                key: "?",
+                label: help("?", "help"),
+            },
+        ];
     }
 
     let mut entries = Vec::with_capacity(7);
@@ -667,6 +710,55 @@ fn build_task_page_overlay<'a>(
     }
 }
 
+/// The persistent navigation row's paint for this model: fixed tabs, slot 2's label,
+/// and the active destination's right-side control.
+fn nav_paint(model: &BoardModel) -> NavPaint {
+    let slot2_label = match &model.board_location {
+        // AC-41: the read-only focus says so in its slot.
+        BoardLocation::ArchivedProject(path) => {
+            format!("{} \u{b7} archived", project_option_label(path.as_path()))
+        }
+        BoardLocation::Project(path) => project_option_label(path.as_path()),
+        // Slot 2 carries the remembered project even while another destination is active.
+        BoardLocation::Desk | BoardLocation::Projects => model
+            .selected_project()
+            .map(project_option_label)
+            .unwrap_or_else(|| "select project".to_string()),
+    };
+    let chip = match (&model.board_location, model.projects_view()) {
+        (BoardLocation::Project(_), _) => Some(NavChipPaint {
+            label: model.thread_filter().label(),
+            kind: NavChipKind::ThreadFilter,
+        }),
+        (BoardLocation::Projects, ProjectsView::Overview) => Some(NavChipPaint {
+            label: "Overview".to_string(),
+            kind: NavChipKind::ProjectsView,
+        }),
+        (BoardLocation::Projects, ProjectsView::Thread(name)) => Some(NavChipPaint {
+            label: format!("#{name}"),
+            kind: NavChipKind::ProjectsView,
+        }),
+        _ => None,
+    };
+    NavPaint {
+        active: model.nav_tab(),
+        slot2_label,
+        slot2_project: model.selected_project().is_some() || model.focus_is_archived(),
+        chip,
+    }
+}
+
+/// Which surface the list paints, from the destination and its View control.
+fn board_surface(model: &BoardModel) -> BoardSurface {
+    match model.effective_lens() {
+        crate::ui::queue::BoardLens::Desk => BoardSurface::Desk,
+        crate::ui::queue::BoardLens::Projects => BoardSurface::Projects,
+        crate::ui::queue::BoardLens::ThreadView(_) => BoardSurface::ThreadView,
+        crate::ui::queue::BoardLens::Project(_)
+        | crate::ui::queue::BoardLens::ArchivedProject(_) => BoardSurface::Project,
+    }
+}
+
 /// Draw the board into any ratatui frame (live TTY or [`ratatui::backend::TestBackend`]).
 ///
 /// the paints the queue frame via [`render::draw_queue_frame`]. Classic master-detail
@@ -706,6 +798,9 @@ struct OverlayPayloads<'a> {
     help_lines: Vec<String>,
     palette_commands: Vec<PaletteCommandRow<'a>>,
     scope_options: Vec<String>,
+    list_picker_options: Vec<String>,
+    list_picker_query: Option<String>,
+    list_picker_selected: usize,
     scope_tabs: Option<render::PickerTabsPaint>,
     launch_card_name: Option<String>,
     scope_selected: usize,
@@ -762,6 +857,16 @@ impl<'a> OverlayPayloads<'a> {
         } else {
             Vec::new()
         };
+        let list_picker_options = model
+            .visible_list_picker_options()
+            .into_iter()
+            .map(|(_, option)| match option.count {
+                Some(count) => format!("{}  {count}", option.label),
+                None => option.label,
+            })
+            .collect();
+        let list_picker_query = model.list_picker_query().map(str::to_string);
+        let list_picker_selected = model.list_picker_selected();
         let scope_selected = if model.popup() == BoardPopup::ProjectPicker {
             model.project_picker_index().unwrap_or(0)
         } else {
@@ -786,6 +891,9 @@ impl<'a> OverlayPayloads<'a> {
             help_lines,
             palette_commands,
             scope_options,
+            list_picker_options,
+            list_picker_query,
+            list_picker_selected,
             scope_selected,
             scope_tabs,
             launch_card_name,
@@ -798,6 +906,25 @@ impl<'a> OverlayPayloads<'a> {
         model: &'a BoardModel,
         geo: &tier::TierGeometry,
     ) -> Option<QueueOverlay<'a>> {
+        if model.input_mode() == BoardInputMode::ProjectsSearch {
+            let input_width = (geo.row_width as usize).saturating_sub(2);
+            let query = EditBuffer::new(
+                model.projects_query(),
+                model.projects_query().chars().count(),
+            );
+            let (text, cursor_col) = escaped_line_window(&query, input_width);
+            return Some(QueueOverlay::ProjectsSearch {
+                input: crate::ui::render::BottomInputSlot {
+                    text,
+                    cursor_col,
+                    placeholder: "search projects…   enter open · esc close",
+                    refusal: None,
+                    message: None,
+                    above_rows: Vec::new(),
+                    cursor_row_offset: 0,
+                },
+            });
+        }
         if let Some(quick_add) = model.quick_add.as_ref().filter(|_| {
             matches!(
                 model.input_mode(),
@@ -823,6 +950,12 @@ impl<'a> OverlayPayloads<'a> {
             // Continuations paint top-first (the painter stacks them upward by index).
             let above_rows: Vec<String> = window[..window.len().saturating_sub(1)].to_vec();
             let multiline = window.len() > 1;
+            // The row names its destination so Enter never has to move the user's
+            // view to prove where the task went.
+            let destination = match &quick_add.scope {
+                TaskScope::Project { path } => project_option_label(Path::new(path)).to_string(),
+                TaskScope::Global => "desk".to_string(),
+            };
             return Some(QueueOverlay::QuickAdd {
                 input: crate::ui::render::BottomInputSlot {
                     text: title,
@@ -842,7 +975,7 @@ impl<'a> OverlayPayloads<'a> {
                     )
                     .unwrap_or(0),
                 },
-                project_scope: matches!(quick_add.scope, TaskScope::Project { .. }),
+                destination,
                 recovery: model.input_mode() == BoardInputMode::SaveRecovery,
             });
         }
@@ -860,11 +993,28 @@ impl<'a> OverlayPayloads<'a> {
         if let Some(name) = self.launch_card_name.as_deref() {
             return Some(QueueOverlay::LaunchCard { name });
         }
+        if model.input_mode() == BoardInputMode::ListPicker {
+            let title = match model.list_picker_kind() {
+                Some(crate::ui::board::ListPickerKind::ProjectsView) => "projects View",
+                _ => "thread filter",
+            };
+            return Some(QueueOverlay::ScopeDropdown {
+                options: &self.list_picker_options,
+                selected: self
+                    .list_picker_selected
+                    .min(self.list_picker_options.len().saturating_sub(1)),
+                tabs: None,
+                title: Some(title),
+                query: self.list_picker_query.as_deref(),
+            });
+        }
         if model.popup() == BoardPopup::ProjectPicker {
             return Some(QueueOverlay::ScopeDropdown {
                 options: &self.scope_options,
                 selected: self.scope_selected,
                 tabs: self.scope_tabs,
+                title: None,
+                query: None,
             });
         }
         None
@@ -981,14 +1131,7 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
     let geo = tier::resolve(area.width, area.height);
     let queue_view = model.queue_view();
     let selection_id = model.saved_task.or(model.selection_id);
-    let scope_label = match &model.board_location {
-        BoardLocation::Home { .. } => String::new(),
-        BoardLocation::Project(path) => project_option_label(path.as_path()),
-        // AC-41: the read-only focus says so on the chip.
-        BoardLocation::ArchivedProject(path) => {
-            format!("{} \u{b7} archived", project_option_label(path.as_path()))
-        }
-    };
+    let surface = board_surface(model);
     let (status_owned, status_undo_offset) = status_row_content(model);
     // The verb bar entries: computed from the selection and the open surface so the label
     // is true for the row it describes, and drawn from this one function -- the same one
@@ -1012,12 +1155,17 @@ fn draw_board_impl(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
         tasks: &model.tasks,
         view: &queue_view,
         selection_id,
-        at_home: model.at_home(),
-        home_tab: model.home_tab(),
-        scope_label: &scope_label,
-        collapsed_projects: &model.collapsed_projects,
-        collapsed_threads: &model.collapsed_threads,
-        collapsed_thread_projects: &model.collapsed_thread_projects,
+        nav: nav_paint(model),
+        surface,
+        thread_labels: surface == BoardSurface::Project
+            && model.thread_filter() == &ThreadFilter::All,
+        show_project_meta: matches!(surface, BoardSurface::Desk | BoardSurface::ThreadView),
+        projects: &queue_view.projects,
+        projects_index: surface == BoardSurface::Projects
+            && matches!(model.projects_view(), ProjectsView::Overview),
+        projects_cursor: model.projects_cursor(),
+        projects_query: model.projects_query(),
+        summary: None,
         status_message: status_owned.as_deref(),
         status_undo_offset,
         verb_items: &verbs,
@@ -1081,14 +1229,7 @@ fn draw_wide_board(
     let queue_view = model.queue_view();
     let selection_id = model.saved_task.or(model.selection_id);
     let selected_task = selection_id.and_then(|id| model.tasks.iter().find(|task| task.id == id));
-    let scope_label = match &model.board_location {
-        BoardLocation::Home { .. } => String::new(),
-        BoardLocation::Project(path) => project_option_label(path.as_path()),
-        // AC-41: the read-only focus says so on the chip.
-        BoardLocation::ArchivedProject(path) => {
-            format!("{} \u{b7} archived", project_option_label(path.as_path()))
-        }
-    };
+    let surface = board_surface(model);
     let (status_owned, status_undo_offset) = status_row_content(model);
     let verbs = board_verb_items(model);
     let payloads = OverlayPayloads::collect(model);
@@ -1182,12 +1323,17 @@ fn draw_wide_board(
         tasks: &model.tasks,
         view: &queue_view,
         selection_id,
-        at_home: model.at_home(),
-        home_tab: model.home_tab(),
-        scope_label: &scope_label,
-        collapsed_projects: &model.collapsed_projects,
-        collapsed_threads: &model.collapsed_threads,
-        collapsed_thread_projects: &model.collapsed_thread_projects,
+        nav: nav_paint(model),
+        surface,
+        thread_labels: surface == BoardSurface::Project
+            && model.thread_filter() == &ThreadFilter::All,
+        show_project_meta: matches!(surface, BoardSurface::Desk | BoardSurface::ThreadView),
+        projects: &queue_view.projects,
+        projects_index: surface == BoardSurface::Projects
+            && matches!(model.projects_view(), ProjectsView::Overview),
+        projects_cursor: model.projects_cursor(),
+        projects_query: model.projects_query(),
+        summary: None,
         status_message: status_owned.as_deref(),
         status_undo_offset,
         verb_items: &verbs,
@@ -1206,10 +1352,10 @@ fn draw_wide_board(
     };
     let task_frame = QueueFrameModel {
         overlay: task_overlay.clone(),
-        at_home: false,
-        scope_label: "",
         list_scroll: 0,
         follow_list: false,
+        projects: &[],
+        projects_index: false,
         ..board_frame.clone()
     };
     let footer_frame = QueueFrameModel {

--- a/src/ui/board/mod.rs
+++ b/src/ui/board/mod.rs
@@ -11,6 +11,6 @@ pub use chrome::DELETE_NOTICE_UNDO;
 pub use commands::{resolve_board_command, BoardCommand, CommandSurface};
 pub use draw::{board_hit_map, board_verb_items, draw_board};
 pub use model::{
-    project_option_label, BoardInputMode, BoardModel, BoardTab, IntentOutcome, PickerTab,
-    ProjectScopeOption, SaveResolution, WalkthroughOutcome, BOARD_TITLE,
+    project_option_label, BoardInputMode, BoardModel, BoardTab, IntentOutcome, ListPickerKind,
+    PickerTab, ProjectScopeOption, ProjectsView, SaveResolution, WalkthroughOutcome, BOARD_TITLE,
 };

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -1650,7 +1650,7 @@ impl BoardModel {
             BoardLocation::Project(path) => Some(path.to_string_lossy().into_owned()),
             _ => None,
         };
-        let in_project = |task: &Task| matches!(&task.scope, TaskScope::Project { path } if Some(path.clone()) == scope);
+        let in_project = |task: &Task| matches!(&task.scope, TaskScope::Project { path } if scope.as_deref().is_some_and(|scope| paths_equivalent(path, scope)));
         let mut threads: BTreeMap<String, usize> = BTreeMap::new();
         let mut unthreaded = 0usize;
         let mut open = 0usize;
@@ -3079,6 +3079,40 @@ mod tests {
             "another project's thread must not offer itself here"
         );
         assert_eq!(model.list_picker_kind(), Some(ListPickerKind::ThreadFilter));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn thread_filter_picker_matches_equivalent_project_aliases() {
+        use std::fs;
+        use std::os::unix::fs::symlink;
+        let root = std::env::temp_dir().join(format!("tsk-thread-alias-{}", std::process::id()));
+        let real = root.join("real");
+        let alias = root.join("alias");
+        fs::create_dir_all(&real).expect("real");
+        symlink(&real, &alias).expect("alias");
+        let mut domain = DomainState::new();
+        let id = create(
+            &mut domain,
+            "aliased",
+            project(alias.to_string_lossy().as_ref()),
+        );
+        domain
+            .edit(
+                id,
+                "aliased",
+                None,
+                project(alias.to_string_lossy().as_ref()),
+                Some("nav".into()),
+            )
+            .expect("thread");
+        let mut model = BoardModel::from_domain(&domain, Some(real));
+        model.open_thread_filter_picker();
+        assert!(model
+            .visible_list_picker_options()
+            .iter()
+            .any(|(_, option)| option.label == "#nav"));
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::context::InvocationSnapshot;
 use crate::domain::{DomainState, HumanStatus, Task, TaskScope};
+use crate::scope::{archived_path_contains, paths_equivalent};
 use crate::ui::capture::CaptureField;
 use crate::ui::edit::{seeded_draft, EditBuffer};
 use crate::ui::input::{
@@ -19,7 +20,7 @@ use crate::ui::input::{
 use crate::ui::mouse::BoardPopup;
 pub use crate::ui::queue::BoardTab;
 use crate::ui::queue::{
-    self, visible_task_ids, BoardLens, QueueView, SectionKind, ThreadProjectCollapseKey,
+    self, visible_task_ids, BoardLens, NavTab, ProjectRow, QueueView, SectionKind, ThreadFilter,
 };
 use crate::ui::selection;
 use crate::ui::terminal_text;
@@ -77,8 +78,13 @@ pub enum BoardInputMode {
     SaveRecovery,
     /// Searchable command palette is open.
     Palette,
-    /// the help card is open.
+    /// The help card is open.
     Help,
+    /// A searchable list picker owns input (project-board thread filter, projects
+    /// index View selector). Query typing, movement, Enter applies, Esc cancels.
+    ListPicker,
+    /// The projects index search field owns text input until Enter or Esc.
+    ProjectsSearch,
     /// Single-line status-row capture from board `+`.
     QuickAdd,
 }
@@ -132,30 +138,80 @@ pub enum ProjectScopeOption {
     Project(PathBuf),
 }
 
-/// Session-only board location: home tabs or one focused project.
+/// Session-only board location: the three persistent destinations plus the read-only
+/// archived focus. Tab digits never shift meaning; slot 2 carries the selected project.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum BoardLocation {
-    Home {
-        tab: BoardTab,
-    },
+    /// Tab 1: the global overview plus the desk backlog.
+    Desk,
+    /// Tab 2: the selected project's board (the old project focus).
     Project(PathBuf),
+    /// Tab 3: the projects index, or its cross-project thread View.
+    Projects,
     /// Read-only focus on an archived project, opened with Enter from the picker's
-    /// archived tab (AC-41). Session-only: leaving it hides those tasks again.
+    /// archived tab (AC-41). Session-only: leaving it hides those tasks again. It
+    /// occupies slot 2 while open.
     ArchivedProject(PathBuf),
 }
 
 impl BoardLocation {
     pub(super) fn lens(&self) -> BoardLens<'_> {
         match self {
-            Self::Home { tab } => BoardLens::Home(*tab),
+            Self::Desk => BoardLens::Desk,
             Self::Project(path) => BoardLens::Project(path.as_path()),
+            Self::Projects => BoardLens::Projects,
             Self::ArchivedProject(path) => BoardLens::ArchivedProject(path.as_path()),
         }
     }
 
     pub(super) fn at_home(&self) -> bool {
-        matches!(self, Self::Home { .. })
+        matches!(self, Self::Desk | Self::Projects)
     }
+}
+
+/// The projects index's View control: the project overview (default) or one
+/// cross-project thread's flat task board.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ProjectsView {
+    #[default]
+    Overview,
+    Thread(String),
+}
+
+/// Which searchable list picker is open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListPickerKind {
+    /// The project board's thread filter (bare `t`).
+    ThreadFilter,
+    /// The projects index's View selector (bare `v`).
+    ProjectsView,
+}
+
+/// One choice inside a searchable list picker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListPickerOption {
+    pub label: String,
+    pub count: Option<usize>,
+    pub value: ListPickerValue,
+}
+
+/// What confirming a list-picker option applies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ListPickerValue {
+    ThreadAll,
+    ThreadNamed(String),
+    ThreadWithout,
+    ProjectsOverview,
+    ProjectsThread(String),
+}
+
+/// An open searchable list picker (thread filter / projects view). Session-only.
+#[derive(Debug, Clone)]
+pub(super) struct ListPickerState {
+    pub kind: ListPickerKind,
+    pub options: Vec<ListPickerOption>,
+    pub selected: usize,
+    pub query: String,
 }
 /// The immutable value a board form carries for its whole lifetime.
 ///
@@ -181,9 +237,11 @@ pub(super) struct QuickAddState {
     /// The immutable invocation snapshot, retained for title prefill, token resolution, and
     /// capture provenance.
     pub(super) snapshot: Box<Option<InvocationSnapshot>>,
-    /// Default from the selected single-project board scope or invocation snapshot, overridden
-    /// by a parsed title token.
+    /// Current visible destination: the default below, overridden while `!p` tokens are
+    /// typed. The input row paints it (`Add to …`).
     pub(super) scope: TaskScope,
+    /// The pre-token destination this draft saves to when no `!p` override applies.
+    pub(super) default: TaskScope,
 }
 
 impl QuickAddState {
@@ -195,6 +253,7 @@ impl QuickAddState {
         Self {
             title: seeded_draft(title),
             snapshot: Box::new(snapshot),
+            default: scope.clone(),
             scope,
         }
     }
@@ -550,7 +609,7 @@ fn board_form_scope_options(
     // AC-39: no dropdown offers an archived project. The form's own initial scope is
     // exempt: a task already sitting in an archived project keeps it as its value.
     let filed = |scope: &TaskScope| match scope {
-        TaskScope::Project { path } => archived.contains(path),
+        TaskScope::Project { path } => archived_path_contains(archived, path),
         TaskScope::Global => false,
     };
     push(initial_scope.clone(), &mut options);
@@ -588,18 +647,26 @@ pub struct BoardModel {
     /// query can filter hidden tasks without re-deriving from records.
     pub(super) archived_projects: BTreeSet<String>,
     pub(super) this_repo: Option<PathBuf>,
-    /// Session board location (home tab or focused project). Not durable.
+    /// Session board location (active surface). Not durable.
     pub(super) board_location: BoardLocation,
+    /// Slot 2 identity, independent from the active surface (for example after switching to
+    /// Desk or the Projects index). Not durable.
+    pub(super) selected_project: Option<PathBuf>,
     /// Wide-slider stage. Focus and single-pane presentation derive from it. Session-only.
     pub(super) wide_stage: WideStage,
     /// Stage `Enter` (or a row double-click) left for the full task page; `Esc` returns there.
     pub(super) stage_origin: Option<WideStage>,
-    /// Project-group headers collapsed on the Projects tab.
-    pub(super) collapsed_projects: HashSet<String>,
-    /// Thread-group headers collapsed on the Threads tab.
-    pub(super) collapsed_threads: HashSet<String>,
-    /// Project sub-headers collapsed under a thread on the Threads tab.
-    pub(super) collapsed_thread_projects: HashSet<ThreadProjectCollapseKey>,
+    /// The project board's session thread filter. It narrows every status section and
+    /// is cleared whenever the selected project changes.
+    pub(super) thread_filter: ThreadFilter,
+    /// The projects index's View: the project overview, or one cross-project thread.
+    pub(super) projects_view: ProjectsView,
+    /// The projects index's search query. Session-only.
+    pub(super) projects_query: String,
+    /// The projects index's selected row cursor. Session-only.
+    pub(super) projects_selected: usize,
+    /// Open searchable list picker (thread filter / projects view). Session-only.
+    pub(super) list_picker: Option<ListPickerState>,
     /// Whether the done drawer lists completed tasks. Session-only.
     pub(super) drawer_open: bool,
     /// The done drawer's archived group starts collapsed on every launch. Session-only.
@@ -700,20 +767,22 @@ pub enum SaveResolution {
 }
 
 impl BoardModel {
-    /// Build a board model with queue-local session state only.
+    /// Build a board model with queue-local session state only. The desk is the
+    /// default destination; [`Self::from_domain`] applies directory-aware startup.
     pub fn from_tasks(tasks: Vec<Task>, this_repo: Option<PathBuf>) -> Self {
         let mut model = Self {
             tasks,
             archived_projects: BTreeSet::new(),
-            this_repo,
-            board_location: BoardLocation::Home {
-                tab: BoardTab::Desk,
-            },
+            this_repo: this_repo.clone(),
+            board_location: BoardLocation::Desk,
+            selected_project: this_repo,
             wide_stage: WideStage::FullBoard,
             stage_origin: None,
-            collapsed_projects: HashSet::new(),
-            collapsed_threads: HashSet::new(),
-            collapsed_thread_projects: HashSet::new(),
+            thread_filter: ThreadFilter::All,
+            projects_view: ProjectsView::Overview,
+            projects_query: String::new(),
+            projects_selected: 0,
+            list_picker: None,
             drawer_open: false,
             archived_collapsed: true,
             launch_card: None,
@@ -749,31 +818,7 @@ impl BoardModel {
             message_restore: None,
         };
         model.seed_selection();
-        model.ensure_home_tab_has_visible_tasks();
         model
-    }
-
-    /// When the default desk tab would show no rows, open on projects (then threads) instead.
-    fn ensure_home_tab_has_visible_tasks(&mut self) {
-        if !self.board_location.at_home() || !self.visible_ids().is_empty() {
-            return;
-        }
-        let has_open = self.tasks.iter().any(|task| {
-            !task.soft_deleted && !self.is_hidden(task) && task.status != HumanStatus::Done
-        });
-        if !has_open {
-            return;
-        }
-        self.board_location = BoardLocation::Home {
-            tab: BoardTab::Projects,
-        };
-        self.seed_selection();
-        if self.visible_ids().is_empty() {
-            self.board_location = BoardLocation::Home {
-                tab: BoardTab::Threads,
-            };
-            self.seed_selection();
-        }
     }
 
     /// Current detail popup (status picker or more menu).
@@ -906,9 +951,24 @@ impl BoardModel {
     }
 
     /// Snapshot tasks from domain state (default agent kind; seed env at open).
+    ///
+    /// Directory-aware startup: launching inside a live repository opens that
+    /// project's board, empty or not (an empty board paints its own add hint).
+    /// Launching anywhere else opens the desk. An archived invocation repository is
+    /// handled by [`Self::offer_launch_card`] instead and stays on the desk.
     pub fn from_domain(state: &DomainState, this_repo: Option<PathBuf>) -> Self {
         let mut model = Self::from_tasks(state.tasks().to_vec(), this_repo);
         model.archived_projects = state.archived_projects();
+        if let Some(repo) = model.this_repo.clone() {
+            if !model.is_archived_project_path(&repo) {
+                let previous_visible = model.visible_ids();
+                model.board_location = BoardLocation::Project(repo);
+                model.reanchor_selection(None, &previous_visible);
+                model.seed_selection();
+            } else {
+                model.selected_project = None;
+            }
+        }
         model
     }
 
@@ -941,39 +1001,14 @@ impl BoardModel {
         }
         match &task.scope {
             TaskScope::Global => false,
-            TaskScope::Project { path } => self.archived_projects.contains(path),
+            TaskScope::Project { path } => archived_path_contains(&self.archived_projects, path),
         }
     }
 
-    /// Switch the home tab, when needed, so `id` would appear in [`Self::visible_ids`].
-    pub(super) fn reveal_task_on_home(&mut self, id: Uuid) {
-        if !self.board_location.at_home() || self.visible_ids().contains(&id) {
-            return;
-        }
-        let Some(task) = self
-            .tasks
-            .iter()
-            .find(|task| task.id == id && !task.soft_deleted && !self.is_hidden(task))
-        else {
-            return;
-        };
-        let tab = if task.thread.is_some() {
-            BoardTab::Threads
-        } else if matches!(task.scope, TaskScope::Project { .. }) {
-            BoardTab::Projects
-        } else {
-            BoardTab::Desk
-        };
-        self.board_location = BoardLocation::Home { tab };
-    }
-
-    fn ensure_selection_visible(&mut self) {
-        let Some(id) = self.selection_id else {
-            return;
-        };
-        self.reveal_task_on_home(id);
-    }
-
+    /// Navigation is never yanked by saves or background merges: a save reanchors the
+    /// pin only when the current destination already renders the saved task, and no
+    /// path switches the board to another project merely to reveal a row.
+    ///
     /// Replace task snapshot from domain (after mutation) and reanchor selection by id.
     pub fn sync_from_domain(&mut self, state: &DomainState) {
         // Capture the prior visible order before the snapshot is replaced, so reanchoring
@@ -989,27 +1024,25 @@ impl BoardModel {
             .filter(|task| !previous_id_set.contains(&task.id))
             .map(|task| task.id)
             .collect();
-        // A merge (or this board's own picker verb) may archive the project this board is
-        // focused on: reset the focus to home desk and name the project on the status row.
-        // The quick-add default is guarded at `OpenCapture`, which never resolves to an
-        // archived project, so the session default is left alone here.
+        // A merge (or this board's own picker verb) may archive the project slot 2 is
+        // showing: reset the destination to the desk and name the project on the status
+        // row. The quick-add default is guarded at `OpenCapture`, which never resolves to
+        // an archived project, so the session default is left alone here.
         // A read-only focus whose project came back (picker, CLI, or a sibling process)
-        // becomes an ordinary project focus: chip, dim rows and verbs all follow.
+        // becomes an ordinary project board: tab, dim rows and verbs all follow.
         if let BoardLocation::ArchivedProject(path) = &self.board_location {
-            if !self
-                .archived_projects
-                .contains(path.to_string_lossy().as_ref())
-            {
+            if !self.is_archived_project_path(path) {
+                self.selected_project = Some(path.clone());
                 self.board_location = BoardLocation::Project(path.clone());
             }
         }
         let focus_archived = match &self.board_location {
-            BoardLocation::Project(path) => self
-                .archived_projects
-                .contains(path.to_string_lossy().as_ref()),
+            BoardLocation::Project(path) => self.is_archived_project_path(path),
             // A read-only focus is deliberately on an archived project (AC-41): it is
             // not the accident this reset exists for.
-            BoardLocation::ArchivedProject(_) | BoardLocation::Home { .. } => false,
+            BoardLocation::ArchivedProject(_) | BoardLocation::Desk | BoardLocation::Projects => {
+                false
+            }
         };
         if focus_archived {
             let name = match &self.board_location {
@@ -1018,9 +1051,8 @@ impl BoardModel {
                 }
                 _ => String::new(),
             };
-            self.board_location = BoardLocation::Home {
-                tab: BoardTab::Desk,
-            };
+            self.board_location = BoardLocation::Desk;
+            self.selected_project = None;
             self.set_message(format!("project {name} is archived"));
         }
         let pinned_edit = self.task_edit_save.as_ref().map(|pending| pending.id);
@@ -1029,16 +1061,14 @@ impl BoardModel {
         self.finish_task_edit_save();
         self.finish_step_editor_save();
         if let Some(id) = pinned_edit.or(pinned_quick_add) {
-            // A save this surface just made owns the selection, but only when the current
-            // lens actually renders it (project focus never reveals across scopes).
-            self.reveal_task_on_home(id);
+            // A save this surface just made owns the selection, but navigation never
+            // follows it: the pin moves only when the current destination already
+            // renders the saved task, otherwise it anchors on the saved id's old
+            // position (or the prior pin) so nothing jumps to the first row.
             if self.visible_ids().contains(&id) {
                 self.retarget_selection(Some(id), SelectionRetarget::Reanchor);
                 self.follow_list.set(true);
             } else {
-                // Anchor on the saved id's old position when it had one (an edit that
-                // left this lens); otherwise fall back to the pre-sync selection so an
-                // externally invisible save cannot jump the pin to the first row.
                 let anchor = if previous_visible.contains(&id) {
                     Some(id)
                 } else {
@@ -1047,16 +1077,19 @@ impl BoardModel {
                 self.reanchor_selection(anchor, &previous_visible);
             }
         } else {
-            // Tasks merged in from disk are somebody else's work: never yank the home tab
-            // or selection toward them. An otherwise-empty view may surface the first one,
-            // so a board opened on nothing still lights up when captures arrive.
+            // Tasks merged in from disk are somebody else's work: never move the
+            // board's destination or selection toward them. An otherwise-empty view
+            // may surface the first one, but only when the current destination already
+            // renders it — the desk's global lanes usually do.
             if previous_visible.is_empty() {
                 if let Some(id) = new_ids.first() {
-                    self.reveal_task_on_home(*id);
+                    if self.visible_ids().contains(id) {
+                        self.retarget_selection(Some(*id), SelectionRetarget::Reanchor);
+                        self.follow_list.set(true);
+                    }
                 }
             }
             self.reanchor_selection(previous, &previous_visible);
-            self.ensure_selection_visible();
         }
     }
 
@@ -1070,47 +1103,177 @@ impl BoardModel {
         self.this_repo.as_deref()
     }
 
-    /// Whether the home tabs are visible (false in project focus).
+    /// Whether the persistent tabs read as "home" surfaces (quick-add scope defaults).
     pub fn at_home(&self) -> bool {
         self.board_location.at_home()
     }
 
-    /// Active home tab when at home; otherwise [`BoardTab::Desk`].
-    pub fn home_tab(&self) -> BoardTab {
+    /// Which navigation tab is active right now.
+    pub fn nav_tab(&self) -> NavTab {
         match &self.board_location {
-            BoardLocation::Home { tab } => *tab,
-            BoardLocation::Project(_) | BoardLocation::ArchivedProject(_) => BoardTab::Desk,
+            BoardLocation::Desk => NavTab::Desk,
+            BoardLocation::Project(_) | BoardLocation::ArchivedProject(_) => NavTab::ProjectBoard,
+            BoardLocation::Projects => NavTab::Projects,
         }
     }
 
-    pub(super) fn set_home_tab(&mut self, tab: BoardTab) {
-        // AC-45: `1`/`2`/`3` from the read-only archived focus go home, which hides that
-        // project's tasks again.
+    /// Switch to a navigation tab. `NavTab::ProjectBoard` with no selected project is
+    /// answered by the caller (the project picker opens instead — the slot never
+    /// changes meaning). Returns whether the board moved.
+    pub(super) fn select_nav_tab(&mut self, tab: NavTab) -> bool {
+        let target = match tab {
+            NavTab::Desk => BoardLocation::Desk,
+            NavTab::Projects => BoardLocation::Projects,
+            NavTab::ProjectBoard => {
+                let Some(path) = self.selected_project.clone() else {
+                    return false;
+                };
+                BoardLocation::Project(path)
+            }
+        };
+        if self.board_location == target {
+            return false;
+        }
+        // AC-45: `1`/`3` from the read-only archived focus leave it, which hides that
+        // project's tasks again. (`2` stays put: the archived focus already occupies
+        // slot 2.)
         if self.focus_is_archived() {
             let previous_visible = self.visible_ids();
-            self.board_location = BoardLocation::Home { tab };
+            self.board_location = target;
             self.reanchor_selection(None, &previous_visible);
             self.seed_selection();
-            return;
+            return true;
         }
-        let BoardLocation::Home { tab: current } = self.board_location else {
-            return;
-        };
-        if current == tab {
+        self.switch_location(target);
+        true
+    }
+
+    /// Move to `target` through the one shared guarded transition: reanchor by the
+    /// previous visible order, clear a project-scoped thread filter when the project
+    /// changes, and never touch open forms or save-recovery state.
+    pub(super) fn switch_location(&mut self, target: BoardLocation) {
+        if self.board_location == target {
             return;
         }
         let previous_visible = self.visible_ids();
         let previous = self.selection_id;
-        self.board_location = BoardLocation::Home { tab };
+        let same_project = matches!(
+            (&self.board_location, &target),
+            (BoardLocation::Project(a), BoardLocation::Project(b))
+                if paths_equivalent(&a.to_string_lossy(), &b.to_string_lossy())
+        );
+        if same_project {
+            // Equivalent spellings are the same stored project identity. Do not rewrite the
+            // selected path merely because a host supplied an alias, but an explicit reopen
+            // still clears its local thread filter.
+            self.thread_filter = ThreadFilter::All;
+            return;
+        }
+        self.thread_filter = ThreadFilter::All;
+        self.board_location = target;
         self.reanchor_selection(previous, &previous_visible);
     }
 
-    /// The selected project scope, when the session is focused on one project.
+    /// The selected project scope carried by slot 2, independent of the active surface.
     pub fn selected_project(&self) -> Option<&Path> {
+        self.selected_project.as_deref()
+    }
+
+    pub fn active_project(&self) -> Option<&Path> {
         match &self.board_location {
-            BoardLocation::Project(path) => Some(path.as_path()),
-            BoardLocation::ArchivedProject(_) | BoardLocation::Home { .. } => None,
+            BoardLocation::Project(path) | BoardLocation::ArchivedProject(path) => {
+                Some(path.as_path())
+            }
+            BoardLocation::Desk | BoardLocation::Projects => None,
         }
+    }
+
+    fn is_archived_project_path(&self, path: &Path) -> bool {
+        let path = path.to_string_lossy();
+        archived_path_contains(&self.archived_projects, &path)
+    }
+
+    /// Whether changing invocation context would discard or hide an unsaved draft.
+    /// Reopen requests defer while any editor or non-empty quick-add owns the user's text.
+    pub fn has_unsaved_work(&self) -> bool {
+        if self.task_session_dirty()
+            || self.quick_add_save.is_some()
+            || self.task_edit_save.is_some()
+        {
+            return true;
+        }
+        if self.form.is_some() && self.input_mode != BoardInputMode::TaskPage {
+            return true;
+        }
+        self.quick_add
+            .as_ref()
+            .is_some_and(|quick_add| !quick_add.title.value().is_empty())
+    }
+
+    /// Clear non-dirty presentation layers so a context switch lands on the target board,
+    /// rather than leaving a clean task page, picker, search, or empty quick-add in front of it.
+    fn dismiss_clean_surfaces_for_reopen(&mut self) {
+        self.detail_open = None;
+        self.wide_stage = WideStage::FullBoard;
+        self.stage_origin = None;
+        self.list_picker = None;
+        self.project_picker = None;
+        self.popup = BoardPopup::None;
+        self.surface = CommandSurface::None;
+        self.command_query.clear();
+        self.command_selected = 0;
+        self.projects_query.clear();
+        self.projects_selected = 0;
+        self.quick_add = None;
+        self.form = None;
+        self.input_mode = BoardInputMode::Normal;
+        self.drawer_open = false;
+        self.text_selection = None;
+        self.last_row_click = None;
+        self.last_project_header_click = None;
+    }
+
+    /// Apply an explicit reopen context without changing task ownership. A dirty editor is
+    /// left untouched and the request remains pending for the caller to retry after save/cancel.
+    /// Archived aliases are checked before switching so path spelling cannot bypass read-only
+    /// project protections.
+    pub fn apply_reopen_project(&mut self, project: Option<PathBuf>) -> bool {
+        if self.has_unsaved_work() {
+            self.set_message("save or cancel edits before reopening tsk");
+            return false;
+        }
+        self.dismiss_clean_surfaces_for_reopen();
+        let Some(project) = project else {
+            self.this_repo = None;
+            self.selected_project = None;
+            self.session_default_scope = Some(TaskScope::Global);
+            self.switch_location(BoardLocation::Desk);
+            self.clear_message();
+            return true;
+        };
+        let project_text = project.to_string_lossy();
+        if self.is_archived_project_path(&project) {
+            let name = crate::ui::render::short_project(&project_text).to_string();
+            self.this_repo = None;
+            self.selected_project = None;
+            self.session_default_scope = Some(TaskScope::Global);
+            self.switch_location(BoardLocation::Desk);
+            self.set_message(format!("project {name} is archived"));
+            return true;
+        }
+        let same = matches!(&self.board_location, BoardLocation::Project(current) if paths_equivalent(&current.to_string_lossy(), &project_text));
+        self.this_repo = Some(project.clone());
+        self.selected_project = Some(project.clone());
+        self.session_default_scope = Some(TaskScope::Project {
+            path: project.to_string_lossy().into_owned(),
+        });
+        if same {
+            self.thread_filter = ThreadFilter::All;
+        } else {
+            self.switch_location(BoardLocation::Project(project));
+        }
+        self.clear_message();
+        true
     }
 
     /// True while the board is in the read-only focus on an archived project (AC-41).
@@ -1139,9 +1302,7 @@ impl BoardModel {
     /// Leave the read-only archived focus for the desk (AC-45).
     pub(super) fn leave_archived_focus(&mut self) {
         let previous_visible = self.visible_ids();
-        self.board_location = BoardLocation::Home {
-            tab: BoardTab::Desk,
-        };
+        self.board_location = BoardLocation::Desk;
         self.reanchor_selection(None, &previous_visible);
         self.seed_selection();
         self.clear_message();
@@ -1150,6 +1311,7 @@ impl BoardModel {
     /// Turn a read-only focus into the ordinary project focus on the same project
     /// (AC-43), keeping the selection where the user left it.
     pub(super) fn enter_project_focus(&mut self, path: PathBuf) {
+        self.selected_project = Some(path.clone());
         let previous_visible = self.visible_ids();
         let previous = self.selection_id;
         self.board_location = BoardLocation::Project(path);
@@ -1158,6 +1320,7 @@ impl BoardModel {
 
     /// Open the read-only focus on `path` (AC-41). Session-only: nothing persists.
     pub(super) fn open_archived_focus(&mut self, path: PathBuf) {
+        self.selected_project = None;
         self.close_popup();
         let previous_visible = self.visible_ids();
         let previous = self.selection_id;
@@ -1168,10 +1331,11 @@ impl BoardModel {
         }
     }
 
-    /// Home boards use the invocation default; project focus defaults to that project.
+    /// The desk and the index use the invocation/session default; slot 2 defaults to
+    /// its own project.
     pub(super) fn quick_add_scope(&self) -> Option<TaskScope> {
         match &self.board_location {
-            BoardLocation::Home { .. } => self.session_default_scope.clone(),
+            BoardLocation::Desk | BoardLocation::Projects => self.session_default_scope.clone(),
             // Quick-add is refused outright in read-only focus, so its scope is moot.
             BoardLocation::Project(path) | BoardLocation::ArchivedProject(path) => {
                 Some(TaskScope::Project {
@@ -1179,6 +1343,31 @@ impl BoardModel {
                 })
             }
         }
+    }
+
+    /// The active destination's right-side control kind, when one is painted.
+    pub fn nav_chip_kind(&self) -> Option<crate::ui::render::NavChipKind> {
+        Some(match (&self.board_location, self.projects_view()) {
+            (BoardLocation::Project(_), _) => crate::ui::render::NavChipKind::ThreadFilter,
+            (BoardLocation::Projects, _) => crate::ui::render::NavChipKind::ProjectsView,
+            _ => return None,
+        })
+    }
+
+    /// The searchable list picker is open (thread filter / projects View).
+    pub fn list_picker_open(&self) -> bool {
+        self.list_picker.is_some()
+    }
+
+    /// The open list picker's kind, when one is open.
+    pub fn list_picker_kind(&self) -> Option<ListPickerKind> {
+        self.list_picker.as_ref().map(|picker| picker.kind)
+    }
+
+    pub fn list_picker_query(&self) -> Option<&str> {
+        self.list_picker
+            .as_ref()
+            .map(|picker| picker.query.as_str())
     }
 
     /// Cancel an armed project-header double-click when another pointer target
@@ -1310,8 +1499,7 @@ impl BoardModel {
             }
         };
         if let Some(repo) = self.this_repo.clone() {
-            let repo_path = repo.to_string_lossy().into_owned();
-            if !self.archived_projects.contains(&repo_path) {
+            if !self.is_archived_project_path(&repo) {
                 push(repo, &mut paths);
             }
         }
@@ -1321,7 +1509,7 @@ impl BoardModel {
                 continue;
             }
             if let TaskScope::Project { path } = &task.scope {
-                if self.archived_projects.contains(path) {
+                if self.is_archived_project_path(Path::new(path)) {
                     continue;
                 }
                 push(PathBuf::from(path), &mut from_tasks);
@@ -1372,117 +1560,327 @@ impl BoardModel {
         self.project_picker = Some(picker);
     }
 
-    /// Queue sections + counts for the current session location.
+    /// Queue sections + counts for the current session destination.
     pub fn queue_view(&self) -> QueueView {
-        queue::query_board(
+        let mut view = queue::query_board(
             &self.tasks,
             &self.archived_projects,
             self.this_repo.as_deref(),
-            self.board_location.lens(),
+            self.effective_lens(),
             self.drawer_open,
-        )
+            &self.thread_filter,
+        );
+        if let BoardLocation::Projects = self.board_location {
+            // The index's search narrows its own rows; task sections are untouched.
+            let query = self.projects_query.trim().to_ascii_lowercase();
+            if !query.is_empty() {
+                view.projects.retain(|row| {
+                    queue::short_project_name(&row.path)
+                        .to_ascii_lowercase()
+                        .contains(&query)
+                        || row.path.to_ascii_lowercase().contains(&query)
+                });
+            }
+        }
+        view
     }
 
-    pub(super) fn toggle_project_collapsed(&mut self, path: &str) {
-        if self.collapsed_projects.contains(path) {
-            self.collapsed_projects.remove(path);
-        } else {
-            self.collapsed_projects.insert(path.to_string());
+    /// The lens the current destination and its view control resolve to.
+    pub(super) fn effective_lens(&self) -> BoardLens<'_> {
+        match (&self.board_location, &self.projects_view) {
+            (BoardLocation::Projects, ProjectsView::Thread(name)) => BoardLens::ThreadView(name),
+            (location, _) => location.lens(),
         }
     }
 
-    pub(super) fn toggle_thread_collapsed(&mut self, name: &str) {
-        if self.collapsed_threads.contains(name) {
-            self.collapsed_threads.remove(name);
+    /// The thread filter active on slot 2's board.
+    pub fn thread_filter(&self) -> &ThreadFilter {
+        &self.thread_filter
+    }
+
+    /// The projects index's current View control.
+    pub fn projects_view(&self) -> &ProjectsView {
+        &self.projects_view
+    }
+
+    /// The index's search query.
+    pub fn projects_query(&self) -> &str {
+        &self.projects_query
+    }
+
+    /// The index rows the current query leaves visible (owned copy: rows are small).
+    pub fn project_rows(&self) -> Vec<ProjectRow> {
+        self.queue_view().projects
+    }
+
+    /// The index cursor, clamped to the rows the current query leaves visible.
+    pub fn projects_cursor(&self) -> usize {
+        let len = self.queue_view().projects.len();
+        self.projects_selected.min(len.saturating_sub(1))
+    }
+
+    /// The index row the cursor rests on.
+    pub fn selected_project_row(&self) -> Option<ProjectRow> {
+        self.queue_view()
+            .projects
+            .get(self.projects_cursor())
+            .cloned()
+    }
+
+    pub(super) fn move_projects_cursor(&mut self, forward: bool) -> bool {
+        let len = self.queue_view().projects.len();
+        if len == 0 {
+            self.projects_selected = 0;
+            return false;
+        }
+        self.projects_selected = if forward {
+            (self.projects_selected + 1) % len
         } else {
-            self.collapsed_threads.insert(name.to_string());
+            self.projects_selected.checked_sub(1).unwrap_or(len - 1)
+        };
+        true
+    }
+
+    /// Open the project board's searchable thread filter picker (bare `t`).
+    pub(super) fn open_thread_filter_picker(&mut self) {
+        if !matches!(self.board_location, BoardLocation::Project(_)) {
+            return;
+        }
+        let scope: Option<String> = match &self.board_location {
+            BoardLocation::Project(path) => Some(path.to_string_lossy().into_owned()),
+            _ => None,
+        };
+        let in_project = |task: &Task| matches!(&task.scope, TaskScope::Project { path } if Some(path.clone()) == scope);
+        let mut threads: BTreeMap<String, usize> = BTreeMap::new();
+        let mut unthreaded = 0usize;
+        let mut open = 0usize;
+        for task in &self.tasks {
+            if task.soft_deleted
+                || task.archived
+                || task.status == HumanStatus::Done
+                || self.is_hidden(task)
+                || !in_project(task)
+            {
+                continue;
+            }
+            open += 1;
+            match task.thread.as_deref() {
+                Some(name) => *threads.entry(name.to_ascii_lowercase()).or_default() += 1,
+                None => unthreaded += 1,
+            }
+        }
+        let mut options = vec![ListPickerOption {
+            label: "All tasks".to_string(),
+            count: Some(open),
+            value: ListPickerValue::ThreadAll,
+        }];
+        let mut named: Vec<(String, usize)> = threads.into_iter().collect();
+        named.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        options.extend(named.into_iter().map(|(name, count)| ListPickerOption {
+            label: format!("#{name}"),
+            count: Some(count),
+            value: ListPickerValue::ThreadNamed(name),
+        }));
+        options.push(ListPickerOption {
+            label: "Without a thread".to_string(),
+            count: Some(unthreaded),
+            value: ListPickerValue::ThreadWithout,
+        });
+        let selected = options
+            .iter()
+            .position(|option| match &option.value {
+                ListPickerValue::ThreadAll => self.thread_filter == ThreadFilter::All,
+                ListPickerValue::ThreadNamed(name) => {
+                    self.thread_filter == ThreadFilter::Named(name.clone())
+                }
+                ListPickerValue::ThreadWithout => self.thread_filter == ThreadFilter::Without,
+                _ => false,
+            })
+            .unwrap_or(0);
+        self.list_picker = Some(ListPickerState {
+            kind: ListPickerKind::ThreadFilter,
+            options,
+            selected,
+            query: String::new(),
+        });
+    }
+
+    /// Open the projects index's searchable View picker (bare `v`).
+    pub(super) fn open_projects_view_picker(&mut self) {
+        if !matches!(self.board_location, BoardLocation::Projects) {
+            return;
+        }
+        let mut threads: BTreeMap<String, usize> = BTreeMap::new();
+        for task in &self.tasks {
+            if task.soft_deleted
+                || task.archived
+                || task.status == HumanStatus::Done
+                || self.is_hidden(task)
+            {
+                continue;
+            }
+            if let Some(name) = task.thread.as_deref() {
+                *threads.entry(name.to_ascii_lowercase()).or_default() += 1;
+            }
+        }
+        let mut options = vec![ListPickerOption {
+            label: "Overview".to_string(),
+            count: None,
+            value: ListPickerValue::ProjectsOverview,
+        }];
+        let mut named: Vec<(String, usize)> = threads.into_iter().collect();
+        named.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        options.extend(named.into_iter().map(|(name, count)| ListPickerOption {
+            label: format!("#{name}"),
+            count: Some(count),
+            value: ListPickerValue::ProjectsThread(name),
+        }));
+        let selected = options
+            .iter()
+            .position(|option| match (&option.value, &self.projects_view) {
+                (ListPickerValue::ProjectsOverview, ProjectsView::Overview) => true,
+                (ListPickerValue::ProjectsThread(name), ProjectsView::Thread(active)) => {
+                    name == active
+                }
+                _ => false,
+            })
+            .unwrap_or(0);
+        self.list_picker = Some(ListPickerState {
+            kind: ListPickerKind::ProjectsView,
+            options,
+            selected,
+            query: String::new(),
+        });
+    }
+
+    /// Options the open picker shows after its search query, as (source index, option).
+    pub fn visible_list_picker_options(&self) -> Vec<(usize, ListPickerOption)> {
+        let Some(picker) = self.list_picker.as_ref() else {
+            return Vec::new();
+        };
+        let query = picker.query.trim().to_ascii_lowercase();
+        picker
+            .options
+            .iter()
+            .enumerate()
+            .filter(|(_, option)| {
+                query.is_empty() || option.label.to_ascii_lowercase().contains(&query)
+            })
+            .map(|(index, option)| (index, option.clone()))
+            .collect()
+    }
+
+    /// The picker row the cursor rests on, in the visible (filtered) order.
+    pub fn list_picker_selected(&self) -> usize {
+        self.list_picker
+            .as_ref()
+            .map(|picker| picker.selected)
+            .unwrap_or(0)
+    }
+
+    pub fn selected_list_picker_option(&self) -> Option<(usize, ListPickerOption)> {
+        let visible = self.visible_list_picker_options();
+        let selected = self
+            .list_picker
+            .as_ref()
+            .map(|picker| picker.selected.min(visible.len().saturating_sub(1)))
+            .unwrap_or(0);
+        visible.into_iter().nth(selected)
+    }
+
+    pub(super) fn move_list_picker(&mut self, forward: bool) {
+        let len = self.visible_list_picker_options().len();
+        if let Some(picker) = self.list_picker.as_mut() {
+            picker.selected = if len == 0 {
+                0
+            } else if forward {
+                (picker.selected + 1) % len
+            } else {
+                picker.selected.checked_sub(1).unwrap_or(len - 1)
+            };
         }
     }
 
-    pub(super) fn toggle_thread_project_collapsed(&mut self, key: ThreadProjectCollapseKey) {
-        if self.collapsed_thread_projects.contains(&key) {
-            self.collapsed_thread_projects.remove(&key);
-        } else {
-            self.collapsed_thread_projects.insert(key);
+    pub(super) fn list_picker_query_insert(&mut self, character: char) {
+        if let Some(picker) = self.list_picker.as_mut() {
+            picker.query.push(character);
+            picker.selected = 0;
         }
     }
 
-    /// Collapse every top-level group on the active home tab, or expand them when they are
-    /// already all collapsed. Thread-project subgroups stay independent: Ctrl+G acts on the
-    /// named thread groups the Threads tab presents at its top level.
+    pub(super) fn list_picker_query_backspace(&mut self) {
+        if let Some(picker) = self.list_picker.as_mut() {
+            picker.query.pop();
+            picker.selected = 0;
+        }
+    }
+
+    pub(super) fn list_picker_query_insert_text(&mut self, text: &str) {
+        if let Some(picker) = self.list_picker.as_mut() {
+            picker.query.push_str(text);
+            picker.selected = 0;
+        }
+    }
+
+    /// Confirm the highlighted picker option: apply its value, close the picker, and
+    /// report what was applied so the reducer can reanchor. `None` leaves the picker
+    /// untouched (no visible option, or a kind/value mismatch).
+    pub(super) fn confirm_list_picker(&mut self) -> Option<ListPickerValue> {
+        let (_, option) = self.selected_list_picker_option()?;
+        let value = option.value.clone();
+        let kind = self.list_picker.as_ref()?.kind;
+        let applied = match (kind, &value) {
+            (ListPickerKind::ThreadFilter, ListPickerValue::ThreadAll) => {
+                self.thread_filter = ThreadFilter::All;
+                true
+            }
+            (ListPickerKind::ThreadFilter, ListPickerValue::ThreadNamed(name)) => {
+                self.thread_filter = ThreadFilter::Named(name.clone());
+                true
+            }
+            (ListPickerKind::ThreadFilter, ListPickerValue::ThreadWithout) => {
+                self.thread_filter = ThreadFilter::Without;
+                true
+            }
+            (ListPickerKind::ProjectsView, ListPickerValue::ProjectsOverview) => {
+                self.projects_view = ProjectsView::Overview;
+                self.projects_selected = 0;
+                true
+            }
+            (ListPickerKind::ProjectsView, ListPickerValue::ProjectsThread(name)) => {
+                self.projects_view = ProjectsView::Thread(name.clone());
+                self.projects_selected = 0;
+                true
+            }
+            _ => false,
+        };
+        if applied {
+            self.list_picker = None;
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn cancel_list_picker(&mut self) {
+        self.list_picker = None;
+    }
+
+    /// Collapse (or reopen) the done drawer's archived group with Ctrl+G. The index
+    /// and the project board have no collapsible task groups of their own; the drawer's
+    /// archived group is the one group the chord still answers (AC-38).
     pub(super) fn toggle_all_groups(&mut self) -> bool {
         let view = self.queue_view();
-        // AC-38: the archived group is one of the board's groups. While the drawer is
-        // open it votes on the direction and folds with the rest; with the drawer shut
-        // toggle-all never touches its state.
         let archived_joins = self.drawer_open
             && view
                 .sections
                 .iter()
                 .any(|section| section.kind == SectionKind::Archived);
-        let fold_archived = |model: &mut Self, collapsed: bool| {
-            if archived_joins {
-                model.archived_collapsed = collapsed;
-            }
-        };
-        match self.board_location {
-            BoardLocation::Home {
-                tab: BoardTab::Projects,
-            } => {
-                let paths: Vec<String> = view
-                    .sections
-                    .iter()
-                    .filter_map(|section| section.project_label.clone())
-                    .collect();
-                if paths.is_empty() && !archived_joins {
-                    return false;
-                }
-                let all_collapsed = paths
-                    .iter()
-                    .all(|path| self.collapsed_projects.contains(path))
-                    && (!archived_joins || self.archived_collapsed);
-                if all_collapsed {
-                    self.collapsed_projects.clear();
-                } else {
-                    self.collapsed_projects.extend(paths);
-                }
-                fold_archived(self, !all_collapsed);
-                true
-            }
-            BoardLocation::Home {
-                tab: BoardTab::Threads,
-            } => {
-                let threads: Vec<String> = view
-                    .sections
-                    .iter()
-                    .filter_map(|section| section.thread_label.clone())
-                    .collect();
-                if threads.is_empty() && !archived_joins {
-                    return false;
-                }
-                let all_collapsed = threads
-                    .iter()
-                    .all(|thread| self.collapsed_threads.contains(thread))
-                    && (!archived_joins || self.archived_collapsed);
-                if all_collapsed {
-                    self.collapsed_threads.clear();
-                } else {
-                    self.collapsed_threads.extend(threads);
-                }
-                fold_archived(self, !all_collapsed);
-                true
-            }
-            // Desk and project focus have no top-level groups of their own, but the open
-            // drawer's archived group still answers the chord.
-            _ => {
-                if archived_joins {
-                    let collapsed = self.archived_collapsed;
-                    fold_archived(self, !collapsed);
-                    true
-                } else {
-                    false
-                }
-            }
+        if archived_joins {
+            self.archived_collapsed = !self.archived_collapsed;
+            true
+        } else {
+            false
         }
     }
 
@@ -1521,14 +1919,7 @@ impl BoardModel {
 
     /// Visible task ids from the queue section query (flat section order).
     pub fn visible_ids(&self) -> Vec<Uuid> {
-        visible_task_ids(
-            &self.queue_view(),
-            self.board_location.lens(),
-            &self.collapsed_projects,
-            &self.collapsed_threads,
-            &self.collapsed_thread_projects,
-            self.archived_collapsed,
-        )
+        visible_task_ids(&self.queue_view(), self.archived_collapsed)
     }
 
     /// Visible tasks in queue section order.
@@ -1710,8 +2101,15 @@ impl BoardModel {
         }
         let pending = self.quick_add_save.take().expect("checked quick-add save");
         self.saved_task = Some(pending.id);
-        self.retarget_selection(Some(pending.id), SelectionRetarget::Reanchor);
-        self.reveal_task_on_home(pending.id);
+        // Navigation never follows a save: the row flash is the feedback, and the pin
+        // moves only when the current destination already renders the new task.
+        if self.visible_ids().contains(&pending.id) {
+            self.retarget_selection(Some(pending.id), SelectionRetarget::Reanchor);
+            self.follow_list.set(true);
+        } else if let Some(previous) = self.selection_id {
+            let previous_visible = self.visible_ids();
+            self.reanchor_selection(Some(previous), &previous_visible);
+        }
         // The pending create is now durable. This is the only point an expanded quick-add
         // may release its complete form, so a failed save can still return to that stash.
         self.form = None;
@@ -2142,6 +2540,7 @@ impl BoardModel {
             BoardInputMode::SaveRecovery => SAVE_RECOVERY_HELP_LINE,
             BoardInputMode::LaunchCard => LAUNCH_CARD_HELP_LINE,
             BoardInputMode::Help => HELP_SURFACE_HELP_LINE,
+            BoardInputMode::ProjectsSearch => crate::ui::input::PROJECTS_SEARCH_HELP_LINE,
             _ => BOARD_HELP_LINE,
         }
     }
@@ -2436,7 +2835,8 @@ impl BoardModel {
         self.follow_list.set(false);
     }
 
-    /// Set the session-only project focus. `None` returns home on the Desk tab.
+    /// Set the session destination through the picker. `None` (the desk choice) goes
+    /// to tab 1, never to the index.
     pub fn set_selected_project(&mut self, project: Option<PathBuf>) {
         self.set_board_scope(match project {
             None => ProjectScopeOption::Home,
@@ -2446,15 +2846,20 @@ impl BoardModel {
 
     pub(super) fn set_board_scope(&mut self, scope: ProjectScopeOption) {
         self.close_popup();
-        let previous_visible = self.visible_ids();
-        let previous = self.selection_id;
-        self.board_location = match scope {
-            ProjectScopeOption::Home => BoardLocation::Home {
-                tab: BoardTab::Desk,
-            },
-            ProjectScopeOption::Project(path) => BoardLocation::Project(path),
-        };
-        self.reanchor_selection(previous, &previous_visible);
+        self.projects_query.clear();
+        if self.input_mode == BoardInputMode::ProjectsSearch {
+            self.input_mode = BoardInputMode::Normal;
+        }
+        match scope {
+            ProjectScopeOption::Home => {
+                self.selected_project = None;
+                self.switch_location(BoardLocation::Desk);
+            }
+            ProjectScopeOption::Project(path) => {
+                self.selected_project = Some(path.clone());
+                self.switch_location(BoardLocation::Project(path));
+            }
+        }
     }
 }
 /// Compact label for one project path.
@@ -2531,67 +2936,226 @@ mod tests {
     }
 
     #[test]
-    fn toggle_all_groups_toggles_only_the_active_home_tabs_top_level_groups() {
+    fn ctrl_g_folds_only_the_done_drawers_archived_group() {
         let mut domain = DomainState::new();
-        let a = create(&mut domain, "task-a", project(REPO_A));
-        let b = create(&mut domain, "task-b", project(REPO_B));
-        domain
-            .edit(
-                a,
-                "task-a",
-                None,
-                project(REPO_A),
-                Some("release".to_string()),
-            )
-            .expect("thread a");
-        domain
-            .edit(
-                b,
-                "task-b",
-                None,
-                project(REPO_B),
-                Some("release".to_string()),
-            )
-            .expect("thread b");
+        create(&mut domain, "task-a", project(REPO_A));
+        create(&mut domain, "task-b", project(REPO_B));
 
         let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
-        model.set_home_tab(BoardTab::Projects);
-        assert!(model.toggle_all_groups());
-        assert!(model.visible_ids().is_empty());
-        assert!(model.toggle_all_groups());
-        assert_eq!(model.visible_ids().len(), 2);
-
-        model.set_home_tab(BoardTab::Threads);
-        assert!(model.toggle_all_groups());
-        assert!(model.visible_ids().is_empty());
-        assert!(model.toggle_all_groups());
-        assert_eq!(model.visible_ids().len(), 2);
-
-        model.set_home_tab(BoardTab::Desk);
+        // Drawer closed: no group answers the chord (the destinations have no
+        // collapsible task groups anymore).
         assert!(!model.toggle_all_groups());
+
+        // Drawer open with an archived group: the chord folds it.
+        model.drawer_open = true;
+        // No archived tasks here, so the archived section never paints.
+        assert!(!model.toggle_all_groups());
+
+        domain
+            .archive_task(model.selected_id().expect("a selected task"))
+            .expect("archive");
+        model.sync_from_domain(&domain);
+        model.drawer_open = true;
+        // The archived group starts collapsed; the chord's first press expands it.
+        assert!(model.toggle_all_groups());
+        assert!(!model.archived_collapsed);
+        assert!(model.toggle_all_groups());
+        assert!(model.archived_collapsed);
     }
 
     #[test]
-    fn seed_selection_skips_rows_hidden_by_collapse() {
+    fn nav_tabs_never_shift_meaning_and_slot_two_without_a_project_opens_nothing_here() {
         let mut domain = DomainState::new();
-        let in_a = create(&mut domain, "task-a", project(REPO_A));
-        let in_b = create(&mut domain, "task-b", project(REPO_B));
+        create(&mut domain, "task-a", project(REPO_A));
 
         let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
-        model.board_location = BoardLocation::Home {
-            tab: BoardTab::Projects,
-        };
-        model.toggle_project_collapsed(REPO_A);
-        model.selection_id = None;
-
-        model.seed_selection();
-
         assert_eq!(
-            model.selected_id(),
-            Some(in_b),
-            "seed must land on a painted row, never inside a collapsed group"
+            model.nav_tab(),
+            NavTab::ProjectBoard,
+            "startup in a repo opens slot 2"
         );
-        assert_ne!(model.selected_id(), Some(in_a));
+
+        assert!(model.select_nav_tab(NavTab::Desk));
+        assert_eq!(model.nav_tab(), NavTab::Desk);
+        assert_eq!(model.selected_project(), Some(Path::new(REPO_A)));
+        assert!(model.select_nav_tab(NavTab::Projects));
+        assert_eq!(model.nav_tab(), NavTab::Projects);
+        assert!(model.select_nav_tab(NavTab::ProjectBoard));
+        assert_eq!(model.nav_tab(), NavTab::ProjectBoard);
+        assert_eq!(model.selected_project(), Some(Path::new(REPO_A)));
+        assert!(model.select_nav_tab(NavTab::Desk));
+        assert!(model.select_nav_tab(NavTab::Projects));
+        assert!(model.select_nav_tab(NavTab::ProjectBoard));
+        assert_eq!(model.nav_tab(), NavTab::ProjectBoard);
+        model.set_selected_project(Some(PathBuf::from(REPO_B)));
+        model.select_nav_tab(NavTab::Desk);
+        assert!(model.select_nav_tab(NavTab::ProjectBoard));
+        assert_eq!(model.selected_project(), Some(Path::new(REPO_B)));
+    }
+
+    #[test]
+    fn switching_projects_clears_the_local_thread_filter() {
+        let mut domain = DomainState::new();
+        create(&mut domain, "task-a", project(REPO_A));
+        create(&mut domain, "task-b", project(REPO_B));
+
+        let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
+        model.thread_filter = ThreadFilter::Named("release".to_string());
+        model.set_selected_project(Some(PathBuf::from(REPO_B)));
+        assert_eq!(
+            model.thread_filter(),
+            &ThreadFilter::All,
+            "the thread filter belongs to one project board; switching clears it"
+        );
+
+        // Same project again: the filter survives.
+        model.thread_filter = ThreadFilter::Without;
+        model.set_selected_project(Some(PathBuf::from(REPO_B)));
+        assert_eq!(model.thread_filter(), &ThreadFilter::Without);
+    }
+
+    #[test]
+    fn picker_desk_choice_lands_on_the_desk_tab_not_the_index() {
+        let mut domain = DomainState::new();
+        create(&mut domain, "task-a", project(REPO_A));
+
+        let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
+        model.set_selected_project(Some(PathBuf::from(REPO_B)));
+        model.set_selected_project(None);
+        assert_eq!(model.nav_tab(), NavTab::Desk);
+    }
+
+    #[test]
+    fn projects_index_cursor_moves_within_the_visible_rows() {
+        let mut domain = DomainState::new();
+        create(&mut domain, "task-a", project("/repos/alpha"));
+        create(&mut domain, "task-b", project("/repos/beta"));
+
+        let mut model = BoardModel::from_domain(&domain, None);
+        model.board_location = BoardLocation::Projects;
+        assert_eq!(model.project_rows().len(), 2);
+        assert!(model.move_projects_cursor(true));
+        assert_eq!(model.projects_cursor(), 1);
+        assert!(model.move_projects_cursor(true));
+        assert_eq!(model.projects_cursor(), 0, "the index cursor wraps");
+        assert!(model.move_projects_cursor(false));
+        assert_eq!(model.projects_cursor(), 1);
+
+        // Search narrows the rows and the cursor clamps.
+        model.projects_query = "beta".to_string();
+        assert_eq!(model.project_rows().len(), 1);
+        assert_eq!(model.projects_cursor(), 0);
+        assert_eq!(
+            model.selected_project_row().expect("row").path,
+            "/repos/beta"
+        );
+        model.projects_query = "zzz".to_string();
+        assert!(model.project_rows().is_empty());
+        assert!(model.selected_project_row().is_none());
+    }
+
+    #[test]
+    fn thread_filter_picker_options_come_from_this_project_only() {
+        let mut domain = DomainState::new();
+        let a = create(&mut domain, "a1", project(REPO_A));
+        domain
+            .edit(a, "a1", None, project(REPO_A), Some("nav".to_string()))
+            .expect("thread");
+        let b = create(&mut domain, "b1", project(REPO_B));
+        domain
+            .edit(b, "b1", None, project(REPO_B), Some("other".to_string()))
+            .expect("thread");
+
+        let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
+        model.open_thread_filter_picker();
+        let options = model.visible_list_picker_options();
+        let labels: Vec<&str> = options
+            .iter()
+            .map(|(_, option)| option.label.as_str())
+            .collect();
+        assert_eq!(
+            labels,
+            vec!["All tasks", "#nav", "Without a thread"],
+            "another project's thread must not offer itself here"
+        );
+        assert_eq!(model.list_picker_kind(), Some(ListPickerKind::ThreadFilter));
+    }
+
+    #[test]
+    fn confirming_thread_filter_narrows_and_clearing_restores() {
+        let mut domain = DomainState::new();
+        let a = create(&mut domain, "a1", project(REPO_A));
+        domain
+            .edit(a, "a1", None, project(REPO_A), Some("nav".to_string()))
+            .expect("thread");
+        create(&mut domain, "a2", project(REPO_A));
+
+        let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
+        model.open_thread_filter_picker();
+        model.move_list_picker(true); // #nav
+        let applied = model.confirm_list_picker();
+        assert_eq!(
+            applied,
+            Some(ListPickerValue::ThreadNamed("nav".to_string()))
+        );
+        assert!(!model.list_picker_open());
+        let visible = model.visible_ids();
+        assert_eq!(
+            visible,
+            vec![a],
+            "the filter narrows the board across statuses"
+        );
+
+        // Re-opening highlights the active filter; step back to All tasks and confirm.
+        model.open_thread_filter_picker();
+        model.move_list_picker(false);
+        let applied = model.confirm_list_picker();
+        assert_eq!(applied, Some(ListPickerValue::ThreadAll));
+        assert_eq!(model.visible_ids().len(), 2);
+    }
+
+    #[test]
+    fn projects_view_picker_lists_cross_project_threads() {
+        let mut domain = DomainState::new();
+        let a = create(&mut domain, "a1", project(REPO_A));
+        domain
+            .edit(a, "a1", None, project(REPO_A), Some("release".to_string()))
+            .expect("thread");
+        create(&mut domain, "b1", project(REPO_B));
+
+        let mut model = BoardModel::from_domain(&domain, None);
+        model.board_location = BoardLocation::Projects;
+        model.open_projects_view_picker();
+        let labels: Vec<String> = model
+            .visible_list_picker_options()
+            .iter()
+            .map(|(_, option)| option.label.clone())
+            .collect();
+        assert_eq!(labels, vec!["Overview", "#release"]);
+
+        model.move_list_picker(true);
+        assert_eq!(
+            model.confirm_list_picker(),
+            Some(ListPickerValue::ProjectsThread("release".to_string()))
+        );
+        assert!(
+            model
+                .queue_view()
+                .sections
+                .iter()
+                .any(|section| section.task_ids.contains(&a)),
+            "the thread view shows the matching task from any project"
+        );
+
+        // Re-opening highlights the active view; step back to Overview and confirm.
+        model.open_projects_view_picker();
+        model.move_list_picker(false);
+        assert_eq!(
+            model.confirm_list_picker(),
+            Some(ListPickerValue::ProjectsOverview)
+        );
+        assert_eq!(model.projects_view(), &ProjectsView::Overview);
+        assert!(!model.project_rows().is_empty());
     }
 
     #[test]
@@ -2603,9 +3167,6 @@ mod tests {
         let t4 = create(&mut domain, "task-4", project(REPO_A));
 
         let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
-        model.board_location = BoardLocation::Home {
-            tab: BoardTab::Projects,
-        };
         model.selection_id = Some(t3);
 
         // One sync carries both an external removal of the rows before the selection
@@ -2628,36 +3189,58 @@ mod tests {
         let desk_task = create(&mut domain, "desk task", TaskScope::Global);
 
         let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
-        assert_eq!(model.home_tab(), BoardTab::Desk);
+        model.board_location = BoardLocation::Desk;
+        model.seed_selection();
+        assert_eq!(model.nav_tab(), NavTab::Desk);
 
         // Another process adds a project task between two syncs.
         create(&mut domain, "external task", project(REPO_B));
         model.sync_from_domain(&domain);
 
         assert_eq!(
-            model.home_tab(),
-            BoardTab::Desk,
-            "a background merge must not move the user's home tab"
+            model.nav_tab(),
+            NavTab::Desk,
+            "a background merge must not move the user's destination"
         );
         assert_eq!(model.selected_id(), Some(desk_task));
     }
 
     #[test]
-    fn sync_from_domain_surfaces_externally_created_tasks_on_an_empty_board() {
+    fn sync_from_domain_surfaces_the_first_arriving_task_only_when_it_is_visible_here() {
         let domain = DomainState::new();
         let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
+        model.board_location = BoardLocation::Desk;
+        assert!(model.visible_ids().is_empty());
 
-        // Another process captures the first task while this board shows nothing.
+        // Another process captures a desk-visible task while this board shows nothing:
+        // the desk's global lanes render it, so the pin moves to it.
         let mut domain = DomainState::new();
-        let captured = create(&mut domain, "first capture", project(REPO_B));
+        let started = create(&mut domain, "first capture", TaskScope::Global);
+        domain
+            .set_status(started, HumanStatus::Started)
+            .expect("start");
         model.sync_from_domain(&domain);
 
         assert_eq!(
-            model.home_tab(),
-            BoardTab::Projects,
-            "an otherwise-empty view follows the arriving task so it renders"
+            model.nav_tab(),
+            NavTab::Desk,
+            "surfacing never moves the destination"
         );
-        assert_eq!(model.selected_id(), Some(captured));
+        assert_eq!(model.selected_id(), Some(started));
+
+        // A task the current destination does not render never drags the view there.
+        let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO_A)));
+        model.board_location = BoardLocation::Desk;
+        model.selection_id = None;
+        let mut domain = DomainState::new();
+        create(&mut domain, "elsewhere", project(REPO_B));
+        model.sync_from_domain(&domain);
+        assert_eq!(model.nav_tab(), NavTab::Desk);
+        assert_eq!(
+            model.selected_id(),
+            None,
+            "an invisible arrival stays invisible rather than switching tabs"
+        );
     }
 
     #[test]

--- a/src/ui/capture.rs
+++ b/src/ui/capture.rs
@@ -14,6 +14,7 @@ use crate::capture::{capture_save, CaptureError};
 use crate::context::InvocationSnapshot;
 use crate::domain::{DomainState, TaskScope};
 use crate::save_recovery::SaveRecovery;
+use crate::scope::{archived_path_contains, paths_equivalent};
 use crate::store::TaskStore;
 
 use super::edit::{
@@ -218,8 +219,12 @@ impl CaptureModel {
             return;
         };
         let path = repo.to_string_lossy().into_owned();
-        self.this_repo_archived = archived.contains(&path);
-        if self.this_repo_archived && self.scope == (TaskScope::Project { path }) {
+        self.this_repo_archived = archived_path_contains(archived, &path);
+        if self.this_repo_archived
+            && matches!(&self.scope, TaskScope::Project { path: scope_path } if archived
+                .iter()
+                .any(|stored| paths_equivalent(stored, scope_path)))
+        {
             self.scope = TaskScope::Global;
         }
     }
@@ -2550,9 +2555,9 @@ mod tests {
     fn capture_scope_never_offers_an_archived_this_project() {
         let snapshot = InvocationSnapshot {
             default_scope: TaskScope::Project {
-                path: "/repos/filed".into(),
+                path: "/private/tmp".into(),
             },
-            this_repo: Some(PathBuf::from("/repos/filed")),
+            this_repo: Some(PathBuf::from("/private/tmp")),
             title_prefill: None,
             provenance: ProvenanceOrigin::Capture,
         };
@@ -2560,7 +2565,7 @@ mod tests {
         assert!(model.this_project_available());
 
         let mut archived = std::collections::BTreeSet::new();
-        archived.insert("/repos/filed".to_string());
+        archived.insert("/tmp".to_string());
         model.mark_archived_projects(&archived);
 
         assert!(

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -215,17 +215,36 @@ pub enum BoardIntent {
     /// the task list: it runs the same effect `ConfirmProjectChoice` does after enough
     /// `ProjectPickerNext`/`ProjectPickerPrev` presses reached this option.
     SelectProjectOption(usize),
-    /// Switch the home board tab (`1` desk · `2` projects · `3` threads).
-    SelectHomeTab(crate::ui::queue::BoardTab),
-    /// Register one click on a Projects-tab group header by section index (mouse-only).
-    SelectSectionProject(usize),
-    /// Register one click on a Threads-tab group header by section index (mouse-only).
-    SelectSectionThread(usize),
-    /// Register one click on a project row under a thread group (mouse-only).
-    SelectSectionThreadProject {
-        section_idx: usize,
-        subgroup_idx: usize,
-    },
+    /// Switch to a persistent navigation tab (`1` desk · `2` selected project · `3`
+    /// projects). Tab 2 with no project opens the picker instead.
+    SelectNavTab(crate::ui::queue::NavTab),
+    /// Open the project board's searchable thread filter picker (bare `t`).
+    OpenThreadFilterPicker,
+    /// Open the projects index's searchable View picker (bare `v`).
+    OpenProjectsViewPicker,
+    /// Focus the visible projects-index search field (`/` or a click).
+    FocusProjectsSearch,
+    /// Move the open list picker's selection.
+    ListPickerNext,
+    ListPickerPrev,
+    /// Apply the highlighted list-picker option.
+    ConfirmListPicker,
+    /// Close the list picker without applying anything.
+    CancelListPicker,
+    /// Choose a visible list-picker row by index and apply it in one step (mouse).
+    SelectListOption(usize),
+    /// Type into the open list picker's search query.
+    ListPickerQueryInsert(char),
+    /// Paste into the open list picker's search query.
+    ListPickerQueryInsertText(String),
+    ListPickerQueryBackspace,
+    /// Type into the projects index's search.
+    ProjectsQueryInsert(char),
+    /// Paste into the projects index's search.
+    ProjectsQueryInsertText(String),
+    ProjectsQueryBackspace,
+    /// Mouse route onto a projects index row: select it and open its project in slot 2.
+    SelectProjectRow(usize),
     /// Move the task page's step cursor onto one steps step by its painted absolute
     /// index (mouse click on an step row; AC-21). A click selects — it never toggles the
     /// step, opens the editor, or arms the delete mark; no key produces it.
@@ -318,6 +337,8 @@ pub const HELP_SURFACE_HELP_LINE: &str = "any key closes";
 /// Compact legend shown while a failed board save is unresolved.
 pub const LAUNCH_CARD_HELP_LINE: &str = "y unarchive · n keep archived";
 pub const SAVE_RECOVERY_HELP_LINE: &str = "↑↓  ·  r retry  ·  c cancel";
+/// Compact legend while the projects index search field owns input.
+pub const PROJECTS_SEARCH_HELP_LINE: &str = "/ search  ·  type  ·  enter open  ·  esc clear";
 /// Compact legend shown while the first-use walkthrough is open.
 pub const WALKTHROUGH_HELP_LINE: &str = "Enter next  ·  Esc skip";
 
@@ -490,12 +511,29 @@ const NORMAL_KEYMAP: &[NormalKeyEntry] = &[
         help_label: "help",
         verb: false,
     },
-    // The project chip is mouse-clickable; `P` gives the keyboard the same route.
+    // The project slot is mouse-clickable; `P` gives the keyboard the same route.
     NormalKeyEntry {
         code: KeyCode::Char('P'),
         intent: BoardIntent::OpenProjectSelector,
         help_chord: "P",
         help_label: "project",
+        verb: false,
+    },
+    // `t` opens the project board's thread filter; `v` the projects index's View
+    // selector. Both are navigation (bare, not verbs); the reducer gates each to its
+    // own destination, so they are inert everywhere else.
+    NormalKeyEntry {
+        code: KeyCode::Char('t'),
+        intent: BoardIntent::OpenThreadFilterPicker,
+        help_chord: "t",
+        help_label: "threads",
+        verb: false,
+    },
+    NormalKeyEntry {
+        code: KeyCode::Char('v'),
+        intent: BoardIntent::OpenProjectsViewPicker,
+        help_chord: "v",
+        help_label: "views",
         verb: false,
     },
 ];
@@ -534,10 +572,18 @@ pub fn normal_help_bindings() -> Vec<(&'static str, &'static str)> {
             bindings.push(binding);
         }
     }
-    // Ctrl+G is deliberately not a normal key-map entry: it only acts on the home
-    // Projects and Threads lenses, never while a task page owns input.
+    // Ctrl+G is deliberately not a normal key-map entry: it only acts on the open
+    // done drawer's archived group, never while a task page owns input.
     bindings.push(("ctrl+g", "groups"));
     bindings
+}
+
+/// Whether a bare character is unbound in normal mode, and so types into destination
+/// search lines (the projects index). Bound keys — nav, verbs, pickers — stay routes.
+pub fn is_unbound_normal_char(character: char) -> bool {
+    !NORMAL_KEYMAP
+        .iter()
+        .any(|entry| entry.code == KeyCode::Char(character))
 }
 
 fn help_chord_shown(chord: &str) -> String {
@@ -606,6 +652,8 @@ pub fn map_key(mode: BoardInputMode, key: KeyEvent) -> Option<BoardIntent> {
         BoardInputMode::Normal => map_normal(key),
         BoardInputMode::TaskPage => map_task_page(key),
         BoardInputMode::ProjectPicker => map_project_picker(key),
+        BoardInputMode::ListPicker => map_list_picker(key),
+        BoardInputMode::ProjectsSearch => map_projects_search(key),
         BoardInputMode::SaveRecovery => map_save_recovery(key),
         BoardInputMode::LaunchCard => map_launch_card(key),
         BoardInputMode::Palette => map_palette(key),
@@ -922,12 +970,28 @@ fn map_form_edit_key(
     }
 }
 
+fn map_projects_search(key: KeyEvent) -> Option<BoardIntent> {
+    if key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+    {
+        return None;
+    }
+    match key.code {
+        KeyCode::Esc => Some(BoardIntent::CloseLayer),
+        KeyCode::Enter => Some(BoardIntent::OpenTaskPage),
+        KeyCode::Backspace => Some(BoardIntent::ProjectsQueryBackspace),
+        KeyCode::Char(character) if !character.is_control() => {
+            Some(BoardIntent::ProjectsQueryInsert(character))
+        }
+        _ => None,
+    }
+}
+
 /// Map a bracketed-paste payload to the intent that inserts it.
 ///
 /// A paste arrives as `Event::Paste`, never as a key press, so it cannot go through
-/// [`map_key`]. The two edit modes and the palette query consume one: each accepts typed
-/// characters, so each accepted a paste before bracketed paste was enabled. Every other mode
-/// ignores it.
+/// [`map_key`]. The two edit modes, the palette, and the projects search consume one.
 pub fn map_edit_paste(mode: BoardInputMode, text: &str) -> Option<BoardIntent> {
     match mode {
         BoardInputMode::QuickAdd => Some(BoardIntent::QuickAddInsertText(text.to_string())),
@@ -940,6 +1004,12 @@ pub fn map_edit_paste(mode: BoardInputMode, text: &str) -> Option<BoardIntent> {
         | BoardInputMode::FormScopeDropdown
         | BoardInputMode::LaunchCard
         | BoardInputMode::TaskPage => None,
+        BoardInputMode::ListPicker => {
+            Some(BoardIntent::ListPickerQueryInsertText(text.to_string()))
+        }
+        BoardInputMode::ProjectsSearch => {
+            Some(BoardIntent::ProjectsQueryInsertText(text.to_string()))
+        }
         BoardInputMode::Palette => Some(BoardIntent::CommandQueryInsertText(text.to_string())),
         BoardInputMode::Normal
         | BoardInputMode::ProjectPicker
@@ -1015,10 +1085,22 @@ pub fn intent_primary_action(intent: &BoardIntent) -> Option<PrimaryBoardAction>
         | BoardIntent::ConfirmProjectChoice
         | BoardIntent::CancelProjectPicker
         | BoardIntent::SelectProjectOption(_)
-        | BoardIntent::SelectHomeTab(_)
-        | BoardIntent::SelectSectionProject(_)
-        | BoardIntent::SelectSectionThread(_)
-        | BoardIntent::SelectSectionThreadProject { .. }
+        | BoardIntent::SelectNavTab(_)
+        | BoardIntent::OpenThreadFilterPicker
+        | BoardIntent::OpenProjectsViewPicker
+        | BoardIntent::ListPickerNext
+        | BoardIntent::ListPickerPrev
+        | BoardIntent::ConfirmListPicker
+        | BoardIntent::CancelListPicker
+        | BoardIntent::SelectListOption(_)
+        | BoardIntent::ListPickerQueryInsert(_)
+        | BoardIntent::ListPickerQueryInsertText(_)
+        | BoardIntent::ListPickerQueryBackspace
+        | BoardIntent::ProjectsQueryInsert(_)
+        | BoardIntent::ProjectsQueryInsertText(_)
+        | BoardIntent::ProjectsQueryBackspace
+        | BoardIntent::FocusProjectsSearch
+        | BoardIntent::SelectProjectRow(_)
         | BoardIntent::SelectStep(_)
         | BoardIntent::RetrySave
         | BoardIntent::CancelSave
@@ -1193,6 +1275,30 @@ fn map_project_picker(key: KeyEvent) -> Option<BoardIntent> {
         KeyCode::Char('j') | KeyCode::Down => Some(BoardIntent::ProjectPickerNext),
         KeyCode::Char('k') | KeyCode::Up => Some(BoardIntent::ProjectPickerPrev),
         KeyCode::Tab | KeyCode::Left | KeyCode::Right => Some(BoardIntent::ProjectPickerSwitchTab),
+        _ => None,
+    }
+}
+
+/// Searchable list picker (thread filter / projects View). Printable keys narrow the
+/// query, arrows move, Enter applies, Esc cancels — the palette's contract with counts.
+fn map_list_picker(key: KeyEvent) -> Option<BoardIntent> {
+    if key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+    {
+        return None;
+    }
+    match key.code {
+        KeyCode::Esc => Some(BoardIntent::CancelListPicker),
+        KeyCode::Enter => Some(BoardIntent::ConfirmListPicker),
+        KeyCode::Down => Some(BoardIntent::ListPickerNext),
+        KeyCode::Up => Some(BoardIntent::ListPickerPrev),
+        KeyCode::Backspace => Some(BoardIntent::ListPickerQueryBackspace),
+        KeyCode::Tab => Some(BoardIntent::ListPickerNext),
+        KeyCode::BackTab => Some(BoardIntent::ListPickerPrev),
+        KeyCode::Char(character) if !character.is_control() => {
+            Some(BoardIntent::ListPickerQueryInsert(character))
+        }
         _ => None,
     }
 }

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -322,6 +322,7 @@ fn verb_intent(model: &BoardModel, index: usize) -> Option<BoardIntent> {
         "esc" => Some(BoardIntent::CloseLayer),
         ":" => Some(BoardIntent::OpenCommandPalette),
         "?" => Some(BoardIntent::OpenHelp),
+        "/" => Some(BoardIntent::FocusProjectsSearch),
         "+" => Some(BoardIntent::OpenCapture),
         _ => None,
     }
@@ -800,22 +801,32 @@ pub fn map_board_mouse(
             Some(QueueHitTarget::LaunchOption(1)) => Some(BoardIntent::LaunchKeepArchived),
             _ => None,
         },
+        BoardInputMode::ListPicker => match hit_at(hits, pos) {
+            Some(QueueHitTarget::ListPickerOption(index)) => {
+                Some(BoardIntent::SelectListOption(index))
+            }
+            Some(QueueHitTarget::ModalChrome) => None,
+            Some(QueueHitTarget::ModalClose) => Some(BoardIntent::CancelListPicker),
+            _ => Some(BoardIntent::CancelListPicker),
+        },
+        BoardInputMode::ProjectsSearch => match hit_at(hits, pos) {
+            Some(QueueHitTarget::ProjectsSearch) => Some(BoardIntent::FocusProjectsSearch),
+            Some(QueueHitTarget::ProjectRow(index)) => Some(BoardIntent::SelectProjectRow(index)),
+            _ => Some(BoardIntent::CloseLayer),
+        },
         BoardInputMode::Normal => match hit_at(hits, pos) {
-            Some(QueueHitTarget::ProjectChip) => Some(BoardIntent::OpenProjectSelector),
-            Some(QueueHitTarget::HomeTab(tab)) => Some(BoardIntent::SelectHomeTab(tab)),
-            Some(QueueHitTarget::SectionProject(index)) => {
-                Some(BoardIntent::SelectSectionProject(index))
-            }
-            Some(QueueHitTarget::SectionThread(index)) => {
-                Some(BoardIntent::SelectSectionThread(index))
-            }
-            Some(QueueHitTarget::SectionThreadProject {
-                section_idx,
-                subgroup_idx,
-            }) => Some(BoardIntent::SelectSectionThreadProject {
-                section_idx,
-                subgroup_idx,
-            }),
+            Some(QueueHitTarget::NavTab(tab)) => Some(BoardIntent::SelectNavTab(tab)),
+            Some(QueueHitTarget::NavChip) => match model.nav_chip_kind() {
+                Some(crate::ui::render::NavChipKind::ThreadFilter) => {
+                    Some(BoardIntent::OpenThreadFilterPicker)
+                }
+                Some(crate::ui::render::NavChipKind::ProjectsView) => {
+                    Some(BoardIntent::OpenProjectsViewPicker)
+                }
+                None => None,
+            },
+            Some(QueueHitTarget::ProjectsSearch) => Some(BoardIntent::FocusProjectsSearch),
+            Some(QueueHitTarget::ProjectRow(index)) => Some(BoardIntent::SelectProjectRow(index)),
             Some(QueueHitTarget::Drawer) => Some(BoardIntent::ToggleDoneDrawer),
             Some(QueueHitTarget::ArchivedHeader) => Some(BoardIntent::ToggleArchivedGroup),
             Some(QueueHitTarget::TaskNumber(id)) => Some(BoardIntent::CopyTaskNumber(id)),

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use uuid::Uuid;
 
 use crate::domain::{HumanStatus, Task, TaskScope};
-use crate::scope::{archived_path_contains, paths_equivalent};
+use crate::scope::PathIdentityCache;
 
 /// The board's persistent navigation destinations.
 ///
@@ -181,14 +181,22 @@ pub fn query_board(
     drawer_open: bool,
     thread_filter: &ThreadFilter,
 ) -> QueueView {
+    let identities = PathIdentityCache::default();
     match lens {
-        BoardLens::Desk => query_desk(tasks, archived_projects, drawer_open),
-        BoardLens::Projects => query_projects_index(tasks, archived_projects, current_repo),
-        BoardLens::Project(path) => {
-            query_project_focus(tasks, archived_projects, path, drawer_open, thread_filter)
+        BoardLens::Desk => query_desk(tasks, archived_projects, drawer_open, &identities),
+        BoardLens::Projects => {
+            query_projects_index(tasks, archived_projects, current_repo, &identities)
         }
+        BoardLens::Project(path) => query_project_focus(
+            tasks,
+            archived_projects,
+            path,
+            drawer_open,
+            thread_filter,
+            &identities,
+        ),
         BoardLens::ThreadView(name) => {
-            query_thread_view(tasks, archived_projects, name, drawer_open)
+            query_thread_view(tasks, archived_projects, name, drawer_open, &identities)
         }
         // AC-41/AC-45: the read-only focus is the only lens that paints an archived
         // project's tasks. It is the project focus computed as if the project were live.
@@ -198,27 +206,36 @@ pub fn query_board(
             path,
             drawer_open,
             &ThreadFilter::All,
+            &identities,
         ),
     }
 }
 
 /// A task survives the working-lens filter: not soft-deleted, not archived, and no
 /// archived project owns its scope.
-fn is_live(task: &Task, archived_projects: &BTreeSet<String>) -> bool {
+fn is_live(
+    task: &Task,
+    archived_projects: &BTreeSet<String>,
+    identities: &PathIdentityCache,
+) -> bool {
     if task.soft_deleted || task.archived {
         return false;
     }
     match &task.scope {
         TaskScope::Global => true,
-        TaskScope::Project { path } => !archived_path_contains(archived_projects, path),
+        TaskScope::Project { path } => !identities.contains(archived_projects, path),
     }
 }
 
 /// Whether an archived project owns the task's scope (its own flag is irrelevant here).
-fn task_owned_by_archived_project(task: &Task, archived_projects: &BTreeSet<String>) -> bool {
+fn task_owned_by_archived_project(
+    task: &Task,
+    archived_projects: &BTreeSet<String>,
+    identities: &PathIdentityCache,
+) -> bool {
     match &task.scope {
         TaskScope::Global => false,
-        TaskScope::Project { path } => archived_path_contains(archived_projects, path),
+        TaskScope::Project { path } => identities.contains(archived_projects, path),
     }
 }
 
@@ -244,14 +261,15 @@ fn query_desk(
     tasks: &[Task],
     archived_projects: &BTreeSet<String>,
     drawer_open: bool,
+    identities: &PathIdentityCache,
 ) -> QueueView {
     let live: Vec<&Task> = tasks
         .iter()
-        .filter(|task| is_live(task, archived_projects))
+        .filter(|task| is_live(task, archived_projects, identities))
         .collect();
     let archived_pool: Vec<&Task> = tasks
         .iter()
-        .filter(|task| !task_owned_by_archived_project(task, archived_projects))
+        .filter(|task| !task_owned_by_archived_project(task, archived_projects, identities))
         .collect();
 
     // NEEDS YOU is the global attention lane: blocked and review across every live
@@ -302,10 +320,11 @@ fn query_projects_index(
     tasks: &[Task],
     archived_projects: &BTreeSet<String>,
     current_repo: Option<&Path>,
+    identities: &PathIdentityCache,
 ) -> QueueView {
     let live: Vec<&Task> = tasks
         .iter()
-        .filter(|task| is_live(task, archived_projects))
+        .filter(|task| is_live(task, archived_projects, identities))
         .collect();
 
     let mut paths: Vec<String> = Vec::new();
@@ -321,10 +340,10 @@ fn query_projects_index(
     // opening tsk inside an empty repo still offers its board.
     if let Some(repo) = current_repo {
         let repo_string = repo.to_string_lossy().into_owned();
-        if !archived_path_contains(archived_projects, &repo_string)
+        if !identities.contains(archived_projects, &repo_string)
             && !paths
                 .iter()
-                .any(|path| paths_equivalent(path, &repo_string))
+                .any(|path| identities.equivalent(path, &repo_string))
         {
             paths.push(repo_string);
             paths.sort();
@@ -336,7 +355,7 @@ fn query_projects_index(
             .iter()
             .map(|path| {
                 let owned = |task: &&Task| {
-                    matches!(&task.scope, TaskScope::Project { path: p } if paths_equivalent(p, path))
+                    matches!(&task.scope, TaskScope::Project { path: p } if identities.equivalent(p, path))
                 };
                 let open: Vec<&&Task> = live.iter().filter(|task| owned(task)).collect();
                 (
@@ -353,10 +372,9 @@ fn query_projects_index(
     let mut order: Vec<usize> = (0..paths.len()).collect();
     order.sort_by_key(|&index| {
         (
-            usize::from(
-                current_repo
-                    .is_some_and(|repo| !paths_equivalent(&paths[index], &repo.to_string_lossy())),
-            ),
+            usize::from(current_repo.is_some_and(|repo| {
+                !identities.equivalent(&paths[index], &repo.to_string_lossy())
+            })),
             paths[index].clone(),
         )
     });
@@ -375,8 +393,9 @@ fn query_projects_index(
                 needs_you,
                 in_motion,
                 ready,
-                current: current_repo
-                    .is_some_and(|repo| paths_equivalent(&paths[*index], &repo.to_string_lossy())),
+                current: current_repo.is_some_and(|repo| {
+                    identities.equivalent(&paths[*index], &repo.to_string_lossy())
+                }),
                 duplicate_basename: basenames.iter().filter(|name| **name == basename).count() > 1,
             }
         })
@@ -397,6 +416,7 @@ fn query_thread_view(
     archived_projects: &BTreeSet<String>,
     name: &str,
     drawer_open: bool,
+    identities: &PathIdentityCache,
 ) -> QueueView {
     let matches_thread = |task: &Task| {
         task.thread
@@ -405,12 +425,13 @@ fn query_thread_view(
     };
     let live: Vec<&Task> = tasks
         .iter()
-        .filter(|task| is_live(task, archived_projects) && matches_thread(task))
+        .filter(|task| is_live(task, archived_projects, identities) && matches_thread(task))
         .collect();
     let archived_pool: Vec<&Task> = tasks
         .iter()
         .filter(|task| {
-            !task_owned_by_archived_project(task, archived_projects) && matches_thread(task)
+            !task_owned_by_archived_project(task, archived_projects, identities)
+                && matches_thread(task)
         })
         .collect();
 
@@ -456,10 +477,14 @@ fn query_project_focus(
     path: &Path,
     drawer_open: bool,
     thread_filter: &ThreadFilter,
+    identities: &PathIdentityCache,
 ) -> QueueView {
     let live: Vec<&Task> = tasks
         .iter()
-        .filter(|task| is_live(task, archived_projects) && task_matches_scope(task, path))
+        .filter(|task| {
+            is_live(task, archived_projects, identities)
+                && task_matches_scope(task, path, identities)
+        })
         .collect();
     let admits = |task: &Task| thread_filter.admits(task);
 
@@ -482,7 +507,7 @@ fn query_project_focus(
         .iter()
         .find_map(|task| match &task.scope {
             TaskScope::Project { path: stored }
-                if paths_equivalent(stored, &path.to_string_lossy()) =>
+                if identities.equivalent(stored, &path.to_string_lossy()) =>
             {
                 Some(stored.clone())
             }
@@ -501,8 +526,8 @@ fn query_project_focus(
     append_done(&mut sections, &done_pool, drawer_open);
     let in_scope: Vec<&Task> = tasks
         .iter()
-        .filter(|task| task_matches_scope(task, path))
-        .filter(|task| !task_owned_by_archived_project(task, archived_projects))
+        .filter(|task| task_matches_scope(task, path, identities))
+        .filter(|task| !task_owned_by_archived_project(task, archived_projects, identities))
         .filter(|task| admits(task))
         .collect();
     append_archived(&mut sections, &in_scope, drawer_open);
@@ -631,9 +656,11 @@ fn push_deck(
 
 /// Whether a task belongs to the project at `path`, tolerating the same directory
 /// reached through different path spellings (symlinks, `/tmp` vs `/private/tmp`).
-fn task_matches_scope(task: &Task, path: &Path) -> bool {
+fn task_matches_scope(task: &Task, path: &Path, identities: &PathIdentityCache) -> bool {
     match &task.scope {
-        TaskScope::Project { path: stored } => paths_equivalent(stored, &path.to_string_lossy()),
+        TaskScope::Project { path: stored } => {
+            identities.equivalent(stored, &path.to_string_lossy())
+        }
         TaskScope::Global => false,
     }
 }

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,21 +1,43 @@
 //! Queue Section Query: pure derivation of the board sections from a task snapshot.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::BTreeSet;
 use std::path::Path;
-use std::time::SystemTime;
 
 use uuid::Uuid;
 
 use crate::domain::{HumanStatus, Task, TaskScope};
+use crate::scope::{archived_path_contains, paths_equivalent};
 
-/// Home-board tab lenses. Tabs are visible only at home; project focus hides them.
+/// The board's persistent navigation destinations.
+///
+/// Tabs never disappear and their digit meanings never shift: `1` desk, `2` the
+/// selected project's board, `3` the projects index. Slot 2 with no selected project
+/// opens the project picker instead of changing meaning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NavTab {
+    #[default]
+    Desk,
+    ProjectBoard,
+    Projects,
+}
+
+/// The two tab lenses reachable directly by digit. Slot 2 is a [`NavTab::ProjectBoard`],
+/// carried by the model's selected project rather than by this enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BoardTab {
     #[default]
     Desk,
     Projects,
-    Threads,
+}
+
+impl From<BoardTab> for NavTab {
+    fn from(tab: BoardTab) -> Self {
+        match tab {
+            BoardTab::Desk => NavTab::Desk,
+            BoardTab::Projects => NavTab::Projects,
+        }
+    }
 }
 
 /// Which list region a section belongs to.
@@ -34,58 +56,83 @@ pub enum SectionKind {
 /// Chrome, not a task: `BoardModel::selected_id()` hides it from verbs.
 pub const ARCHIVED_HEADER_ROW_ID: Uuid = Uuid::from_u128(0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0001);
 
-/// Session filter for project focus (today's scoped project board).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DeckScope<'a> {
-    Global,
-    Project(&'a Path),
+/// Session thread filter for the project board. It narrows every status section,
+/// done drawer included; `All` is the unfiltered board.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ThreadFilter {
+    #[default]
+    All,
+    /// Only tasks whose normalized thread matches this name (ASCII-case-insensitive).
+    Named(String),
+    /// Only tasks with no thread at all.
+    Without,
+}
+
+impl ThreadFilter {
+    /// Whether `task` passes this filter.
+    fn admits(&self, task: &Task) -> bool {
+        match self {
+            ThreadFilter::All => true,
+            ThreadFilter::Named(name) => task
+                .thread
+                .as_deref()
+                .is_some_and(|thread| thread.eq_ignore_ascii_case(name)),
+            ThreadFilter::Without => task.thread.is_none(),
+        }
+    }
+
+    /// The label the board's thread control paints for this filter.
+    pub fn label(&self) -> String {
+        match self {
+            ThreadFilter::All => "all".to_string(),
+            ThreadFilter::Named(name) => format!("#{name}"),
+            ThreadFilter::Without => "without a thread".to_string(),
+        }
+    }
 }
 
 /// How the board query is scoped for one paint/selection pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoardLens<'a> {
-    Home(BoardTab),
+    Desk,
+    Projects,
     Project(&'a Path),
+    /// Flat cross-project board for one thread name (the projects index's thread View).
+    ThreadView(&'a str),
     /// Read-only focus on an archived project (AC-41): the same shape as `Project`, but
     /// the project's archived state does not hide its tasks.
     ArchivedProject(&'a Path),
 }
 
-/// Ordered open tasks sharing a normalized thread name in a scoped ON DECK section.
+/// One selectable row of the projects index: a project and its open-work counts.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ThreadBlock {
-    pub name: String,
-    pub open_count: usize,
-    pub task_ids: Vec<Uuid>,
-}
-
-/// Project-scoped tasks under one thread group on the Threads tab.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ThreadProjectSubgroup {
-    /// `None` is the desk/global scope under this thread.
-    pub project_path: Option<String>,
-    pub task_ids: Vec<Uuid>,
+pub struct ProjectRow {
+    /// Stored project scope path.
+    pub path: String,
+    /// Blocked + review count (live, open tasks only).
+    pub needs_you: usize,
+    /// Started count.
+    pub in_motion: usize,
+    /// Ready count.
+    pub ready: usize,
+    /// True when this is the invocation directory's project.
+    pub current: bool,
+    /// Basenames seen across the whole index; a row whose basename repeats shows its
+    /// path so identical names stay distinguishable.
+    pub duplicate_basename: bool,
 }
 
 /// One ordered section of the queue board.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueueSection {
     pub kind: SectionKind,
-    /// Project path for a project-group section. `None` for NEEDS YOU, IN MOTION, DONE, desk ON DECK, and
-    /// thread-group sections.
+    /// Project path for a project-group section. `None` for every status section on
+    /// the desk, project board, thread view, and drawer.
     pub project_label: Option<String>,
-    /// Thread name for a thread-group section on the Threads tab.
-    pub thread_label: Option<String>,
-    /// Thread groups for scoped ON DECK sections only, newest group first.
-    pub thread_blocks: Vec<ThreadBlock>,
-    /// Project sub-groups for one thread on the Threads tab.
-    pub thread_subgroups: Vec<ThreadProjectSubgroup>,
-    /// Unthreaded scoped ON DECK tasks, after every thread block.
-    pub loose_task_ids: Vec<Uuid>,
     /// Exact flattening for task-only consumers and selection.
     pub task_ids: Vec<Uuid>,
     pub count: usize,
-    /// True when a scoped deck group has zero open tasks (renderer paints the empty hint).
+    /// True when a section has zero tasks (renderer paints the empty hint).
     pub empty_hint: bool,
 }
 
@@ -102,6 +149,8 @@ pub struct StatusCounts {
 pub struct QueueView {
     pub sections: Vec<QueueSection>,
     pub counts: StatusCounts,
+    /// The projects index rows, present only for the Projects lens.
+    pub projects: Vec<ProjectRow>,
 }
 
 /// Derive queue sections for the active board lens.
@@ -111,34 +160,45 @@ pub fn query_lens(
     lens: BoardLens<'_>,
     drawer_open: bool,
 ) -> QueueView {
-    query_board(tasks, &BTreeSet::new(), current_repo, lens, drawer_open)
+    query_board(
+        tasks,
+        &BTreeSet::new(),
+        current_repo,
+        lens,
+        drawer_open,
+        &ThreadFilter::All,
+    )
 }
 
 /// Derive queue sections with an archived-project set. A task is hidden when it is
 /// soft-deleted, archived, or belongs to an archived project: no working lens paints it.
+/// `thread_filter` narrows the project board across every status, drawer included.
 pub fn query_board(
     tasks: &[Task],
     archived_projects: &BTreeSet<String>,
     current_repo: Option<&Path>,
     lens: BoardLens<'_>,
     drawer_open: bool,
+    thread_filter: &ThreadFilter,
 ) -> QueueView {
     match lens {
-        BoardLens::Home(BoardTab::Desk) => query_home_desk(tasks, archived_projects, drawer_open),
-        BoardLens::Home(BoardTab::Projects) => {
-            query_home_projects(tasks, archived_projects, current_repo, drawer_open)
-        }
-        BoardLens::Home(BoardTab::Threads) => {
-            query_home_threads(tasks, archived_projects, drawer_open)
-        }
+        BoardLens::Desk => query_desk(tasks, archived_projects, drawer_open),
+        BoardLens::Projects => query_projects_index(tasks, archived_projects, current_repo),
         BoardLens::Project(path) => {
-            query_project_focus(tasks, archived_projects, path, drawer_open)
+            query_project_focus(tasks, archived_projects, path, drawer_open, thread_filter)
+        }
+        BoardLens::ThreadView(name) => {
+            query_thread_view(tasks, archived_projects, name, drawer_open)
         }
         // AC-41/AC-45: the read-only focus is the only lens that paints an archived
         // project's tasks. It is the project focus computed as if the project were live.
-        BoardLens::ArchivedProject(path) => {
-            query_project_focus(tasks, &BTreeSet::new(), path, drawer_open)
-        }
+        BoardLens::ArchivedProject(path) => query_project_focus(
+            tasks,
+            &BTreeSet::new(),
+            path,
+            drawer_open,
+            &ThreadFilter::All,
+        ),
     }
 }
 
@@ -150,7 +210,7 @@ fn is_live(task: &Task, archived_projects: &BTreeSet<String>) -> bool {
     }
     match &task.scope {
         TaskScope::Global => true,
-        TaskScope::Project { path } => !archived_projects.contains(path),
+        TaskScope::Project { path } => !archived_path_contains(archived_projects, path),
     }
 }
 
@@ -158,19 +218,12 @@ fn is_live(task: &Task, archived_projects: &BTreeSet<String>) -> bool {
 fn task_owned_by_archived_project(task: &Task, archived_projects: &BTreeSet<String>) -> bool {
     match &task.scope {
         TaskScope::Global => false,
-        TaskScope::Project { path } => archived_projects.contains(path),
+        TaskScope::Project { path } => archived_path_contains(archived_projects, path),
     }
 }
 
-/// Task ids visible for selection, honoring home-tab collapse state.
-pub fn visible_task_ids(
-    view: &QueueView,
-    lens: BoardLens<'_>,
-    collapsed_projects: &HashSet<String>,
-    collapsed_threads: &HashSet<String>,
-    collapsed_thread_projects: &HashSet<ThreadProjectCollapseKey>,
-    archived_collapsed: bool,
-) -> Vec<Uuid> {
+/// Task ids visible for selection, honoring the done drawer's archived group collapse.
+pub fn visible_task_ids(view: &QueueView, archived_collapsed: bool) -> Vec<Uuid> {
     let mut out = Vec::new();
     for section in &view.sections {
         if section.kind == SectionKind::Archived {
@@ -182,60 +235,12 @@ pub fn visible_task_ids(
             }
             continue;
         }
-        match lens {
-            BoardLens::Home(BoardTab::Projects) => {
-                let Some(path) = section.project_label.as_deref() else {
-                    push_section_tasks(&mut out, section);
-                    continue;
-                };
-                if collapsed_projects.contains(path) {
-                    continue;
-                }
-                push_section_tasks(&mut out, section);
-            }
-            BoardLens::Home(BoardTab::Threads) => {
-                // Sections without a thread label are the DONE drawer; its rows
-                // paint on this tab, so they must stay selectable.
-                let Some(thread) = section.thread_label.as_deref() else {
-                    push_section_tasks(&mut out, section);
-                    continue;
-                };
-                if collapsed_threads.contains(thread) {
-                    continue;
-                }
-                if section.thread_subgroups.is_empty() {
-                    push_section_tasks(&mut out, section);
-                    continue;
-                }
-                for subgroup in &section.thread_subgroups {
-                    let key = ThreadProjectCollapseKey {
-                        thread: thread.to_string(),
-                        project_path: subgroup.project_path.clone(),
-                    };
-                    if collapsed_thread_projects.contains(&key) {
-                        continue;
-                    }
-                    out.extend(subgroup.task_ids.iter().copied());
-                }
-            }
-            _ => push_section_tasks(&mut out, section),
-        }
+        out.extend(section.task_ids.iter().copied());
     }
     out
 }
 
-/// Session-only collapse identity for a project row under a thread group.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ThreadProjectCollapseKey {
-    pub thread: String,
-    pub project_path: Option<String>,
-}
-
-fn push_section_tasks(out: &mut Vec<Uuid>, section: &QueueSection) {
-    out.extend(section.task_ids.iter().copied());
-}
-
-fn query_home_desk(
+fn query_desk(
     tasks: &[Task],
     archived_projects: &BTreeSet<String>,
     drawer_open: bool,
@@ -248,6 +253,15 @@ fn query_home_desk(
         .iter()
         .filter(|task| !task_owned_by_archived_project(task, archived_projects))
         .collect();
+
+    // NEEDS YOU is the global attention lane: blocked and review across every live
+    // scope, desk included, with project attribution painted beside each row.
+    let mut need: Vec<&Task> = live
+        .iter()
+        .copied()
+        .filter(|t| is_needs_you_status(t.status))
+        .collect();
+    sort_by_updated_desc(&mut need);
 
     let mut motion: Vec<&Task> = live
         .iter()
@@ -256,124 +270,183 @@ fn query_home_desk(
         .collect();
     sort_by_updated_desc(&mut motion);
 
-    let mut desk: Vec<&Task> = live
+    // ON DECK · desk is the personal backlog: desk-scope ready tasks only. Project
+    // backlogs live on their project boards, never here.
+    let mut deck: Vec<&Task> = live
         .iter()
         .copied()
-        .filter(|t| {
-            matches!(
-                t.status,
-                HumanStatus::Ready | HumanStatus::Blocked | HumanStatus::Review
-            ) && matches!(t.scope, TaskScope::Global)
-        })
+        .filter(|t| t.status == HumanStatus::Ready && matches!(t.scope, TaskScope::Global))
         .collect();
-    sort_by_updated_desc(&mut desk);
-    let (need, ready) = split_needs_you(&desk);
+    sort_by_updated_desc(&mut deck);
 
     let mut sections = Vec::new();
     push_needs_you(&mut sections, &need);
     if !motion.is_empty() {
-        sections.push(section_from(SectionKind::InMotion, None, None, &motion));
+        sections.push(section_from(SectionKind::InMotion, None, &motion));
     }
-    push_deck(&mut sections, None, &ready, &need);
+    push_deck(&mut sections, None, &deck, &need);
 
     append_done(&mut sections, &live, drawer_open);
     append_archived(&mut sections, &archived_pool, drawer_open);
 
     QueueView {
         sections,
-        counts: status_counts(&live, drawer_open),
+        counts: status_counts(&live),
+        projects: Vec::new(),
     }
 }
 
-fn query_home_projects(
+/// The projects index: one selectable row per live project with open-work counts.
+/// This is navigation, not a task list: no expanded task sections.
+fn query_projects_index(
     tasks: &[Task],
     archived_projects: &BTreeSet<String>,
     current_repo: Option<&Path>,
-    drawer_open: bool,
 ) -> QueueView {
     let live: Vec<&Task> = tasks
         .iter()
         .filter(|task| is_live(task, archived_projects))
         .collect();
-    let archived_pool: Vec<&Task> = tasks
-        .iter()
-        .filter(|task| !task_owned_by_archived_project(task, archived_projects))
-        .collect();
-    let project_paths = open_project_paths(&live, current_repo);
 
-    let mut sections = Vec::new();
-    for path in project_paths {
-        let group: Vec<&Task> = live
-            .iter()
-            .copied()
-            .filter(|t| t.status != HumanStatus::Done)
-            .filter(|t| matches!(&t.scope, TaskScope::Project { path: p } if p == &path))
-            .collect();
-        let mut ordered = group;
-        sort_by_status_then_updated(&mut ordered);
-        sections.push(project_group_section(path, &ordered));
+    let mut paths: Vec<String> = Vec::new();
+    for task in &live {
+        if let TaskScope::Project { path } = &task.scope {
+            if !paths.contains(path) {
+                paths.push(path.clone());
+            }
+        }
     }
-
-    append_done(&mut sections, &live, drawer_open);
-    append_archived(&mut sections, &archived_pool, drawer_open);
-
-    QueueView {
-        sections,
-        counts: status_counts(&live, drawer_open),
-    }
-}
-
-fn query_home_threads(
-    tasks: &[Task],
-    archived_projects: &BTreeSet<String>,
-    drawer_open: bool,
-) -> QueueView {
-    let live: Vec<&Task> = tasks
-        .iter()
-        .filter(|task| is_live(task, archived_projects))
-        .collect();
-    let archived_pool: Vec<&Task> = tasks
-        .iter()
-        .filter(|task| !task_owned_by_archived_project(task, archived_projects))
-        .collect();
-
-    let mut by_thread: BTreeMap<String, Vec<&Task>> = BTreeMap::new();
-    for task in live
-        .iter()
-        .copied()
-        .filter(|t| t.status != HumanStatus::Done)
-    {
-        if let Some(name) = task.thread.as_deref() {
-            by_thread
-                .entry(name.to_ascii_lowercase())
-                .or_default()
-                .push(task);
+    paths.sort();
+    // The invocation directory's project is listed even when it has no tasks yet, so
+    // opening tsk inside an empty repo still offers its board.
+    if let Some(repo) = current_repo {
+        let repo_string = repo.to_string_lossy().into_owned();
+        if !archived_path_contains(archived_projects, &repo_string)
+            && !paths
+                .iter()
+                .any(|path| paths_equivalent(path, &repo_string))
+        {
+            paths.push(repo_string);
+            paths.sort();
         }
     }
 
-    let mut thread_names: Vec<String> = by_thread.keys().cloned().collect();
-    thread_names.sort_by_key(|name| {
-        Reverse(
-            by_thread[name]
-                .iter()
-                .map(|task| task.updated_at)
-                .max()
-                .unwrap_or(SystemTime::UNIX_EPOCH),
+    let counts_of = |paths: &[String]| -> Vec<(usize, usize, usize)> {
+        paths
+            .iter()
+            .map(|path| {
+                let owned = |task: &&Task| {
+                    matches!(&task.scope, TaskScope::Project { path: p } if paths_equivalent(p, path))
+                };
+                let open: Vec<&&Task> = live.iter().filter(|task| owned(task)).collect();
+                (
+                    open.iter().filter(|task| is_needs_you_status(task.status)).count(),
+                    open.iter().filter(|task| task.status == HumanStatus::Started).count(),
+                    open.iter().filter(|task| task.status == HumanStatus::Ready).count(),
+                )
+            })
+            .collect()
+    };
+    let counts = counts_of(&paths);
+
+    // Current directory first, then alphabetical.
+    let mut order: Vec<usize> = (0..paths.len()).collect();
+    order.sort_by_key(|&index| {
+        (
+            usize::from(
+                current_repo
+                    .is_some_and(|repo| !paths_equivalent(&paths[index], &repo.to_string_lossy())),
+            ),
+            paths[index].clone(),
         )
     });
 
-    let mut sections = Vec::new();
-    for name in thread_names {
-        let group = &by_thread[&name];
-        sections.push(thread_group_section(name, group));
+    let basenames: Vec<String> = paths
+        .iter()
+        .map(|path| short_project_name(path).to_ascii_lowercase())
+        .collect();
+    let projects = order
+        .iter()
+        .map(|index| {
+            let (needs_you, in_motion, ready) = counts[*index];
+            let basename = basenames[*index].clone();
+            ProjectRow {
+                path: paths[*index].clone(),
+                needs_you,
+                in_motion,
+                ready,
+                current: current_repo
+                    .is_some_and(|repo| paths_equivalent(&paths[*index], &repo.to_string_lossy())),
+                duplicate_basename: basenames.iter().filter(|name| **name == basename).count() > 1,
+            }
+        })
+        .collect();
+
+    QueueView {
+        sections: Vec::new(),
+        counts: status_counts(&live),
+        projects,
     }
+}
+
+/// Flat cross-project board for one thread name: matching tasks of every live scope
+/// grouped by status only, with project attribution painted beside each row. Desk
+/// tasks keep their desk ownership; nothing moves between projects.
+fn query_thread_view(
+    tasks: &[Task],
+    archived_projects: &BTreeSet<String>,
+    name: &str,
+    drawer_open: bool,
+) -> QueueView {
+    let matches_thread = |task: &Task| {
+        task.thread
+            .as_deref()
+            .is_some_and(|thread| thread.eq_ignore_ascii_case(name))
+    };
+    let live: Vec<&Task> = tasks
+        .iter()
+        .filter(|task| is_live(task, archived_projects) && matches_thread(task))
+        .collect();
+    let archived_pool: Vec<&Task> = tasks
+        .iter()
+        .filter(|task| {
+            !task_owned_by_archived_project(task, archived_projects) && matches_thread(task)
+        })
+        .collect();
+
+    let mut need: Vec<&Task> = live
+        .iter()
+        .copied()
+        .filter(|t| is_needs_you_status(t.status))
+        .collect();
+    sort_by_updated_desc(&mut need);
+    let mut motion: Vec<&Task> = live
+        .iter()
+        .copied()
+        .filter(|t| t.status == HumanStatus::Started)
+        .collect();
+    sort_by_updated_desc(&mut motion);
+    let mut deck: Vec<&Task> = live
+        .iter()
+        .copied()
+        .filter(|t| t.status == HumanStatus::Ready)
+        .collect();
+    sort_by_updated_desc(&mut deck);
+
+    let mut sections = Vec::new();
+    push_needs_you(&mut sections, &need);
+    if !motion.is_empty() {
+        sections.push(section_from(SectionKind::InMotion, None, &motion));
+    }
+    push_deck(&mut sections, None, &deck, &need);
 
     append_done(&mut sections, &live, drawer_open);
     append_archived(&mut sections, &archived_pool, drawer_open);
 
     QueueView {
         sections,
-        counts: status_counts(&live, drawer_open),
+        counts: status_counts(&live),
+        projects: Vec::new(),
     }
 }
 
@@ -382,136 +455,80 @@ fn query_project_focus(
     archived_projects: &BTreeSet<String>,
     path: &Path,
     drawer_open: bool,
+    thread_filter: &ThreadFilter,
 ) -> QueueView {
-    let scope = DeckScope::Project(path);
     let live: Vec<&Task> = tasks
         .iter()
-        .filter(|task| is_live(task, archived_projects) && task_matches_scope(task, scope))
+        .filter(|task| is_live(task, archived_projects) && task_matches_scope(task, path))
         .collect();
+    let admits = |task: &Task| thread_filter.admits(task);
 
     let mut motion: Vec<&Task> = live
         .iter()
         .copied()
-        .filter(|t| t.status == HumanStatus::Started)
+        .filter(|t| t.status == HumanStatus::Started && admits(t))
         .collect();
     sort_by_updated_desc(&mut motion);
 
     let mut open: Vec<&Task> = live
         .iter()
         .copied()
-        .filter(|t| !matches!(t.status, HumanStatus::Started | HumanStatus::Done))
+        .filter(|t| !matches!(t.status, HumanStatus::Started | HumanStatus::Done) && admits(t))
         .collect();
     sort_by_updated_desc(&mut open);
     let (need, ready) = split_needs_you(&open);
 
-    let (label, _) = live
+    let label = live
         .iter()
         .find_map(|task| match &task.scope {
-            TaskScope::Project { path: stored } if Path::new(stored) == path => {
+            TaskScope::Project { path: stored }
+                if paths_equivalent(stored, &path.to_string_lossy()) =>
+            {
                 Some(stored.clone())
             }
             _ => None,
         })
-        .map(|stored| (stored, ()))
-        .unwrap_or_else(|| (path.to_string_lossy().into_owned(), ()));
+        .unwrap_or_else(|| path.to_string_lossy().into_owned());
 
     let mut sections = Vec::new();
     push_needs_you(&mut sections, &need);
     if !motion.is_empty() {
-        sections.push(section_from(SectionKind::InMotion, None, None, &motion));
+        sections.push(section_from(SectionKind::InMotion, None, &motion));
     }
-    push_deck(&mut sections, Some(label), &ready, &need);
-    append_done(&mut sections, &live, drawer_open);
+    push_deck(&mut sections, Some(label.clone()), &ready, &need);
+
+    let done_pool: Vec<&Task> = live.iter().copied().filter(|t| admits(t)).collect();
+    append_done(&mut sections, &done_pool, drawer_open);
     let in_scope: Vec<&Task> = tasks
         .iter()
-        .filter(|task| task_matches_scope(task, scope))
+        .filter(|task| task_matches_scope(task, path))
         .filter(|task| !task_owned_by_archived_project(task, archived_projects))
+        .filter(|task| admits(task))
         .collect();
     append_archived(&mut sections, &in_scope, drawer_open);
 
-    QueueView {
-        sections,
-        counts: status_counts(&live, drawer_open),
-    }
-}
-
-fn open_project_paths(live: &[&Task], current_repo: Option<&Path>) -> Vec<String> {
-    let mut paths: BTreeSet<String> = BTreeSet::new();
-    for task in live
+    // An empty board (or a filter that hides everything) keeps one hinted section, so
+    // the project board always answers with an add affordance instead of a bare pane.
+    if !sections
         .iter()
-        .copied()
-        .filter(|t| t.status != HumanStatus::Done)
+        .any(|section| section.kind != SectionKind::Done && section.kind != SectionKind::Archived)
     {
-        if let TaskScope::Project { path } = &task.scope {
-            paths.insert(path.clone());
-        }
-    }
-    let mut ordered: Vec<String> = paths.into_iter().collect();
-    if let Some(repo) = current_repo {
-        if let Some(pos) = ordered.iter().position(|path| Path::new(path) == repo) {
-            let current = ordered.remove(pos);
-            ordered.insert(0, current);
-        }
-    }
-    ordered
-}
-
-fn project_group_section(path: String, tasks: &[&Task]) -> QueueSection {
-    let task_ids: Vec<Uuid> = tasks.iter().map(|t| t.id).collect();
-    let count = task_ids.len();
-    QueueSection {
-        kind: SectionKind::OnDeck,
-        project_label: Some(path),
-        thread_label: None,
-        thread_blocks: Vec::new(),
-        thread_subgroups: Vec::new(),
-        loose_task_ids: Vec::new(),
-        task_ids,
-        count,
-        empty_hint: count == 0,
-    }
-}
-
-fn thread_group_section(name: String, tasks: &[&Task]) -> QueueSection {
-    let mut by_scope: BTreeMap<Option<String>, Vec<&Task>> = BTreeMap::new();
-    for task in tasks {
-        let key = match &task.scope {
-            TaskScope::Global => None,
-            TaskScope::Project { path } => Some(path.clone()),
-        };
-        by_scope.entry(key).or_default().push(*task);
-    }
-
-    let mut scope_keys: Vec<Option<String>> = by_scope.keys().cloned().collect();
-    scope_keys.sort_by_key(|path| match path {
-        None => (1u8, String::new()),
-        Some(path) => (0u8, path.clone()),
-    });
-
-    let mut thread_subgroups = Vec::new();
-    let mut task_ids = Vec::new();
-    for path in scope_keys {
-        let mut group = by_scope.remove(&path).unwrap_or_default();
-        sort_by_status_then_updated(&mut group);
-        let ids: Vec<Uuid> = group.iter().map(|t| t.id).collect();
-        task_ids.extend(ids.iter().copied());
-        thread_subgroups.push(ThreadProjectSubgroup {
-            project_path: path,
-            task_ids: ids,
+        sections.push(QueueSection {
+            kind: SectionKind::OnDeck,
+            project_label: Some(label),
+            task_ids: Vec::new(),
+            count: 0,
+            empty_hint: true,
         });
     }
 
-    let count = task_ids.len();
-    QueueSection {
-        kind: SectionKind::OnDeck,
-        project_label: None,
-        thread_label: Some(name),
-        thread_blocks: Vec::new(),
-        thread_subgroups,
-        loose_task_ids: Vec::new(),
-        task_ids,
-        count,
-        empty_hint: count == 0,
+    // Status counts come from the filtered set, so the chrome never advertises work
+    // the active thread filter is hiding.
+    let counted: Vec<&Task> = live.iter().copied().filter(|t| admits(t)).collect();
+    QueueView {
+        sections,
+        counts: status_counts(&counted),
+        projects: Vec::new(),
     }
 }
 
@@ -526,7 +543,7 @@ fn append_done(sections: &mut Vec<QueueSection>, live: &[&Task], drawer_open: bo
         .collect();
     sort_by_updated_desc(&mut done);
     if !done.is_empty() {
-        sections.push(section_from(SectionKind::Done, None, None, &done));
+        sections.push(section_from(SectionKind::Done, None, &done));
     }
 }
 
@@ -544,24 +561,19 @@ fn append_archived(sections: &mut Vec<QueueSection>, in_scope: &[&Task], drawer_
         .collect();
     sort_by_updated_desc(&mut archived);
     if !archived.is_empty() {
-        sections.push(section_from(SectionKind::Archived, None, None, &archived));
+        sections.push(section_from(SectionKind::Archived, None, &archived));
     }
 }
 
-fn status_counts(live: &[&Task], drawer_open: bool) -> StatusCounts {
+fn status_counts(live: &[&Task]) -> StatusCounts {
     let in_motion = live
         .iter()
         .filter(|t| t.status == HumanStatus::Started)
         .count();
-    let done = if drawer_open {
-        live.iter()
-            .filter(|t| t.status == HumanStatus::Done)
-            .count()
-    } else {
-        live.iter()
-            .filter(|t| t.status == HumanStatus::Done)
-            .count()
-    };
+    let done = live
+        .iter()
+        .filter(|t| t.status == HumanStatus::Done)
+        .count();
     let need = live
         .iter()
         .filter(|t| is_needs_you_status(t.status))
@@ -592,7 +604,7 @@ fn split_needs_you<'a>(tasks: &[&'a Task]) -> (Vec<&'a Task>, Vec<&'a Task>) {
 
 fn push_needs_you(sections: &mut Vec<QueueSection>, need: &[&Task]) {
     if !need.is_empty() {
-        sections.push(section_from(SectionKind::NeedsYou, None, None, need));
+        sections.push(section_from(SectionKind::NeedsYou, None, need));
     }
 }
 
@@ -606,16 +618,23 @@ fn push_deck(
     if ready.is_empty() && !need.is_empty() {
         return;
     }
-    sections.push(deck_section(project_label, ready));
+    let task_ids: Vec<Uuid> = ready.iter().map(|t| t.id).collect();
+    let count = task_ids.len();
+    sections.push(QueueSection {
+        kind: SectionKind::OnDeck,
+        project_label,
+        task_ids,
+        count,
+        empty_hint: count == 0,
+    });
 }
 
-fn task_matches_scope(task: &Task, scope: DeckScope<'_>) -> bool {
-    match scope {
-        DeckScope::Global => matches!(task.scope, TaskScope::Global),
-        DeckScope::Project(selected) => matches!(
-            &task.scope,
-            TaskScope::Project { path } if Path::new(path) == selected
-        ),
+/// Whether a task belongs to the project at `path`, tolerating the same directory
+/// reached through different path spellings (symlinks, `/tmp` vs `/private/tmp`).
+fn task_matches_scope(task: &Task, path: &Path) -> bool {
+    match &task.scope {
+        TaskScope::Project { path: stored } => paths_equivalent(stored, &path.to_string_lossy()),
+        TaskScope::Global => false,
     }
 }
 
@@ -623,96 +642,24 @@ fn sort_by_updated_desc(tasks: &mut [&Task]) {
     tasks.sort_by_key(|t| Reverse(t.updated_at));
 }
 
-fn status_rank(status: HumanStatus) -> u8 {
-    match status {
-        HumanStatus::Started => 0,
-        HumanStatus::Review => 1,
-        HumanStatus::Blocked => 2,
-        HumanStatus::Ready => 3,
-        HumanStatus::Done => 4,
-    }
-}
-
-fn sort_by_status_then_updated(tasks: &mut [&Task]) {
-    tasks.sort_by(|a, b| {
-        status_rank(a.status)
-            .cmp(&status_rank(b.status))
-            .then_with(|| b.updated_at.cmp(&a.updated_at))
-    });
-}
-
-fn section_from(
-    kind: SectionKind,
-    project_label: Option<String>,
-    thread_label: Option<String>,
-    tasks: &[&Task],
-) -> QueueSection {
+fn section_from(kind: SectionKind, project_label: Option<String>, tasks: &[&Task]) -> QueueSection {
     let task_ids: Vec<Uuid> = tasks.iter().map(|t| t.id).collect();
     let count = task_ids.len();
     QueueSection {
         kind,
         project_label,
-        thread_label,
-        thread_blocks: Vec::new(),
-        thread_subgroups: Vec::new(),
-        loose_task_ids: Vec::new(),
         task_ids,
         count,
         empty_hint: false,
     }
 }
 
-/// ON DECK section for a scoped group: empty groups keep the header and set `empty_hint`.
-fn deck_section(project_label: Option<String>, tasks: &[&Task]) -> QueueSection {
-    let mut grouped: BTreeMap<String, Vec<&Task>> = BTreeMap::new();
-    let mut loose = Vec::new();
-    for task in tasks {
-        if let Some(name) = task.thread.as_deref() {
-            grouped
-                .entry(name.to_ascii_lowercase())
-                .or_default()
-                .push(*task);
-        } else {
-            loose.push(*task);
-        }
-    }
-
-    let mut thread_blocks: Vec<ThreadBlock> = grouped
-        .into_iter()
-        .map(|(name, tasks)| ThreadBlock {
-            name,
-            open_count: tasks.len(),
-            task_ids: tasks.iter().map(|task| task.id).collect(),
-        })
-        .collect();
-    thread_blocks.sort_by_key(|block| {
-        Reverse(
-            tasks
-                .iter()
-                .find(|task| task.id == block.task_ids[0])
-                .expect("thread block task comes from deck tasks")
-                .updated_at,
-        )
-    });
-
-    let loose_task_ids: Vec<Uuid> = loose.iter().map(|task| task.id).collect();
-    let task_ids = thread_blocks
-        .iter()
-        .flat_map(|block| block.task_ids.iter().copied())
-        .chain(loose_task_ids.iter().copied())
-        .collect();
-    let count = tasks.len();
-    QueueSection {
-        kind: SectionKind::OnDeck,
-        project_label,
-        thread_label: None,
-        thread_blocks,
-        thread_subgroups: Vec::new(),
-        loose_task_ids,
-        task_ids,
-        count,
-        empty_hint: count == 0,
-    }
+/// Basename of a project path, for labels and search.
+pub fn short_project_name(path: &str) -> &str {
+    path.trim_end_matches('/')
+        .rsplit('/')
+        .find(|component| !component.is_empty())
+        .unwrap_or(path)
 }
 
 #[cfg(test)]
@@ -802,14 +749,21 @@ mod tests {
             task.archived = true;
         }
 
-        // Home drawer: every scope's archived tasks, newest first. A task whose
+        // Desk drawer: every scope's archived tasks, newest first. A task whose
         // project is archived stays hidden (task 3).
-        let home = query_board(&tasks, &gone, None, BoardLens::Home(BoardTab::Desk), true);
+        let home = query_board(
+            &tasks,
+            &gone,
+            None,
+            BoardLens::Desk,
+            true,
+            &ThreadFilter::All,
+        );
         let group = home
             .sections
             .iter()
             .find(|s| s.kind == SectionKind::Archived)
-            .expect("archived group at home");
+            .expect("archived group at desk");
         assert_eq!(
             ids(group),
             vec![Uuid::from_u128(2), Uuid::from_u128(1)],
@@ -824,6 +778,7 @@ mod tests {
             None,
             BoardLens::Project(Path::new("/repos/a")),
             true,
+            &ThreadFilter::All,
         );
         let group = focus
             .sections
@@ -834,7 +789,7 @@ mod tests {
     }
 
     #[test]
-    fn thread_header_and_open_count_exclude_an_archived_task() {
+    fn an_archived_only_thread_paints_no_filter_match_anywhere() {
         let mut tasks = vec![task_with_thread(
             1,
             HumanStatus::Ready,
@@ -845,54 +800,43 @@ mod tests {
         )];
         tasks[0].archived = true;
 
-        // Scoped deck (project focus): the thread's only open task is archived, so no
-        // block paints.
-        let deck = query_lens(
+        // Project board: the thread's only open task is archived, so the filter
+        // offers no match and the deck shows the empty hint instead.
+        let deck = query_board(
             &tasks,
+            &BTreeSet::new(),
             None,
             BoardLens::Project(Path::new("/repos/a")),
             false,
+            &ThreadFilter::Named("release".to_string()),
         );
         let on_deck = deck
             .sections
             .iter()
             .find(|s| s.kind == SectionKind::OnDeck)
-            .expect("project focus on deck");
+            .expect("project board on deck");
         assert!(
-            on_deck.thread_blocks.is_empty(),
-            "an archived-only thread must paint no header: {:?}",
-            on_deck.thread_blocks
+            on_deck.empty_hint,
+            "an archived-only thread paints the hint"
         );
 
-        // Threads tab: no section for the thread at all.
-        let threads = query_lens(&tasks, None, BoardLens::Home(BoardTab::Threads), false);
-        assert!(
-            !threads
-                .sections
-                .iter()
-                .any(|s| s.thread_label.as_deref() == Some("release")),
-            "an archived-only thread must not paint on the threads tab"
-        );
-
-        // Sanity: unarchived again, the header and its open count are back.
-        tasks[0].archived = false;
-        let deck = query_lens(
+        // Thread view: no sections for the thread at all beyond the hint.
+        let view = query_board(
             &tasks,
+            &BTreeSet::new(),
             None,
-            BoardLens::Project(Path::new("/repos/a")),
+            BoardLens::ThreadView("release"),
             false,
+            &ThreadFilter::All,
         );
-        let on_deck = deck
-            .sections
-            .iter()
-            .find(|s| s.kind == SectionKind::OnDeck)
-            .expect("project focus on deck");
-        assert_eq!(on_deck.thread_blocks.len(), 1);
-        assert_eq!(on_deck.thread_blocks[0].open_count, 1);
+        assert!(
+            !view.sections.iter().any(|s| !s.empty_hint),
+            "an archived-only thread must not paint on the thread view"
+        );
     }
 
     #[test]
-    fn archived_project_hides_its_tasks_from_projects_threads_and_desk_in_motion() {
+    fn archived_project_hides_its_tasks_from_index_threadview_and_desk() {
         let mut archived = BTreeSet::new();
         archived.insert("/repos/gone".to_string());
         let tasks = vec![
@@ -910,40 +854,36 @@ mod tests {
             task(5, HumanStatus::Ready, project("/repos/here"), false, 10),
         ];
 
-        // Projects tab: the archived project paints no group, the live one stays.
-        let projects = query_board(
+        // Projects index: the archived project paints no row, the live one stays.
+        let index = query_board(
             &tasks,
             &archived,
             None,
-            BoardLens::Home(BoardTab::Projects),
+            BoardLens::Projects,
             false,
+            &ThreadFilter::All,
         );
         assert!(
-            !projects
-                .sections
-                .iter()
-                .any(|s| s.project_label.as_deref() == Some("/repos/gone")),
-            "archived project must not paint a projects-tab group"
+            !index.projects.iter().any(|row| row.path == "/repos/gone"),
+            "archived project must not paint an index row"
         );
-        assert!(projects
-            .sections
-            .iter()
-            .any(|s| s.project_label.as_deref() == Some("/repos/here")),);
+        assert!(index.projects.iter().any(|row| row.path == "/repos/here"));
 
-        // Threads tab: the archived project's thread contributes nothing.
-        let threads = query_board(
+        // Thread view: the archived project's thread contributes nothing.
+        let view = query_board(
             &tasks,
             &archived,
             None,
-            BoardLens::Home(BoardTab::Threads),
+            BoardLens::ThreadView("release"),
             false,
+            &ThreadFilter::All,
         );
         assert!(
-            !threads
+            !view
                 .sections
                 .iter()
-                .any(|s| s.thread_label.as_deref() == Some("release")),
-            "an archived project's thread must not paint on the threads tab"
+                .any(|s| s.task_ids.contains(&Uuid::from_u128(3))),
+            "an archived project's thread must not paint on the thread view"
         );
 
         // Desk IN MOTION: the archived project's started task is gone, the global one stays.
@@ -951,8 +891,9 @@ mod tests {
             &tasks,
             &archived,
             None,
-            BoardLens::Home(BoardTab::Desk),
+            BoardLens::Desk,
             false,
+            &ThreadFilter::All,
         );
         let motion = section_ids(&desk, SectionKind::InMotion);
         assert!(!motion.contains(&Uuid::from_u128(1)));
@@ -960,7 +901,7 @@ mod tests {
     }
 
     #[test]
-    fn home_desk_in_motion_is_global_started_sorted_by_updated_desc() {
+    fn desk_in_motion_is_global_started_sorted_by_updated_desc() {
         let tasks = vec![
             task(1, HumanStatus::Started, TaskScope::Global, false, 10),
             task(2, HumanStatus::Started, project("/repos/a"), false, 30),
@@ -969,7 +910,7 @@ mod tests {
             task(5, HumanStatus::Started, project("/repos/b"), false, 20),
         ];
 
-        let view = query_lens(&tasks, None, BoardLens::Home(BoardTab::Desk), false);
+        let view = query_lens(&tasks, None, BoardLens::Desk, false);
 
         let motion: Vec<_> = view
             .sections
@@ -989,40 +930,50 @@ mod tests {
             .collect();
         assert_eq!(desk.len(), 1);
         assert_eq!(ids(desk[0]), vec![Uuid::from_u128(4)]);
-        assert!(section_ids(&view, SectionKind::InMotion).contains(&Uuid::from_u128(2)));
         assert!(!section_ids(&view, SectionKind::OnDeck).contains(&Uuid::from_u128(2)));
     }
 
     #[test]
-    fn home_desk_puts_global_blocked_and_review_in_needs_you() {
+    fn desk_needs_you_is_global_across_every_live_scope() {
         let tasks = vec![
             task(1, HumanStatus::Blocked, TaskScope::Global, false, 10),
-            task(2, HumanStatus::Review, TaskScope::Global, false, 30),
+            task(2, HumanStatus::Review, project("/repos/a"), false, 30),
             task(3, HumanStatus::Ready, TaskScope::Global, false, 20),
-            task(4, HumanStatus::Blocked, project("/repos/a"), false, 40),
-            task(5, HumanStatus::Started, TaskScope::Global, false, 50),
+            task(4, HumanStatus::Blocked, project("/repos/b"), false, 40),
+            task(5, HumanStatus::Review, project("/repos/a"), false, 50),
+            task(6, HumanStatus::Blocked, project("/repos/gone"), false, 60),
         ];
+        let mut gone = BTreeSet::new();
+        gone.insert("/repos/gone".to_string());
 
-        let view = query_lens(&tasks, None, BoardLens::Home(BoardTab::Desk), false);
+        let view = query_board(
+            &tasks,
+            &gone,
+            None,
+            BoardLens::Desk,
+            false,
+            &ThreadFilter::All,
+        );
         assert_eq!(
             section_ids(&view, SectionKind::NeedsYou),
-            vec![Uuid::from_u128(2), Uuid::from_u128(1)]
+            vec![
+                Uuid::from_u128(5),
+                Uuid::from_u128(4),
+                Uuid::from_u128(2),
+                Uuid::from_u128(1),
+            ],
+            "blocked/review from every live project plus desk, newest first"
         );
         assert_eq!(
             section_ids(&view, SectionKind::OnDeck),
-            vec![Uuid::from_u128(3)]
+            vec![Uuid::from_u128(3)],
+            "project ready tasks never leak into the desk backlog"
         );
-        assert!(!section_ids(&view, SectionKind::NeedsYou).contains(&Uuid::from_u128(4)));
-        assert_eq!(view.counts.need, 3);
-        assert_eq!(
-            view.sections[0].kind,
-            SectionKind::NeedsYou,
-            "NEEDS YOU sits above IN MOTION"
-        );
+        assert_eq!(view.sections[0].kind, SectionKind::NeedsYou);
     }
 
     #[test]
-    fn project_focus_puts_blocked_and_review_in_needs_you() {
+    fn project_board_puts_blocked_and_review_in_needs_you() {
         let tasks = vec![
             task(1, HumanStatus::Started, project("/repos/a"), false, 100),
             task(2, HumanStatus::Blocked, project("/repos/a"), false, 80),
@@ -1031,11 +982,13 @@ mod tests {
             task(5, HumanStatus::Blocked, project("/repos/b"), false, 60),
         ];
 
-        let view = query_lens(
+        let view = query_board(
             &tasks,
+            &BTreeSet::new(),
             None,
             BoardLens::Project(Path::new("/repos/a")),
             false,
+            &ThreadFilter::All,
         );
         assert_eq!(
             section_ids(&view, SectionKind::NeedsYou),
@@ -1052,16 +1005,18 @@ mod tests {
     #[test]
     fn empty_deck_is_omitted_when_needs_you_has_rows() {
         let desk_tasks = vec![task(1, HumanStatus::Blocked, TaskScope::Global, false, 10)];
-        let desk = query_lens(&desk_tasks, None, BoardLens::Home(BoardTab::Desk), false);
+        let desk = query_lens(&desk_tasks, None, BoardLens::Desk, false);
         assert!(desk.sections.iter().all(|s| s.kind != SectionKind::OnDeck));
         assert!(!desk.sections.iter().any(|s| s.empty_hint));
 
         let project_tasks = vec![task(2, HumanStatus::Review, project("/repos/a"), false, 10)];
-        let project = query_lens(
+        let project = query_board(
             &project_tasks,
+            &BTreeSet::new(),
             None,
             BoardLens::Project(Path::new("/repos/a")),
             false,
+            &ThreadFilter::All,
         );
         assert!(project
             .sections
@@ -1071,45 +1026,102 @@ mod tests {
     }
 
     #[test]
-    fn home_projects_keeps_started_under_project_ordered_by_status() {
-        let tasks = vec![
-            task(1, HumanStatus::Ready, project("/repos/a"), false, 10),
-            task(2, HumanStatus::Started, project("/repos/a"), false, 20),
-            task(3, HumanStatus::Blocked, project("/repos/a"), false, 30),
-            task(4, HumanStatus::Review, project("/repos/a"), false, 40),
-            task(5, HumanStatus::Started, project("/repos/b"), false, 50),
-        ];
-
-        let view = query_lens(
+    fn empty_project_board_keeps_one_hinted_deck_section() {
+        let tasks = vec![task(9, HumanStatus::Ready, project("/repos/b"), false, 10)];
+        let view = query_board(
             &tasks,
-            Some(Path::new("/repos/a")),
-            BoardLens::Home(BoardTab::Projects),
+            &BTreeSet::new(),
+            None,
+            BoardLens::Project(Path::new("/repos/a")),
             false,
+            &ThreadFilter::All,
         );
-
-        assert!(view
+        let deck = view
             .sections
             .iter()
-            .all(|section| section.kind != SectionKind::InMotion));
-
-        let a = view
-            .sections
-            .iter()
-            .find(|s| s.project_label.as_deref() == Some("/repos/a"))
-            .expect("project a");
-        assert_eq!(
-            ids(a),
-            vec![
-                Uuid::from_u128(2),
-                Uuid::from_u128(4),
-                Uuid::from_u128(3),
-                Uuid::from_u128(1),
-            ]
-        );
+            .find(|s| s.kind == SectionKind::OnDeck)
+            .expect("empty project keeps the deck section");
+        assert!(deck.empty_hint);
+        assert!(deck.task_ids.is_empty());
     }
 
     #[test]
-    fn home_threads_groups_cross_project_by_name_with_project_subgroups() {
+    fn thread_filter_narrows_every_project_status_and_the_drawer() {
+        let tasks = vec![
+            task_with_thread(
+                1,
+                HumanStatus::Blocked,
+                project("/a"),
+                false,
+                50,
+                Some("nav"),
+            ),
+            task_with_thread(
+                2,
+                HumanStatus::Started,
+                project("/a"),
+                false,
+                40,
+                Some("nav"),
+            ),
+            task_with_thread(3, HumanStatus::Ready, project("/a"), false, 30, Some("nav")),
+            task_with_thread(4, HumanStatus::Done, project("/a"), false, 20, Some("nav")),
+            task_with_thread(
+                5,
+                HumanStatus::Blocked,
+                project("/a"),
+                false,
+                60,
+                Some("docs"),
+            ),
+            task_with_thread(6, HumanStatus::Ready, project("/a"), false, 70, None),
+        ];
+        let lens = BoardLens::Project(Path::new("/a"));
+
+        let nav = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            None,
+            lens,
+            true,
+            &ThreadFilter::Named("nav".to_string()),
+        );
+        assert_eq!(
+            section_ids(&nav, SectionKind::NeedsYou),
+            vec![Uuid::from_u128(1)]
+        );
+        assert_eq!(
+            section_ids(&nav, SectionKind::InMotion),
+            vec![Uuid::from_u128(2)]
+        );
+        assert_eq!(
+            section_ids(&nav, SectionKind::OnDeck),
+            vec![Uuid::from_u128(3)]
+        );
+        assert_eq!(
+            section_ids(&nav, SectionKind::Done),
+            vec![Uuid::from_u128(4)]
+        );
+        assert_eq!(nav.counts.need, 1, "status counts reflect the filtered set");
+
+        let without = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            None,
+            lens,
+            false,
+            &ThreadFilter::Without,
+        );
+        assert_eq!(
+            section_ids(&without, SectionKind::OnDeck),
+            vec![Uuid::from_u128(6)],
+            "unthreaded tasks are the Without-a-thread filter's matches"
+        );
+        assert!(section_ids(&without, SectionKind::NeedsYou).is_empty());
+    }
+
+    #[test]
+    fn thread_view_is_flat_across_projects_and_desk_with_no_nesting() {
         let tasks = vec![
             task_with_thread(
                 1,
@@ -1143,18 +1155,206 @@ mod tests {
                 5,
                 Some("other"),
             ),
+            task_with_thread(
+                5,
+                HumanStatus::Blocked,
+                project("/repos/a"),
+                false,
+                8,
+                Some("release"),
+            ),
         ];
 
-        let view = query_lens(&tasks, None, BoardLens::Home(BoardTab::Threads), false);
-        let release = view
-            .sections
-            .iter()
-            .find(|s| s.thread_label.as_deref() == Some("release"))
-            .expect("release thread");
-        assert_eq!(release.thread_subgroups.len(), 3);
+        let view = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            None,
+            BoardLens::ThreadView("release"),
+            false,
+            &ThreadFilter::All,
+        );
         assert_eq!(
-            ids(release),
-            vec![Uuid::from_u128(1), Uuid::from_u128(3), Uuid::from_u128(2),]
+            section_ids(&view, SectionKind::NeedsYou),
+            vec![Uuid::from_u128(3), Uuid::from_u128(5)]
+        );
+        assert_eq!(
+            section_ids(&view, SectionKind::InMotion),
+            vec![Uuid::from_u128(1)]
+        );
+        assert_eq!(
+            section_ids(&view, SectionKind::OnDeck),
+            vec![Uuid::from_u128(2)]
+        );
+        assert!(
+            view.sections.iter().all(|s| s.project_label.is_none()),
+            "thread view sections are plain status groups, no thread/project nesting"
+        );
+        assert!(!all_listed_ids(&view).contains(&Uuid::from_u128(4)));
+    }
+
+    #[test]
+    fn thread_view_matches_names_ascii_case_insensitively_and_includes_done() {
+        let tasks = vec![
+            task_with_thread(
+                1,
+                HumanStatus::Ready,
+                project("/a"),
+                false,
+                10,
+                Some("Release"),
+            ),
+            task_with_thread(
+                2,
+                HumanStatus::Done,
+                project("/a"),
+                false,
+                30,
+                Some("RELEASE"),
+            ),
+        ];
+        let view = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            None,
+            BoardLens::ThreadView("release"),
+            true,
+            &ThreadFilter::All,
+        );
+        assert_eq!(
+            section_ids(&view, SectionKind::OnDeck),
+            vec![Uuid::from_u128(1)]
+        );
+        assert_eq!(
+            section_ids(&view, SectionKind::Done),
+            vec![Uuid::from_u128(2)]
+        );
+    }
+
+    #[test]
+    fn projects_index_lists_counts_current_first_and_flags_duplicate_basenames() {
+        let tasks = vec![
+            task(1, HumanStatus::Blocked, project("/w/launch"), false, 10),
+            task(2, HumanStatus::Started, project("/w/launch"), false, 20),
+            task(3, HumanStatus::Ready, project("/w/launch"), false, 30),
+            task(4, HumanStatus::Ready, project("/w/launch"), false, 35),
+            task(5, HumanStatus::Review, project("/w/herdr"), false, 40),
+            task(6, HumanStatus::Done, project("/w/herdr"), false, 50),
+            task(7, HumanStatus::Ready, project("/x/site"), false, 60),
+            task(8, HumanStatus::Ready, project("/y/site"), false, 70),
+        ];
+
+        let view = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            Some(Path::new("/w/herdr")),
+            BoardLens::Projects,
+            false,
+            &ThreadFilter::All,
+        );
+
+        let names: Vec<&str> = view.projects.iter().map(|row| row.path.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["/w/herdr", "/w/launch", "/x/site", "/y/site"],
+            "the invocation project leads, the rest sort by path"
+        );
+        assert!(view.projects[0].current);
+        assert!(!view.projects[1].current);
+
+        let launch = &view.projects[1];
+        assert_eq!(launch.needs_you, 1, "blocked counts as needs-you");
+        assert_eq!(launch.in_motion, 1);
+        assert_eq!(launch.ready, 2, "done tasks never count");
+        assert!(!launch.duplicate_basename);
+
+        let sites: Vec<&ProjectRow> = view.projects[2..].iter().collect();
+        assert!(
+            sites.iter().all(|row| row.duplicate_basename),
+            "two projects named site must be flagged so rows can disambiguate with paths"
+        );
+
+        assert!(
+            view.sections.is_empty(),
+            "the index is navigation, never an expanded task list"
+        );
+    }
+
+    #[test]
+    fn projects_index_lists_the_invocation_project_even_with_no_tasks() {
+        let tasks = vec![task(1, HumanStatus::Ready, project("/w/other"), false, 10)];
+        let view = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            Some(Path::new("/w/fresh")),
+            BoardLens::Projects,
+            false,
+            &ThreadFilter::All,
+        );
+        assert_eq!(view.projects.len(), 2);
+        assert_eq!(view.projects[0].path, "/w/fresh");
+        assert!(view.projects[0].current);
+        assert_eq!(
+            (
+                view.projects[0].needs_you,
+                view.projects[0].in_motion,
+                view.projects[0].ready
+            ),
+            (0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn project_board_matches_tasks_across_path_spellings() {
+        use std::fs;
+
+        // The stored scope was captured through one spelling of the directory; the
+        // invocation resolved the same directory through a symlink (the /tmp vs
+        // /private/tmp mismatch). The lens must still match, without rewriting the
+        // stored identity.
+        static SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-path-spelling-{}-{seq}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).expect("mkdir");
+        let link = std::env::temp_dir().join(format!(
+            "tsk-path-spelling-link-{}-{seq}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let _ = fs::remove_file(&link);
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&dir, &link).expect("symlink");
+        #[cfg(not(unix))]
+        {
+            let _ = &link;
+            fs::remove_dir_all(&dir).expect("cleanup");
+            return;
+        }
+
+        let stored = dir.to_string_lossy().into_owned();
+        let invoked = link.to_string_lossy().into_owned();
+        let tasks = vec![task(1, HumanStatus::Ready, project(&stored), false, 10)];
+        let view = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            None,
+            BoardLens::Project(Path::new(&invoked)),
+            false,
+            &ThreadFilter::All,
+        );
+        let matched = section_ids(&view, SectionKind::OnDeck) == vec![Uuid::from_u128(1)];
+        fs::remove_file(&link).ok();
+        fs::remove_dir_all(&dir).ok();
+        assert!(
+            matched,
+            "equivalent path spellings must match the stored project scope"
         );
     }
 
@@ -1167,10 +1367,10 @@ mod tests {
             task(4, HumanStatus::Ready, TaskScope::Global, false, 50),
         ];
 
-        let closed = query_lens(&tasks, None, BoardLens::Home(BoardTab::Desk), false);
+        let closed = query_lens(&tasks, None, BoardLens::Desk, false);
         assert!(closed.sections.iter().all(|s| s.kind != SectionKind::Done));
 
-        let open = query_lens(&tasks, None, BoardLens::Home(BoardTab::Desk), true);
+        let open = query_lens(&tasks, None, BoardLens::Desk, true);
         let done: Vec<_> = open
             .sections
             .iter()
@@ -1181,7 +1381,7 @@ mod tests {
     }
 
     #[test]
-    fn project_focus_filters_sections_to_matching_project() {
+    fn project_board_filters_sections_to_matching_project() {
         let tasks = vec![
             task(1, HumanStatus::Started, project("/repos/a"), false, 100),
             task(2, HumanStatus::Started, project("/repos/b"), false, 90),
@@ -1189,11 +1389,13 @@ mod tests {
             task(20, HumanStatus::Done, project("/repos/a"), false, 40),
         ];
 
-        let view = query_lens(
+        let view = query_board(
             &tasks,
+            &BTreeSet::new(),
             None,
             BoardLens::Project(Path::new("/repos/a")),
             true,
+            &ThreadFilter::All,
         );
 
         assert_eq!(
@@ -1208,77 +1410,60 @@ mod tests {
     }
 
     #[test]
-    fn visible_task_ids_honors_project_and_thread_collapse() {
+    fn visible_task_ids_keeps_done_drawer_rows_selectable() {
         let tasks = vec![
             task(1, HumanStatus::Ready, project("/repos/a"), false, 10),
-            task(2, HumanStatus::Ready, project("/repos/b"), false, 20),
-            task_with_thread(
-                3,
-                HumanStatus::Ready,
-                project("/repos/a"),
-                false,
-                30,
-                Some("release"),
-            ),
-        ];
-        let view = query_lens(&tasks, None, BoardLens::Home(BoardTab::Projects), false);
-        let mut collapsed_projects = HashSet::new();
-        collapsed_projects.insert("/repos/a".to_string());
-        let visible = visible_task_ids(
-            &view,
-            BoardLens::Home(BoardTab::Projects),
-            &collapsed_projects,
-            &HashSet::new(),
-            &HashSet::new(),
-            false,
-        );
-        assert_eq!(visible, vec![Uuid::from_u128(2)]);
-
-        let threads = query_lens(&tasks, None, BoardLens::Home(BoardTab::Threads), false);
-        let mut collapsed_threads = HashSet::new();
-        collapsed_threads.insert("release".to_string());
-        let visible_threads = visible_task_ids(
-            &threads,
-            BoardLens::Home(BoardTab::Threads),
-            &HashSet::new(),
-            &collapsed_threads,
-            &HashSet::new(),
-            false,
-        );
-        assert!(visible_threads.is_empty());
-    }
-
-    #[test]
-    fn visible_task_ids_threads_keeps_done_drawer_rows_selectable() {
-        let tasks = vec![
-            task_with_thread(
-                1,
-                HumanStatus::Ready,
-                project("/repos/a"),
-                false,
-                10,
-                Some("release"),
-            ),
             task(2, HumanStatus::Done, project("/repos/a"), false, 40),
         ];
-        let threads = query_lens(&tasks, None, BoardLens::Home(BoardTab::Threads), true);
+        let view = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            None,
+            BoardLens::Project(Path::new("/repos/a")),
+            true,
+            &ThreadFilter::All,
+        );
         assert_eq!(
-            section_ids(&threads, SectionKind::Done),
+            section_ids(&view, SectionKind::Done),
             vec![Uuid::from_u128(2)]
         );
 
-        let visible = visible_task_ids(
-            &threads,
-            BoardLens::Home(BoardTab::Threads),
-            &HashSet::new(),
-            &HashSet::new(),
-            &HashSet::new(),
-            false,
-        );
+        // No archived tasks: the drawer paints DONE rows only.
+        let visible = visible_task_ids(&view, false);
         assert_eq!(
             visible,
             vec![Uuid::from_u128(1), Uuid::from_u128(2)],
             "painted DONE drawer rows must stay in the selectable set"
+        );
+
+        // With an archived task present, the header row is always selectable so Enter
+        // can toggle the group; the collapsed group paints only its header.
+        let mut tasks = tasks.clone();
+        let mut archived =
+            task_with_thread(3, HumanStatus::Ready, project("/repos/a"), false, 50, None);
+        archived.archived = true;
+        tasks.push(archived);
+        let view = query_board(
+            &tasks,
+            &BTreeSet::new(),
+            None,
+            BoardLens::Project(Path::new("/repos/a")),
+            true,
+            &ThreadFilter::All,
+        );
+        let expanded = visible_task_ids(&view, false);
+        assert!(
+            expanded.contains(&ARCHIVED_HEADER_ROW_ID) && expanded.contains(&Uuid::from_u128(3))
+        );
+        let collapsed = visible_task_ids(&view, true);
+        assert_eq!(
+            collapsed,
+            vec![
+                Uuid::from_u128(1),
+                Uuid::from_u128(2),
+                ARCHIVED_HEADER_ROW_ID
+            ],
+            "the collapsed archived group paints only its header"
         );
     }
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -3816,10 +3816,13 @@ fn paint_project_row(
     let after_motion = motion_x + display_width(&motion);
     spans.push(Span::raw(" ".repeat(ready_x.saturating_sub(after_motion))));
     let ready = row.ready.to_string();
-    spans.push(Span::styled(ready, style_dim()));
-    // Keep annotations after the aligned counts so they cannot consume the basename budget.
+    spans.push(Span::styled(ready.clone(), style_dim()));
+    // Escape and budget the path before constructing a styled span. `bound_line` only
+    // sanitizes on overflow, while control bytes have zero display width.
     if !path_suffix.is_empty() {
-        spans.push(Span::styled(path_suffix, style_dim()));
+        let suffix_budget = (width as usize).saturating_sub(ready_x + display_width(&ready));
+        let safe_suffix = present_line(&path_suffix, suffix_budget);
+        spans.push(Span::styled(safe_suffix, style_dim()));
     }
     if row.current {
         spans.push(Span::styled(" · current directory", style_dim()));
@@ -4183,23 +4186,47 @@ fn paint_status_line(
     (bound_line(Line::from(spans), width as usize), undo_hit)
 }
 
+/// Measured selector tabs. Desk and Projects are reserved controls, so only the
+/// middle project label is shortened at narrow widths. The same result drives paint,
+/// wrapping, and hit regions.
+fn selector_tab_texts(model: &QueueFrameModel<'_>, width: usize) -> [(NavTab, String); 3] {
+    let desk = " desk ".to_string();
+    let projects = " projects ".to_string();
+    let arrow = if model.nav.slot2_project {
+        " ▾ "
+    } else {
+        " ▸ "
+    };
+    let middle_budget = width
+        .saturating_sub(display_width(&desk))
+        .saturating_sub(display_width(&projects))
+        .saturating_sub(6);
+    let name_budget = middle_budget
+        .saturating_sub(1)
+        .saturating_sub(display_width(arrow));
+    let middle = format!(
+        " {}{arrow}",
+        present_line(&model.nav.slot2_label, name_budget)
+    );
+    [
+        (NavTab::Desk, desk),
+        (NavTab::ProjectBoard, middle),
+        (NavTab::Projects, projects),
+    ]
+}
+
 /// Whether the destination control needs a dedicated row to keep tabs and its selected
 /// value readable without overlap, especially at the 40-column operating floor.
 fn selector_chip_wraps(model: &QueueFrameModel<'_>, width: u16) -> bool {
     let Some(chip) = model.nav.chip.as_ref() else {
         return false;
     };
-    let slot2 = model.nav.slot2_label.as_str();
-    let tabs = [
-        " desk ".to_string(),
-        if model.nav.slot2_project {
-            format!(" {slot2} ▾ ")
-        } else {
-            format!(" {slot2} ▸ ")
-        },
-        " projects ".to_string(),
-    ];
-    let tabs_width = tabs.iter().map(|tab| display_width(tab)).sum::<usize>() + 6;
+    let tabs = selector_tab_texts(model, width as usize);
+    let tabs_width = tabs
+        .iter()
+        .map(|(_, tab)| display_width(tab))
+        .sum::<usize>()
+        + 6;
     let chip_width = display_width(&format!(" {} ▾ ", chip.label));
     tabs_width.saturating_add(chip_width) > width as usize
 }
@@ -4218,19 +4245,7 @@ fn paint_selector_row(
 
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut left_width = 0usize;
-    let slot2 = model.nav.slot2_label.as_str();
-    let tabs: [(NavTab, String); 3] = [
-        (NavTab::Desk, " desk ".to_string()),
-        (
-            NavTab::ProjectBoard,
-            if model.nav.slot2_project {
-                format!(" {slot2} \u{25be} ")
-            } else {
-                format!(" {slot2} \u{25b8} ")
-            },
-        ),
-        (NavTab::Projects, " projects ".to_string()),
-    ];
+    let tabs = selector_tab_texts(model, width);
     for (index, (tab, text)) in tabs.iter().enumerate() {
         if index > 0 {
             spans.push(Span::styled(" \u{b7} ".to_string(), style_dim()));
@@ -4527,6 +4542,122 @@ mod tests {
             })
             .expect("draw");
         terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn narrow_selector_reserves_desk_and_projects_tabs() {
+        let view = QueueView {
+            sections: vec![],
+            counts: StatusCounts::default(),
+            projects: vec![],
+        };
+        let model = QueueFrameModel {
+            tasks: &[],
+            view: &view,
+            selection_id: None,
+            nav: NavPaint {
+                active: NavTab::ProjectBoard,
+                slot2_label: "x".repeat(32),
+                slot2_project: true,
+                chip: None,
+            },
+            surface: BoardSurface::Projects,
+            thread_labels: false,
+            show_project_meta: false,
+            projects: &[],
+            projects_index: false,
+            projects_cursor: 0,
+            projects_query: "",
+            summary: None,
+            status_message: None,
+            status_undo_offset: None,
+            verb_items: &[],
+            now: SystemTime::UNIX_EPOCH,
+            overlay: QueueOverlay::None,
+            detail_open: None,
+            list_scroll: 0,
+            follow_list: false,
+            archived_collapsed: true,
+            archived_header_selected: false,
+            rows_dim: false,
+        };
+        let (line, hits) = paint_selector_row(&model, &tier::resolve(40, 24));
+        let text = plain(&line);
+        assert!(text.contains("desk"));
+        assert!(text.contains("projects"));
+        assert!(
+            text.contains('▾'),
+            "project tab must retain its chevron: {text}"
+        );
+        assert!(display_width(&text) <= 40);
+        for (target, x, width) in hits {
+            assert!(
+                x.saturating_add(width) <= 40,
+                "{target:?} overflows selector"
+            );
+        }
+    }
+
+    #[test]
+    fn project_row_escapes_control_bytes_even_when_suffix_fits() {
+        let unsafe_path = "/tmp/\u{1b}]52;clipboard\u{7}/repo".to_string();
+        let projects = vec![
+            ProjectRow {
+                path: unsafe_path.clone(),
+                needs_you: 0,
+                in_motion: 0,
+                ready: 1,
+                current: false,
+                duplicate_basename: true,
+            },
+            ProjectRow {
+                path: "/other/repo".into(),
+                needs_you: 0,
+                in_motion: 0,
+                ready: 1,
+                current: false,
+                duplicate_basename: true,
+            },
+        ];
+        let view = QueueView {
+            sections: vec![],
+            counts: StatusCounts::default(),
+            projects: projects.clone(),
+        };
+        let model = QueueFrameModel {
+            tasks: &[],
+            view: &view,
+            selection_id: None,
+            nav: NavPaint {
+                active: NavTab::Projects,
+                slot2_label: "select project".into(),
+                slot2_project: false,
+                chip: None,
+            },
+            surface: BoardSurface::Projects,
+            thread_labels: false,
+            show_project_meta: false,
+            projects: &projects,
+            projects_index: true,
+            projects_cursor: 0,
+            projects_query: "",
+            summary: None,
+            status_message: None,
+            status_undo_offset: None,
+            verb_items: &[],
+            now: SystemTime::UNIX_EPOCH,
+            overlay: QueueOverlay::None,
+            detail_open: None,
+            list_scroll: 0,
+            follow_list: false,
+            archived_collapsed: true,
+            archived_header_selected: false,
+            rows_dim: false,
+        };
+        let line = paint_project_row(&model, 0, false, 120);
+        let text = plain(&line);
+        assert!(text.contains("\\u{001b}]52;clipboard\\u{0007}"));
+        assert!(!text.contains('\u{1b}'));
     }
 
     #[test]

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -4,7 +4,6 @@
 //! `Modifier::{BOLD, DIM, UNDERLINED, REVERSED}`, plus [`draw_queue_frame`] for the
 //! the deck-only board skeleton.
 
-use std::collections::HashSet;
 use std::path::Path;
 use std::time::SystemTime;
 
@@ -19,9 +18,7 @@ use uuid::Uuid;
 use super::capture::CaptureField;
 use super::edit::{place_edit_cursor, place_edit_cursor_at};
 use super::present_line;
-use super::queue::{
-    BoardTab, QueueSection, QueueView, SectionKind, StatusCounts, ThreadProjectCollapseKey,
-};
+use super::queue::{NavTab, ProjectRow, QueueSection, QueueView, SectionKind, StatusCounts};
 use super::scrollbar;
 use super::tier::{Tier, TierGeometry};
 use crate::domain::{HumanStatus, Task, TaskScope};
@@ -197,8 +194,8 @@ pub fn paint_task_row_lines(
 /// Paint one task row: glyph+title on the left, right-aligned meta in the meta budget.
 ///
 /// Title and meta never share cells. Over-budget text is clipped through
-/// [`present_line`] so truncation always shows `…`. Compact geometry
-/// (`meta_column_width == 0`) drops meta and gives the title the full row.
+/// [`present_line`] so truncation always shows `…`. Compact geometry drops meta on
+/// narrow terminals, while wide compact frames retain a bounded identity column.
 pub fn paint_task_row(row: &TaskRowPaint<'_>, geo: &TierGeometry) -> Line<'static> {
     paint_task_row_with_indent(row, geo, 0)
 }
@@ -287,8 +284,15 @@ fn paint_task_row_with_indent(
     bound_line(Line::from(spans), row_w)
 }
 
-fn task_meta_budget(_row: &TaskRowPaint<'_>, geo: &TierGeometry) -> usize {
-    geo.meta_column_width as usize
+fn task_meta_budget(row: &TaskRowPaint<'_>, geo: &TierGeometry) -> usize {
+    if geo.meta_column_width == 0 && geo.width >= 78 && !row.meta.is_empty() {
+        // A short pane may use compact density despite having standard-width room.
+        // Preserve project/thread identity there; genuinely narrow panes keep the
+        // existing title-first layout and task titles still wrap.
+        (geo.row_width as usize / 4).min(36)
+    } else {
+        geo.meta_column_width as usize
+    }
 }
 
 /// Present untrusted text into a single mono-styled line bounded to `width` cells.
@@ -442,6 +446,10 @@ pub enum QueueOverlay<'a> {
         selected: usize,
         /// Picker tabs (main/archived). None for non-picker uses.
         tabs: Option<PickerTabsPaint>,
+        /// Card title override (the searchable list pickers name themselves).
+        title: Option<&'a str>,
+        /// Search query echoed in the card title (searchable list pickers).
+        query: Option<&'a str>,
     },
     /// Inline title edit surface (accordion row on standard; full takeover on compact).
     EditTitle { draft: String, cursor_col: u16 },
@@ -455,9 +463,12 @@ pub enum QueueOverlay<'a> {
     /// Single-line capture painted into the two bottom chrome rows, never covering the queue.
     QuickAdd {
         input: BottomInputSlot<'a>,
-        project_scope: bool,
+        /// Where Enter saves this draft, named for the user (`desk` / project name).
+        destination: String,
         recovery: bool,
     },
+    /// Projects Overview search, painted in the same shared footer slot as quick-add.
+    ProjectsSearch { input: BottomInputSlot<'a> },
     /// The task page: a full-height, view-first takeover for one bound task. `focus` is
     /// `None` in view mode; field edits focus the same drafts the board form carries.
     TaskPage {
@@ -530,18 +541,25 @@ pub struct QueueFrameModel<'a> {
     pub view: &'a QueueView,
     /// Selected task id, if any.
     pub selection_id: Option<Uuid>,
-    /// Home tabs are visible (project focus hides them).
-    pub at_home: bool,
-    /// Active home tab.
-    pub home_tab: BoardTab,
-    /// Project-focus label on the selector row's right chip.
-    pub scope_label: &'a str,
-    /// Collapsed project groups on the Projects tab.
-    pub collapsed_projects: &'a HashSet<String>,
-    /// Collapsed thread groups on the Threads tab.
-    pub collapsed_threads: &'a HashSet<String>,
-    /// Collapsed project rows under a thread group.
-    pub collapsed_thread_projects: &'a HashSet<ThreadProjectCollapseKey>,
+    /// Persistent navigation paint: the three tabs, slot 2's label, and the
+    /// destination's right-side control (thread filter / View selector).
+    pub nav: NavPaint,
+    /// Which board surface the list paints (section titles and row attribution).
+    pub surface: BoardSurface,
+    /// Paint `#thread` labels beside task rows (project board, unfiltered only).
+    pub thread_labels: bool,
+    /// Paint project attribution in every row's meta (desk global lanes, thread view).
+    pub show_project_meta: bool,
+    /// The projects index rows (Projects surface, Overview view). When `projects_index`
+    /// is set the list paints these instead of task sections.
+    pub projects: &'a [ProjectRow],
+    pub projects_index: bool,
+    /// The index row the cursor rests on.
+    pub projects_cursor: usize,
+    /// The projects-index search query used by the shared footer input.
+    pub projects_query: &'a str,
+    /// Context summary painted above a filtered or cross-project task list.
+    pub summary: Option<String>,
     /// Optional status-line notice; replaces the default counts when set.
     pub status_message: Option<&'a str>,
     /// Column offset of the delete-notice `u Undo` control inside `status_message`, when
@@ -572,6 +590,43 @@ pub struct QueueFrameModel<'a> {
     pub rows_dim: bool,
 }
 
+/// Persistent navigation row paint: three fixed tabs plus the destination control.
+#[derive(Debug, Clone)]
+pub struct NavPaint {
+    /// Which tab is active (reverse-bold).
+    pub active: NavTab,
+    /// Slot 2's label: the selected project's name, `name · archived` in read-only
+    /// focus, or the empty-slot affordance `select project`.
+    pub slot2_label: String,
+    /// Whether slot 2 currently carries a project (its click opens the picker then).
+    pub slot2_project: bool,
+    /// Right-side control of the active destination.
+    pub chip: Option<NavChipPaint>,
+}
+
+/// The right-side destination control: the project board's thread filter, or the
+/// projects index's View selector.
+#[derive(Debug, Clone)]
+pub struct NavChipPaint {
+    pub label: String,
+    pub kind: NavChipKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavChipKind {
+    ThreadFilter,
+    ProjectsView,
+}
+
+/// Which board surface owns the list (drives section titles and row meta).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoardSurface {
+    Desk,
+    Project,
+    Projects,
+    ThreadView,
+}
+
 /// The project picker's tab row: which list is active and how many entries the
 /// archived one carries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -583,7 +638,14 @@ pub struct PickerTabsPaint {
 /// Logical control under a painted rectangle (rebuilt every frame).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueueHitTarget {
-    ProjectChip,
+    /// One painted persistent navigation tab.
+    NavTab(NavTab),
+    /// The active destination's right-side control (thread filter / View selector).
+    NavChip,
+    /// The visible projects-index search field.
+    ProjectsSearch,
+    /// One painted row of the projects index, indexed into `QueueView::projects`.
+    ProjectRow(usize),
     /// The quick-add input row. Clicking it keeps the already-focused line focused.
     QuickAddInput,
     Task(Uuid),
@@ -607,21 +669,13 @@ pub enum QueueHitTarget {
     /// One painted row of the open project-scope dropdown, indexed exactly as
     /// `BoardModel::project_options()` orders them.
     ProjectOption(usize),
+    /// One painted row of an open searchable list picker (thread filter / View),
+    /// indexed in the visible (filtered) order.
+    ListPickerOption(usize),
     /// One painted tab of the project picker's tab row.
     PickerTab(crate::ui::board::PickerTab),
     /// One choice row of the launch card (0 = unarchive, 1 = keep archived).
     LaunchOption(usize),
-    /// One painted home tab on the selector row.
-    HomeTab(BoardTab),
-    /// One ON DECK project-group header on the Projects tab, indexed into sections.
-    SectionProject(usize),
-    /// One thread-group header on the Threads tab, indexed into sections.
-    SectionThread(usize),
-    /// One project sub-header under a thread group.
-    SectionThreadProject {
-        section_idx: usize,
-        subgroup_idx: usize,
-    },
     /// The open help card's full-frame dismiss hit -- a click anywhere the card's own
     /// `ModalClose`/`ModalChrome`/body hits do not shadow closes it, matching the
     /// keyboard's "any key closes". The board behind the card stays visible and painted;
@@ -1068,7 +1122,13 @@ fn draw_queue_frame_impl(
 ) -> (QueueHitMap, Option<(usize, usize)>) {
     let surface = clipped_area(surface, frame.area());
     let input_slot_geo = bottom_input_slot_geometry(*geo, &model.overlay);
-    let geo = &input_slot_geo;
+    let mut selector_geo = input_slot_geo;
+    if selector_chip_wraps(model, selector_geo.row_width) && selector_geo.viewport_height > 0 {
+        // A wrapped control gets one blank row between it and the tabs.
+        selector_geo.viewport_top = selector_geo.viewport_top.saturating_add(2);
+        selector_geo.viewport_height = selector_geo.viewport_height.saturating_sub(2);
+    }
+    let geo = &selector_geo;
     let mut hits = QueueHitMap::default();
     let mut painted_list_scroll = None;
     let width = geo.row_width;
@@ -1090,6 +1150,17 @@ fn draw_queue_frame_impl(
             put_line(frame, surface, row, width, line);
             for (target, x, w) in regions {
                 hits.push(target, Rect::new(x, row, w, 1));
+            }
+            if selector_chip_wraps(model, width) {
+                let chip_row = row.saturating_add(2);
+                if chip_row < geo.rule_row.unwrap_or(geo.height) {
+                    let (chip, x, chip_width) = paint_selector_chip(model, width);
+                    put_line(frame, surface, chip_row, width, chip);
+                    hits.push(
+                        QueueHitTarget::NavChip,
+                        Rect::new(x, chip_row, chip_width, 1),
+                    );
+                }
             }
         }
     }
@@ -1239,8 +1310,14 @@ fn paint_footer(
                 }
             }
             paint_bottom_input_slot(frame, surface, row, width, input);
-            if matches!(model.overlay, QueueOverlay::QuickAdd { .. }) {
-                hits.push(QueueHitTarget::QuickAddInput, Rect::new(0, row, width, 1));
+            match model.overlay {
+                QueueOverlay::QuickAdd { .. } => {
+                    hits.push(QueueHitTarget::QuickAddInput, Rect::new(0, row, width, 1));
+                }
+                QueueOverlay::ProjectsSearch { .. } => {
+                    hits.push(QueueHitTarget::ProjectsSearch, Rect::new(0, row, width, 1));
+                }
+                _ => {}
             }
         } else {
             let (line, undo_hit) = paint_status_line(
@@ -1273,6 +1350,7 @@ fn paint_footer(
             | QueueOverlay::ScopeDropdown { .. } => &[],
             QueueOverlay::QuickAdd { recovery, .. } if *recovery => &[],
             QueueOverlay::QuickAdd { .. } => QUICK_ADD_VERBS,
+            QueueOverlay::ProjectsSearch { .. } => &[],
             // The page's field edits keep the form legends; its view mode reads the
             // model-computed page verbs (status-dependent, like the board row's own).
             QueueOverlay::TaskPage {
@@ -1292,18 +1370,13 @@ fn paint_footer(
             model.overlay,
             QueueOverlay::None | QueueOverlay::TaskPage { focus: None, .. },
         );
-        if let QueueOverlay::QuickAdd {
-            project_scope,
-            recovery: true,
-            ..
-        } = &model.overlay
-        {
+        if let QueueOverlay::QuickAdd { destination, .. } = &model.overlay {
             paint_quick_add_hint(
                 frame,
                 surface,
                 row,
                 width,
-                *project_scope,
+                destination,
                 model.status_message,
                 geo.tier,
             );
@@ -1345,7 +1418,9 @@ pub(crate) fn bottom_input_geometry(mut geo: TierGeometry, active: bool) -> Tier
 /// accidentally reserving rows differently from the line it paints.
 fn bottom_input_slot<'a>(overlay: &'a QueueOverlay<'a>) -> Option<&'a BottomInputSlot<'a>> {
     match overlay {
-        QueueOverlay::QuickAdd { input, .. } => Some(input),
+        QueueOverlay::QuickAdd { input, .. } | QueueOverlay::ProjectsSearch { input } => {
+            Some(input)
+        }
         QueueOverlay::TaskPage { bottom_input, .. } => bottom_input.as_ref(),
         _ => None,
     }
@@ -1543,8 +1618,12 @@ fn paint_overlay(
             options,
             selected,
             tabs,
+            title,
+            query,
         } => {
-            paint_scope_dropdown(frame, geo, surface, options, *selected, *tabs, hits);
+            paint_scope_dropdown(
+                frame, geo, surface, options, *selected, *tabs, *title, *query, hits,
+            );
         }
         QueueOverlay::EditTitle {
             ref draft,
@@ -1559,7 +1638,7 @@ fn paint_overlay(
         } => {
             paint_edit_notes_overlay(frame, geo, surface, rows, *cursor_row, *cursor_col);
         }
-        QueueOverlay::QuickAdd { .. } => {}
+        QueueOverlay::QuickAdd { .. } | QueueOverlay::ProjectsSearch { .. } => {}
         QueueOverlay::TaskPage {
             ref header_rows,
             ref header_identifier,
@@ -1758,6 +1837,8 @@ fn paint_edit_notes_overlay(
 struct ModalCardSpec<'a> {
     title: &'a str,
     content_rows: u16,
+    /// Let searchable options use spare outer margins before clipping their names.
+    min_content_width: u16,
     legend: &'a [VerbEntry<'a>],
     /// A full-frame dismiss hit to push first, before the card's own chrome (see below).
     dismiss: Option<QueueHitTarget>,
@@ -1791,6 +1872,7 @@ fn paint_modal_card(
     let ModalCardSpec {
         title,
         content_rows,
+        min_content_width,
         legend,
         dismiss,
         legend_hits,
@@ -1802,10 +1884,15 @@ fn paint_modal_card(
         hits.push(target, Rect::new(0, 0, geo.row_width, geo.height));
     }
 
-    let card_w = bounds.width.saturating_sub(4).clamp(1, 62);
     // Blank inset around the content, shed on both axes in compact so its scarce cells
     // go to actual body text instead of decorative breathing room.
     let pad: u16 = if geo.tier == Tier::Compact { 0 } else { 1 };
+    let card_w = bounds
+        .width
+        .saturating_sub(4)
+        .clamp(1, 62)
+        .max(min_content_width.saturating_add(2 + 2 * pad))
+        .min(bounds.width);
     let chrome_rows = modal_chrome_rows(geo.tier, !legend.is_empty());
     let shown_content = content_rows.min(bounds.height.saturating_sub(chrome_rows));
     let card_h = (chrome_rows + shown_content).min(bounds.height).max(1);
@@ -2119,6 +2206,7 @@ fn paint_palette_overlay(
         ModalCardSpec {
             title: &title,
             content_rows: rows as u16,
+            min_content_width: 0,
             legend: PALETTE_FOOTER,
             dismiss: None,
             legend_hits: None,
@@ -2230,6 +2318,7 @@ fn paint_help_overlay(
         ModalCardSpec {
             title: &title,
             content_rows: shown.len() as u16,
+            min_content_width: 0,
             legend: HELP_FOOTER,
             dismiss: Some(QueueHitTarget::HelpDismiss),
             legend_hits: None,
@@ -3036,6 +3125,7 @@ fn paint_launch_card(
         ModalCardSpec {
             title: "",
             content_rows: 1,
+            min_content_width: 0,
             legend: LAUNCH_FOOTER,
             dismiss: None,
             legend_hits: Some(QueueHitTarget::LaunchOption),
@@ -3057,6 +3147,7 @@ fn paint_launch_card(
 /// The board's `P` project-scope picker: a centered modal card, not the chip-anchored
 /// dropdown this used to paint. [`paint_page_scope_dropdown`] (the task-page form's own
 /// scope control) is a separate, unrelated painter and keeps its chip-anchored panel.
+#[allow(clippy::too_many_arguments)]
 fn paint_scope_dropdown(
     frame: &mut Frame<'_>,
     geo: &TierGeometry,
@@ -3064,14 +3155,17 @@ fn paint_scope_dropdown(
     options: &[String],
     selected: usize,
     tabs: Option<PickerTabsPaint>,
+    title_override: Option<&str>,
+    query: Option<&str>,
     hits: &mut QueueHitMap,
 ) {
-    if geo.row_width == 0 || (tabs.is_none() && options.is_empty()) {
+    if geo.row_width == 0 || (tabs.is_none() && title_override.is_none() && options.is_empty()) {
         return;
     }
     let tabs_rows = usize::from(tabs.is_some());
-    // An empty archived list still paints its empty-state row.
-    let empty_state = tabs.is_some() && options.is_empty();
+    // Search owns a visible menu even when nothing matches, so its query can be
+    // corrected or dismissed. Archived lists also retain their empty-state row.
+    let empty_state = options.is_empty();
     // Help/project-scope have nothing worth preserving underneath (no query row like the
     // palette), so the full frame is the ceiling: a narrow compact terminal gets every row
     // the border+footer would otherwise leave idle.
@@ -3102,7 +3196,14 @@ fn paint_scope_dropdown(
     };
     let above = scroll > 0;
     let below = scroll + rows < options.len();
-    let title = titled_with_scroll_marker("project", above, below);
+    let default_title = "project";
+    let base_title = title_override.unwrap_or(default_title);
+    let title = match query {
+        Some(query) if !query.is_empty() => {
+            titled_with_scroll_marker(&format!("{base_title}: {query}"), above, below)
+        }
+        _ => titled_with_scroll_marker(base_title, above, below),
+    };
 
     let content = paint_modal_card(
         frame,
@@ -3112,6 +3213,16 @@ fn paint_scope_dropdown(
         ModalCardSpec {
             title: &title,
             content_rows: (rows + tabs_rows + usize::from(tabs.is_some())) as u16,
+            min_content_width: if title_override.is_some() {
+                options
+                    .iter()
+                    .map(|option| display_width(option) + 2)
+                    .max()
+                    .unwrap_or(0)
+                    .min(u16::MAX as usize) as u16
+            } else {
+                0
+            },
             legend: if tabs.is_some_and(|tabs| tabs.archived_active) {
                 ARCHIVED_TAB_FOOTER
             } else {
@@ -3175,7 +3286,15 @@ fn paint_scope_dropdown(
             frame,
             surface,
             Rect::new(content.x, y, content.width, 1),
-            paint_bounded_line("  no archived projects", content.width, style_dim()),
+            paint_bounded_line(
+                if tabs.is_some() {
+                    "  no archived projects"
+                } else {
+                    "  no matching options"
+                },
+                content.width,
+                style_dim(),
+            ),
         );
         return;
     }
@@ -3201,39 +3320,33 @@ fn paint_scope_dropdown(
         );
         // `j` remains the source index after windowing, so a click selects the same option
         // Up/Down plus Enter would confirm rather than its position within this paint slice.
-        hits.push(QueueHitTarget::ProjectOption(j), rect);
+        if tabs.is_none() && title_override.is_some() {
+            hits.push(QueueHitTarget::ListPickerOption(j), rect);
+        } else {
+            hits.push(QueueHitTarget::ProjectOption(j), rect);
+        }
         hits.push_copyable(rect);
     }
 }
 
 enum ListRow {
     Blank,
-    /// Section header row for IN MOTION, DONE, desk ON DECK, or project focus ON DECK.
+    /// Section header row for NEEDS YOU, IN MOTION, ON DECK and the drawer.
     Header(SectionKind, usize, Line<'static>),
-    /// Collapsible project-group header on the Projects tab.
-    ProjectGroupHeader {
-        section_idx: usize,
-        line: Line<'static>,
-    },
-    /// Collapsible thread-group header on the Threads tab.
-    ThreadGroupHeader {
-        section_idx: usize,
-        line: Line<'static>,
-    },
-    /// Collapsible project sub-header under a thread group.
-    ThreadProjectHeader {
-        section_idx: usize,
-        subgroup_idx: usize,
-        line: Line<'static>,
-    },
     /// The done drawer's archived group header (sticky, selectable, hits map to the
     /// toggle intent). Selection styling is baked into the line.
     ArchivedHeader {
         line: Line<'static>,
     },
+    /// One selectable projects index row (navigation, never a task). The selected
+    /// marker is baked into the line.
+    ProjectRow {
+        index: usize,
+        line: Line<'static>,
+    },
+    /// Dim header row of the projects index's count columns.
+    IndexHeader(Line<'static>),
     Hint(Line<'static>),
-    /// Decorative scoped ON DECK thread-block label inside project focus.
-    ThreadHeader(Line<'static>),
     Task {
         id: Uuid,
         line: Line<'static>,
@@ -3257,12 +3370,7 @@ impl ListRow {
     fn is_sticky_header(&self) -> bool {
         matches!(
             self,
-            ListRow::Header(..)
-                | ListRow::ProjectGroupHeader { .. }
-                | ListRow::ThreadGroupHeader { .. }
-                | ListRow::ThreadProjectHeader { .. }
-                | ListRow::ArchivedHeader { .. }
-                | ListRow::ThreadHeader(_)
+            ListRow::Header(..) | ListRow::ArchivedHeader { .. } | ListRow::IndexHeader(_)
         )
     }
 }
@@ -3310,38 +3418,17 @@ fn paint_list_row(
                 hits.push(QueueHitTarget::Drawer, Rect::new(0, y, content_width, 1));
             }
         }
-        ListRow::ProjectGroupHeader { section_idx, line } => {
+        ListRow::IndexHeader(line) => {
             put_line(frame, surface, y, content_width, line.clone());
-            if base_list_interactive {
-                hits.push(
-                    QueueHitTarget::SectionProject(*section_idx),
-                    Rect::new(0, y, content_width, 1),
-                );
-            }
         }
-        ListRow::ThreadGroupHeader { section_idx, line } => {
+        ListRow::ProjectRow { index, line } => {
             put_line(frame, surface, y, content_width, line.clone());
             if base_list_interactive {
                 hits.push(
-                    QueueHitTarget::SectionThread(*section_idx),
+                    QueueHitTarget::ProjectRow(*index),
                     Rect::new(0, y, content_width, 1),
                 );
-            }
-        }
-        ListRow::ThreadProjectHeader {
-            section_idx,
-            subgroup_idx,
-            line,
-        } => {
-            put_line(frame, surface, y, content_width, line.clone());
-            if base_list_interactive {
-                hits.push(
-                    QueueHitTarget::SectionThreadProject {
-                        section_idx: *section_idx,
-                        subgroup_idx: *subgroup_idx,
-                    },
-                    Rect::new(0, y, content_width, 1),
-                );
+                hits.push_copyable(Rect::new(0, y, content_width, 1));
             }
         }
         ListRow::ArchivedHeader { line } => {
@@ -3353,9 +3440,7 @@ fn paint_list_row(
                 );
             }
         }
-        ListRow::Hint(line) | ListRow::ThreadHeader(line) => {
-            put_line(frame, surface, y, content_width, line.clone())
-        }
+        ListRow::Hint(line) => put_line(frame, surface, y, content_width, line.clone()),
         ListRow::Task {
             id,
             line,
@@ -3477,27 +3562,26 @@ fn build_list_rows(
                      out: &mut Vec<ListRow>,
                      selected_idx: &mut Option<usize>,
                      anchor_last_idx: &mut Option<usize>,
-                     in_project_section: bool,
-                     indented_under_thread: bool,
+                     project_attribution: bool,
+                     thread_label: bool,
                      dim: bool| {
         let Some(task) = model.tasks.iter().find(|task| task.id == id) else {
             // Stale ids may outlive a snapshot refresh. Skip them without inventing a row.
             return;
         };
-        let meta = row_meta(task, model.now, in_project_section);
+        let meta = row_meta(
+            task,
+            model.now,
+            project_attribution || model.show_project_meta,
+            thread_label && model.thread_labels,
+        );
         let selected = model.selection_id == Some(task.id)
             && !matches!(model.overlay, QueueOverlay::ScopeDropdown { .. });
         // A long title wraps onto continuation lines indented under its own first
         // row; every painted line carries the task's hit target and selection.
         let identifier = task.number.map(|number| format!("T{number}"));
         let lines = if rail {
-            paint_rail_row_lines(
-                task,
-                identifier.as_deref(),
-                selected,
-                geo.row_width,
-                usize::from(indented_under_thread) * 2,
-            )
+            paint_rail_row_lines(task, identifier.as_deref(), selected, geo.row_width, 0)
         } else {
             paint_task_row_lines(
                 &TaskRowPaint {
@@ -3511,7 +3595,7 @@ fn build_list_rows(
                     dim: dim || model.rows_dim,
                 },
                 geo,
-                usize::from(indented_under_thread) * 2,
+                0,
             )
         };
         if selected {
@@ -3542,6 +3626,39 @@ fn build_list_rows(
             *anchor_last_idx = Some(out.len() - 1);
         }
     };
+
+    // The projects index paints navigation rows, not task sections. It is the one
+    // surface whose rows are neither tasks nor chrome.
+    if model.projects_index {
+        out.push(ListRow::IndexHeader(paint_index_header(geo.row_width)));
+        if model.projects.is_empty() {
+            out.push(ListRow::Hint(paint_bounded_line(
+                "    no projects match",
+                geo.row_width,
+                style_dim(),
+            )));
+            return (out, anchor_last_idx, selected_idx);
+        }
+        for (index, _row) in model.projects.iter().enumerate() {
+            let selected = index == model.projects_cursor;
+            out.push(ListRow::ProjectRow {
+                index,
+                line: paint_project_row(model, index, selected, geo.row_width),
+            });
+            if selected {
+                selected_idx = Some(out.len() - 1);
+            }
+        }
+        return (out, anchor_last_idx, selected_idx);
+    }
+
+    if let Some(summary) = model.summary.as_deref() {
+        out.push(ListRow::Hint(paint_bounded_line(
+            &format!("    {summary}"),
+            geo.row_width,
+            style_dim(),
+        )));
+    }
 
     for (section_idx, section) in model.view.sections.iter().enumerate() {
         // The rail drops the done drawer and its archived group: it is a navigation
@@ -3585,149 +3702,131 @@ fn build_list_rows(
             out.push(ListRow::Blank);
         }
 
-        if model.at_home && model.home_tab == BoardTab::Projects && section.project_label.is_some()
-        {
-            let path = section.project_label.clone().unwrap_or_default();
-            let collapsed = model.collapsed_projects.contains(&path);
-            out.push(ListRow::ProjectGroupHeader {
-                section_idx,
-                line: paint_project_group_header(section, geo.row_width, collapsed),
-            });
-            out.push(ListRow::Blank);
-            if collapsed {
-                continue;
-            }
-            if section.empty_hint {
-                out.push(ListRow::Hint(paint_empty_hint(geo.row_width)));
-                continue;
-            }
-            for id in section.task_ids.iter().copied() {
-                push_task(
-                    id,
-                    &mut out,
-                    &mut selected_idx,
-                    &mut anchor_last_idx,
-                    true,
-                    false,
-                    false,
-                );
-            }
-            continue;
-        }
-
-        if model.at_home && model.home_tab == BoardTab::Threads && section.thread_label.is_some() {
-            let thread = section.thread_label.clone().unwrap_or_default();
-            let collapsed = model.collapsed_threads.contains(&thread);
-            out.push(ListRow::ThreadGroupHeader {
-                section_idx,
-                line: paint_thread_group_header(section, geo.row_width, collapsed),
-            });
-            out.push(ListRow::Blank);
-            if collapsed {
-                continue;
-            }
-            if section.empty_hint {
-                out.push(ListRow::Hint(paint_empty_hint(geo.row_width)));
-                continue;
-            }
-            for (subgroup_idx, subgroup) in section.thread_subgroups.iter().enumerate() {
-                let key = ThreadProjectCollapseKey {
-                    thread: thread.clone(),
-                    project_path: subgroup.project_path.clone(),
-                };
-                let sub_collapsed = model.collapsed_thread_projects.contains(&key);
-                out.push(ListRow::ThreadProjectHeader {
-                    section_idx,
-                    subgroup_idx,
-                    line: paint_thread_project_header(
-                        subgroup.project_path.as_deref(),
-                        subgroup.task_ids.len(),
-                        geo.row_width,
-                        geo,
-                    ),
-                });
-                if sub_collapsed {
-                    continue;
-                }
-                for id in subgroup.task_ids.iter().copied() {
-                    push_task(
-                        id,
-                        &mut out,
-                        &mut selected_idx,
-                        &mut anchor_last_idx,
-                        true,
-                        true,
-                        false,
-                    );
-                }
-                out.push(ListRow::Blank);
-            }
-            continue;
-        }
-
         out.push(ListRow::Header(
             section.kind,
             section_idx,
-            paint_section_header(section, geo.row_width, model.at_home, model.home_tab),
+            paint_section_header(section, geo.row_width, model.surface),
         ));
         out.push(ListRow::Blank);
         if section.empty_hint {
             out.push(ListRow::Hint(paint_empty_hint(geo.row_width)));
             continue;
         }
-        let in_project_section =
-            section.kind == SectionKind::OnDeck && section.project_label.is_some();
-        if !section.thread_blocks.is_empty() {
-            for block in &section.thread_blocks {
-                out.push(ListRow::ThreadHeader(paint_thread_header(
-                    &block.name,
-                    block.open_count,
-                    geo,
-                )));
-                for id in block.task_ids.iter().copied() {
-                    push_task(
-                        id,
-                        &mut out,
-                        &mut selected_idx,
-                        &mut anchor_last_idx,
-                        in_project_section,
-                        true,
-                        false,
-                    );
-                }
-                out.push(ListRow::Blank);
-            }
-            for id in section.loose_task_ids.iter().copied() {
-                push_task(
-                    id,
-                    &mut out,
-                    &mut selected_idx,
-                    &mut anchor_last_idx,
-                    in_project_section,
-                    false,
-                    false,
-                );
-            }
-        } else {
-            for id in section.task_ids.iter().copied() {
-                push_task(
-                    id,
-                    &mut out,
-                    &mut selected_idx,
-                    &mut anchor_last_idx,
-                    in_project_section,
-                    false,
-                    false,
-                );
-            }
+        // Thread labels paint beside project-board rows while no filter narrows the
+        // board (a selected thread makes every label the same word). Cross-project
+        // surfaces carry project attribution instead, through the meta flag.
+        let thread_label = model.thread_labels;
+        for id in section.task_ids.iter().copied() {
+            push_task(
+                id,
+                &mut out,
+                &mut selected_idx,
+                &mut anchor_last_idx,
+                false,
+                thread_label,
+                false,
+            );
         }
     }
     (out, anchor_last_idx, selected_idx)
 }
 
-/// Rail row(s) for one task: `  <mark> T<n> <title>`, wrapped at the rail width with a
-/// four-cell continuation indent and a trailing pad cell so no glyph touches the rule.
-/// The selected row paints the hollow `▹` marker; every other row keeps its status glyph.
+/// The projects index's dim column legend.
+fn paint_index_header(width: u16) -> Line<'static> {
+    let (needs_x, motion_x, ready_x) = project_columns(width as usize);
+    let compact = width < 52;
+    let labels = if compact {
+        ("PROJECT", "NEED", "MOTION", "READY")
+    } else {
+        ("PROJECT", "NEEDS YOU", "IN MOTION", "READY")
+    };
+    let mut spans = vec![Span::styled(labels.0.to_string(), style_dim())];
+    let mut x = labels.0.len();
+    for (column, label) in [
+        (needs_x, labels.1),
+        (motion_x, labels.2),
+        (ready_x, labels.3),
+    ] {
+        spans.push(Span::raw(" ".repeat(column.saturating_sub(x))));
+        spans.push(Span::styled(label.to_string(), style_dim()));
+        x = column + label.len();
+    }
+    bound_line(Line::from(spans), width as usize)
+}
+
+fn project_columns(width: usize) -> (usize, usize, usize) {
+    if width >= 52 {
+        (18, 29, 40)
+    } else {
+        let ready = width.saturating_sub(5);
+        let motion = ready.saturating_sub(10);
+        let needs = motion.saturating_sub(10);
+        (needs, motion, ready)
+    }
+}
+
+/// One projects index row: the project name (plus path when basenames collide, and a
+/// `current directory` marker for the invocation project) with its open-work counts.
+fn paint_project_row(
+    model: &QueueFrameModel<'_>,
+    index: usize,
+    selected: bool,
+    width: u16,
+) -> Line<'static> {
+    let Some(row) = model.projects.get(index) else {
+        return paint_bounded_line("", width, style_plain());
+    };
+    let marker = if selected { "\u{25b8} " } else { "  " };
+    let basename = crate::ui::board::project_option_label(Path::new(&row.path));
+    let (needs_x, motion_x, ready_x) = project_columns(width as usize);
+    let name = if row.duplicate_basename && width < 80 {
+        let parent = Path::new(&row.path)
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .unwrap_or(&row.path);
+        format!("{basename} (/{parent})")
+    } else {
+        basename
+    };
+    let path_suffix = if row.duplicate_basename && width >= 80 {
+        format!("  \u{b7} {}", row.path)
+    } else {
+        String::new()
+    };
+    let name_style = if selected {
+        style_bold()
+    } else {
+        style_plain()
+    };
+    // The name gets the space before the first count, not the whole row. The previous
+    // budget accidentally truncated the complete row to one cell when a name was long.
+    let prefix_width = display_width(&format!(" {marker}"));
+    let name_budget = needs_x.saturating_sub(prefix_width).max(1);
+    let name = present_line(&name, name_budget);
+    let mut spans = vec![Span::styled(format!(" {marker}{name}"), name_style)];
+    let current = prefix_width + display_width(&name);
+    spans.push(Span::raw(" ".repeat(needs_x.saturating_sub(current))));
+    let needs = row.needs_you.to_string();
+    spans.push(Span::styled(needs.clone(), style_dim()));
+    let after_needs = needs_x + display_width(&needs);
+    spans.push(Span::raw(" ".repeat(motion_x.saturating_sub(after_needs))));
+    let motion = row.in_motion.to_string();
+    spans.push(Span::styled(motion.clone(), style_dim()));
+    let after_motion = motion_x + display_width(&motion);
+    spans.push(Span::raw(" ".repeat(ready_x.saturating_sub(after_motion))));
+    let ready = row.ready.to_string();
+    spans.push(Span::styled(ready, style_dim()));
+    // Keep annotations after the aligned counts so they cannot consume the basename budget.
+    if !path_suffix.is_empty() {
+        spans.push(Span::styled(path_suffix, style_dim()));
+    }
+    if row.current {
+        spans.push(Span::styled(" · current directory", style_dim()));
+    }
+    bound_line(Line::from(spans), width as usize)
+}
+
 fn paint_rail_row_lines(
     task: &Task,
     identifier: Option<&str>,
@@ -3800,85 +3899,6 @@ fn paint_rail_row_lines(
 /// Paint one scoped ON DECK thread block label. Headers are presentation-only: their
 /// associated ids stay in the task-only queue stream, so neither keyboard selection nor
 /// mouse hit testing can land on this row.
-fn paint_thread_header(name: &str, open_count: usize, geo: &TierGeometry) -> Line<'static> {
-    let text = match geo.tier {
-        Tier::Standard => format!("  #{name} · {open_count} open"),
-        Tier::Compact => format!("  #{name} {open_count}"),
-    };
-    paint_bounded_line(&text, geo.row_width, style_dim())
-}
-
-fn paint_project_group_header(
-    section: &QueueSection,
-    width: u16,
-    collapsed: bool,
-) -> Line<'static> {
-    let title = section
-        .project_label
-        .as_deref()
-        .map(short_project)
-        .unwrap_or("project");
-    paint_collapsible_header(
-        if collapsed { "▸" } else { "▾" },
-        title,
-        section.count,
-        width,
-    )
-}
-
-fn paint_thread_group_header(section: &QueueSection, width: u16, collapsed: bool) -> Line<'static> {
-    let title = section
-        .thread_label
-        .as_deref()
-        .map(|name| format!("#{name}"))
-        .unwrap_or_else(|| "#thread".to_string());
-    paint_collapsible_header(
-        if collapsed { "▸" } else { "▾" },
-        &title,
-        section.count,
-        width,
-    )
-}
-
-fn paint_thread_project_header(
-    project_path: Option<&str>,
-    count: usize,
-    width: u16,
-    geo: &TierGeometry,
-) -> Line<'static> {
-    let title = match project_path {
-        Some(path) => short_project(path).to_string(),
-        None => "desk".to_string(),
-    };
-    let text = match geo.tier {
-        Tier::Standard => format!("  {title} · {count} open"),
-        Tier::Compact => format!("  {title} {count}"),
-    };
-    paint_bounded_line(&text, width, style_dim())
-}
-
-fn paint_collapsible_header(chevron: &str, title: &str, count: usize, width: u16) -> Line<'static> {
-    let left = present_line(&format!(" {chevron} {title} "), width as usize);
-    let right_budget = (width as usize).saturating_sub(display_width(&left));
-    let right = if right_budget == 0 {
-        String::new()
-    } else {
-        present_line(&format!("{} ", count), right_budget)
-    };
-    let rule_w = (width as usize)
-        .saturating_sub(display_width(&left))
-        .saturating_sub(display_width(&right));
-    let rule = "─".repeat(rule_w);
-    bound_line(
-        Line::from(vec![
-            Span::styled(left, style_bold()),
-            Span::styled(rule, style_dim()),
-            Span::styled(right, style_dim()),
-        ]),
-        width as usize,
-    )
-}
-
 /// The archived group's header: `{chevron} archived · {n}` with no rule. Selected,
 /// the word is bold and the rest dim; unselected, everything is dim. Never reverse.
 fn paint_archived_header(
@@ -3903,10 +3923,9 @@ fn paint_archived_header(
 fn paint_section_header(
     section: &QueueSection,
     width: u16,
-    at_home: bool,
-    home_tab: BoardTab,
+    surface: BoardSurface,
 ) -> Line<'static> {
-    let title = section_title(section, at_home, home_tab);
+    let title = section_title(section, surface);
     let left = present_line(&format!(" {title} "), width as usize);
     let right_budget = (width as usize).saturating_sub(display_width(&left));
     let right = if right_budget == 0 {
@@ -3917,7 +3936,7 @@ fn paint_section_header(
     let rule_w = (width as usize)
         .saturating_sub(display_width(&left))
         .saturating_sub(display_width(&right));
-    let rule = "─".repeat(rule_w);
+    let rule = "\u{2500}".repeat(rule_w);
     bound_line(
         Line::from(vec![
             Span::styled(left, style_bold()),
@@ -3928,16 +3947,14 @@ fn paint_section_header(
     )
 }
 
-fn section_title(section: &QueueSection, at_home: bool, home_tab: BoardTab) -> String {
+fn section_title(section: &QueueSection, surface: BoardSurface) -> String {
     match section.kind {
         SectionKind::NeedsYou => "NEEDS YOU".to_string(),
         SectionKind::InMotion => "IN MOTION".to_string(),
         SectionKind::Done => "DONE".to_string(),
         SectionKind::Archived => "archived".to_string(),
-        SectionKind::OnDeck
-            if at_home && home_tab == BoardTab::Desk && section.project_label.is_none() =>
-        {
-            "desk".to_string()
+        SectionKind::OnDeck if surface == BoardSurface::Desk && section.project_label.is_none() => {
+            "ON DECK \u{b7} desk".to_string()
         }
         SectionKind::OnDeck => "ON DECK".to_string(),
     }
@@ -4081,26 +4098,20 @@ fn paint_quick_add_hint(
     surface: Rect,
     row: u16,
     width: u16,
-    project_scope: bool,
+    destination: &str,
     message: Option<&str>,
     tier: Tier,
 ) {
     let (text, style) = if let Some(message) = message {
         (message.to_string(), style_reverse_bold())
     } else {
+        // The line names where Enter saves, so quick-add never has to move the
+        // user's view to prove where a task went.
         let text = match tier {
-            Tier::Standard => format!(
-                "Enter save · esc cancel · tab expand · scope: {}",
-                if project_scope {
-                    "this project"
-                } else {
-                    "desk"
-                }
-            ),
-            Tier::Compact => format!(
-                "⏎ save · esc · tab · {}",
-                if project_scope { "proj" } else { "desk" }
-            ),
+            Tier::Standard => {
+                format!("Enter save · esc cancel · tab expand · add to {destination}")
+            }
+            Tier::Compact => format!("⏎ save · esc · tab · + {destination}"),
         };
         (text, style_dim())
     };
@@ -4172,7 +4183,29 @@ fn paint_status_line(
     (bound_line(Line::from(spans), width as usize), undo_hit)
 }
 
-/// Selector: home tabs left, project picker chip right.
+/// Whether the destination control needs a dedicated row to keep tabs and its selected
+/// value readable without overlap, especially at the 40-column operating floor.
+fn selector_chip_wraps(model: &QueueFrameModel<'_>, width: u16) -> bool {
+    let Some(chip) = model.nav.chip.as_ref() else {
+        return false;
+    };
+    let slot2 = model.nav.slot2_label.as_str();
+    let tabs = [
+        " desk ".to_string(),
+        if model.nav.slot2_project {
+            format!(" {slot2} ▾ ")
+        } else {
+            format!(" {slot2} ▸ ")
+        },
+        " projects ".to_string(),
+    ];
+    let tabs_width = tabs.iter().map(|tab| display_width(tab)).sum::<usize>() + 6;
+    let chip_width = display_width(&format!(" {} ▾ ", chip.label));
+    tabs_width.saturating_add(chip_width) > width as usize
+}
+
+/// Paint the selector row's persistent tabs. Tabs never disappear, so `1`/`2`/`3`
+/// keep their keyboard mappings even though the digit labels are not shown.
 fn paint_selector_row(
     model: &QueueFrameModel<'_>,
     geo: &TierGeometry,
@@ -4183,70 +4216,74 @@ fn paint_selector_row(
         return (Line::from(""), hits);
     }
 
-    let mut left_spans: Vec<Span<'static>> = Vec::new();
+    let mut spans: Vec<Span<'static>> = Vec::new();
     let mut left_width = 0usize;
-
-    if model.at_home {
-        for (index, (tab, label)) in [
-            (BoardTab::Desk, "desk"),
-            (BoardTab::Projects, "projects"),
-            (BoardTab::Threads, "threads"),
-        ]
-        .iter()
-        .enumerate()
-        {
-            if index > 0 {
-                left_spans.push(Span::styled(" · ".to_string(), style_dim()));
-                left_width += 3;
-            }
-            let active = model.home_tab == *tab;
-            let text = format!(" {label} ");
-            let shown = present_line(&text, width.saturating_sub(left_width));
-            let w = display_width(&shown);
-            hits.push((
-                QueueHitTarget::HomeTab(*tab),
-                left_width as u16,
-                w.max(1) as u16,
-            ));
-            left_spans.push(Span::styled(
-                shown,
-                if active {
-                    style_reverse_bold()
-                } else {
-                    style_dim()
-                },
-            ));
-            left_width += w;
+    let slot2 = model.nav.slot2_label.as_str();
+    let tabs: [(NavTab, String); 3] = [
+        (NavTab::Desk, " desk ".to_string()),
+        (
+            NavTab::ProjectBoard,
+            if model.nav.slot2_project {
+                format!(" {slot2} \u{25be} ")
+            } else {
+                format!(" {slot2} \u{25b8} ")
+            },
+        ),
+        (NavTab::Projects, " projects ".to_string()),
+    ];
+    for (index, (tab, text)) in tabs.iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::styled(" \u{b7} ".to_string(), style_dim()));
+            left_width += 3;
         }
+        let active = model.nav.active == *tab;
+        let shown = present_line(text, width.saturating_sub(left_width));
+        let w = display_width(&shown);
+        hits.push((
+            QueueHitTarget::NavTab(*tab),
+            left_width as u16,
+            w.max(1) as u16,
+        ));
+        spans.push(Span::styled(
+            shown,
+            if active {
+                style_reverse_bold()
+            } else {
+                style_dim()
+            },
+        ));
+        left_width += w;
     }
 
-    let mut spans = left_spans;
-    if model.at_home {
-        let pad = width.saturating_sub(left_width);
-        if pad > 0 {
-            spans.push(Span::styled(" ".repeat(pad), style_plain()));
+    // The active destination's control rides the row's right side when it fits. Narrow
+    // frames paint it on the dedicated row added by `draw_queue_frame_impl`.
+    if !selector_chip_wraps(model, geo.row_width) {
+        if let Some(chip) = model.nav.chip.as_ref() {
+            let chip_text = present_line(&format!(" {} \u{25be} ", chip.label), width);
+            let chip_w = display_width(&chip_text);
+            let spacer_w = width.saturating_sub(left_width).saturating_sub(chip_w);
+            let chip_x = (left_width + spacer_w) as u16;
+            spans.push(Span::styled(" ".repeat(spacer_w), style_plain()));
+            spans.push(Span::styled(chip_text, style_dim()));
+            hits.push((QueueHitTarget::NavChip, chip_x, chip_w.max(1) as u16));
         }
-    } else {
-        let chip_label = model.scope_label;
-        let chip_budget = (geo.selector_chip_max as usize).min(width);
-        let chip_raw = format!("{chip_label} ▾ ");
-        let chip_text = present_line(&chip_raw, chip_budget);
-        let chip_w = display_width(&chip_text);
-        let spacer_w = width.saturating_sub(left_width).saturating_sub(chip_w);
-        let chip_x = (left_width + spacer_w) as u16;
-        spans.push(Span::styled(" ".repeat(spacer_w), style_plain()));
-        spans.push(Span::styled(
-            present_line(chip_label, chip_budget.saturating_sub(display_width(" ▾ "))),
-            style_bold(),
-        ));
-        spans.push(Span::styled(
-            present_line(" ▾ ", chip_budget.saturating_sub(display_width(chip_label))),
-            style_dim(),
-        ));
-        hits.push((QueueHitTarget::ProjectChip, chip_x, chip_w.max(1) as u16));
     }
 
     (bound_line(Line::from(spans), width), hits)
+}
+
+fn paint_selector_chip(model: &QueueFrameModel<'_>, width: u16) -> (Line<'static>, u16, u16) {
+    let Some(chip) = model.nav.chip.as_ref() else {
+        return (Line::from(""), 0, 0);
+    };
+    let chip_text = present_line(&format!(" {} \u{25be} ", chip.label), width as usize);
+    let chip_width = display_width(&chip_text).min(width as usize);
+    let x = (width as usize).saturating_sub(chip_width) as u16;
+    let line = Line::from(vec![
+        Span::styled(" ".repeat(x as usize), style_plain()),
+        Span::styled(chip_text, style_dim()),
+    ]);
+    (line, x, chip_width.max(1) as u16)
 }
 
 /// Verb bar: ` key label · key label …`, trimmed to `budget` entries.
@@ -4303,47 +4340,55 @@ fn paint_verb_bar(
 
 /// Widest row-meta display width across the tasks the view paints. The wide split's board
 /// column uses it to size its meta column to the content actually shown, instead of the
-/// narrow board's fixed reserve.
+/// narrow board's fixed reserve. Relative ages are deliberately excluded from row metadata.
 pub fn widest_row_meta_width(tasks: &[Task], view: &QueueView, now: SystemTime) -> usize {
     let mut widest = 0usize;
     for section in &view.sections {
-        let in_project_section =
-            section.kind == SectionKind::OnDeck && section.project_label.is_some();
+        let attribution = section.project_label.is_none();
         for id in &section.task_ids {
             if let Some(task) = tasks.iter().find(|task| task.id == *id) {
-                widest = widest.max(display_width(&row_meta(task, now, in_project_section)));
+                widest = widest.max(display_width(&row_meta(task, now, attribution, false)));
+                // Stage A may paint project-board thread attribution even though the
+                // section metadata does not carry that surface flag. Budget both real
+                // attribution shapes so a full valid thread is never clipped there.
+                widest = widest.max(display_width(&row_meta(task, now, false, true)));
             }
         }
     }
     widest
 }
 
-fn row_meta(task: &Task, now: SystemTime, in_project_section: bool) -> String {
-    let age = format_age(now, task.updated_at);
-    let project = if !in_project_section {
+fn row_meta(
+    task: &Task,
+    _now: SystemTime,
+    project_attribution: bool,
+    thread_label: bool,
+) -> String {
+    let project = if project_attribution {
         match &task.scope {
             TaskScope::Project { path } => Some(short_project(path).to_string()),
-            TaskScope::Global => None,
+            TaskScope::Global => Some("desk".to_string()),
         }
     } else {
         None
     };
-    fit_row_meta(project, age)
+    let thread = if thread_label {
+        task.thread.as_deref().map(|name| format!("#{name}"))
+    } else {
+        None
+    };
+    fit_row_meta(project, thread)
 }
 
-/// Keep the age intact and shrink the project basename inside the standard meta column.
-fn fit_row_meta(project: Option<String>, age: String) -> String {
-    const CONTENT: usize = 27;
-    const SEP: &str = " · ";
-    let project = project.and_then(|name| {
-        let room = CONTENT.saturating_sub(display_width(&age).saturating_add(display_width(SEP)));
-        (room > 0).then(|| present_line(&name, room))
-    });
-    [project, Some(age)]
+/// Keep the genuine project/thread attribution intact. Relative ages belong to task-page
+/// information, not task rows, so metadata has no fixed age reserve or artificial cap.
+fn fit_row_meta(project: Option<String>, thread: Option<String>) -> String {
+    [project, thread]
         .into_iter()
         .flatten()
+        .filter(|value| !value.is_empty())
         .collect::<Vec<_>>()
-        .join(SEP)
+        .join(" · ")
 }
 
 pub(crate) fn format_age(now: SystemTime, then: SystemTime) -> String {
@@ -4583,12 +4628,12 @@ mod tests {
         );
         let meta_text = plain(&meta_only);
         assert!(
-            meta_text.contains('…'),
-            "long meta must truncate with …, got {meta_text:?}"
+            !meta_text.contains('…'),
+            "full task-row attribution should fit without the old age cap, got {meta_text:?}"
         );
         assert!(
-            meta_text.contains("short"),
-            "short title must remain intact when only meta overflows"
+            meta_text.contains(long_meta),
+            "full metadata must remain readable when it fits, got {meta_text:?}"
         );
     }
 

--- a/src/ui/tier.rs
+++ b/src/ui/tier.rs
@@ -147,8 +147,8 @@ pub const STANDARD_VERB_BAR_ENTRY_BUDGET: u16 = 7;
 /// Minimum width for the standard board tier. This is the default Herdr split amendment.
 const STANDARD_MIN_WIDTH: u16 = 78;
 
-/// Reserved trailing meta cells in the standard tier (project · age).
-const STANDARD_META_COLUMN_WIDTH: u16 = 28;
+/// Reserved trailing meta cells in the standard tier for full project/thread attribution.
+const STANDARD_META_COLUMN_WIDTH: u16 = 36;
 
 /// Map terminal dimensions to a tier and frame geometry.
 ///
@@ -400,7 +400,10 @@ mod tests {
             );
             if (w, h) == (STANDARD_MIN_WIDTH, 24) {
                 assert_eq!(g.meta_column_width, STANDARD_META_COLUMN_WIDTH);
-                assert_eq!(g.title_width, 50, "78 columns retain 50 title cells");
+                assert_eq!(
+                    g.title_width, 42,
+                    "78 columns retain room for full thread metadata"
+                );
             }
             let narrowed = g.with_row_width(w.saturating_sub(2));
             assert_eq!(narrowed.row_width, w.saturating_sub(2), "{w}x{h}");

--- a/tests/fixtures/queue_board/accordion.txt
+++ b/tests/fixtures/queue_board/accordion.txt
@@ -1,22 +1,22 @@
 ┌────────────────────────────────────────────────────────────────────────────────┐
 │                                                                                │
-│ desk  ·  projects  ·  threads                                                  │
+│ desk  ·  tsk ▾  ·  projects                                              all ▾ │
+│                                                                                │
+│ NEEDS YOU ───────────────────────────────────────────────────────────────────2 │
+│                                                                                │
+│  ■ T5 Wire dispatch cleanup receipts                                     herdr │
+│  ▲ T6 Docs refresh pass after F9 ships                                   herdr │
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ T1 Smoke-test worktree dispatch                                    tsk · 3m │
+│  ▸ T1 Smoke-test worktree dispatch                                         tsk │
 │    │ no notes yet                                                              │
 │    └                                                                           │
-│  ▸ T2 Edit target binding pin                                      herdr · 12m │
+│  ▸ T2 Edit target binding pin                                            herdr │
 │                                                                                │
-│ desk ────────────────────────────────────────────────────────────────────────1 │
+│ ON DECK · desk ──────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ T7 Global backlog note                                                   2d │
-│                                                                                │
-│                                                                                │
-│                                                                                │
-│                                                                                │
-│                                                                                │
+│  ○ T7 Global backlog note                                                 desk │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/board.txt
+++ b/tests/fixtures/queue_board/board.txt
@@ -1,20 +1,20 @@
 ┌────────────────────────────────────────────────────────────────────────────────┐
 │                                                                                │
-│ desk  ·  projects  ·  threads                                                  │
+│ desk  ·  tsk ▾  ·  projects                                              all ▾ │
+│                                                                                │
+│ NEEDS YOU ───────────────────────────────────────────────────────────────────2 │
+│                                                                                │
+│  ■ T5 Wire dispatch cleanup receipts                                     herdr │
+│  ▲ T6 Docs refresh pass after F9 ships                                   herdr │
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ T1 Smoke-test worktree dispatch                                    tsk · 3m │
-│  ▸ T2 Edit target binding pin                                      herdr · 12m │
+│  ▸ T1 Smoke-test worktree dispatch                                         tsk │
+│  ▸ T2 Edit target binding pin                                            herdr │
 │                                                                                │
-│ desk ────────────────────────────────────────────────────────────────────────1 │
+│ ON DECK · desk ──────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ T7 Global backlog note                                                   2d │
-│                                                                                │
-│                                                                                │
-│                                                                                │
-│                                                                                │
-│                                                                                │
+│  ○ T7 Global backlog note                                                 desk │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/fixtures/queue_board/board_default_split_78.txt
+++ b/tests/fixtures/queue_board/board_default_split_78.txt
@@ -1,20 +1,20 @@
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │                                                                              │
-│ desk  ·  projects  ·  threads                                                │
+│ desk  ·  tsk ▾  ·  projects                                            all ▾ │
+│                                                                              │
+│ NEEDS YOU ─────────────────────────────────────────────────────────────────2 │
+│                                                                              │
+│  ■ T5 Wire dispatch cleanup receipts                                   herdr │
+│  ▲ T6 Docs refresh pass after F9 ships                                 herdr │
 │                                                                              │
 │ IN MOTION ─────────────────────────────────────────────────────────────────2 │
 │                                                                              │
-│  ▸ T1 Smoke-test worktree dispatch                                  tsk · 3m │
-│  ▸ T2 Edit target binding pin                                    herdr · 12m │
+│  ▸ T1 Smoke-test worktree dispatch                                       tsk │
+│  ▸ T2 Edit target binding pin                                          herdr │
 │                                                                              │
-│ desk ──────────────────────────────────────────────────────────────────────1 │
+│ ON DECK · desk ────────────────────────────────────────────────────────────1 │
 │                                                                              │
-│  ○ T7 Global backlog note                                                 2d │
-│                                                                              │
-│                                                                              │
-│                                                                              │
-│                                                                              │
-│                                                                              │
+│  ○ T7 Global backlog note                                               desk │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/tests/fixtures/queue_board/done_drawer.txt
+++ b/tests/fixtures/queue_board/done_drawer.txt
@@ -1,25 +1,25 @@
 ┌────────────────────────────────────────────────────────────────────────────────┐
 │                                                                                │
-│ desk  ·  projects  ·  threads                                                  │
+│ desk  ·  tsk ▾  ·  projects                                              all ▾ │
+│                                                                                │
+│ NEEDS YOU ───────────────────────────────────────────────────────────────────2 │
+│                                                                                │
+│  ■ T5 Wire dispatch cleanup receipts                                     herdr │
+│  ▲ T6 Docs refresh pass after F9 ships                                   herdr │
 │                                                                                │
 │ IN MOTION ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ T1 Smoke-test worktree dispatch                                    tsk · 3m │
-│  ▸ T2 Edit target binding pin                                      herdr · 12m │
+│  ▸ T1 Smoke-test worktree dispatch                                         tsk │
+│  ▸ T2 Edit target binding pin                                            herdr │
 │                                                                                │
-│ desk ────────────────────────────────────────────────────────────────────────1 │
+│ ON DECK · desk ──────────────────────────────────────────────────────────────1 │
 │                                                                                │
-│  ○ T7 Global backlog note                                                   2d │
+│  ○ T7 Global backlog note                                                 desk │
 │                                                                                │
 │ DONE ────────────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ✓ T8 Ship the queue board milestone                                  tsk · 5h │
-│  ✓ T9 Retire classic board chrome                                           6h │
-│                                                                                │
-│                                                                                │
-│                                                                                │
-│                                                                                │
-│                                                                                │
+│  ✓ T8 Ship the queue board milestone                                       tsk │
+│  ✓ T9 Retire classic board chrome                                         desk │
 │────────────────────────────────────────────────────────────────────────────────│
 │ 2 done                                                                         │
 │ enter open · ctrl+d done · ctrl+b block · : palette · ? help · + capture · f a…│

--- a/tests/fixtures/queue_board/done_drawer_archived.txt
+++ b/tests/fixtures/queue_board/done_drawer_archived.txt
@@ -1,25 +1,25 @@
 ┌────────────────────────────────────────────────────────────────────────────────┐
 │                                                                                │
-│ desk  ·  projects  ·  threads                                                  │
+│ desk  ·  tsk ▾  ·  projects                                              all ▾ │
+│                                                                               ▌│
+│ NEEDS YOU ─────────────────────────────────────────────────────────────────2  ▌│
+│                                                                               ▌│
+│  ■ T5 Wire dispatch cleanup receipts                                   herdr  ▌│
+│  ▲ T6 Docs refresh pass after F9 ships                                 herdr  ▌│
+│                                                                               ▌│
+│ IN MOTION ─────────────────────────────────────────────────────────────────2  ▌│
+│                                                                               ▌│
+│  ▸ T1 Smoke-test worktree dispatch                                       tsk  ▌│
+│  ▸ T2 Edit target binding pin                                          herdr  ▌│
+│                                                                               ▌│
+│ ON DECK · desk ────────────────────────────────────────────────────────────1  ▌│
+│                                                                               ▌│
+│  ○ T7 Global backlog note                                               desk  ▌│
+│                                                                               ▌│
+│ DONE ──────────────────────────────────────────────────────────────────────2  ▌│
 │                                                                                │
-│ IN MOTION ───────────────────────────────────────────────────────────────────2 │
-│                                                                                │
-│  ▸ T1 Smoke-test worktree dispatch                                    tsk · 3m │
-│  ▸ T2 Edit target binding pin                                      herdr · 12m │
-│                                                                                │
-│ desk ────────────────────────────────────────────────────────────────────────1 │
-│                                                                                │
-│  ○ T7 Global backlog note                                                   2d │
-│                                                                                │
-│ DONE ────────────────────────────────────────────────────────────────────────2 │
-│                                                                                │
-│  ✓ T8 Ship the queue board milestone                                  tsk · 5h │
-│  ✓ T9 Retire classic board chrome                                           6h │
-│                                                                                │
-│ ▾ archived · 2                                                                 │
-│                                                                                │
-│  ○ T31 Archived receipt sweep                                        tsk · 45m │
-│  ■ T32 Archived vendored spike                                             50m │
+│  ✓ T8 Ship the queue board milestone                                     tsk   │
+│  ✓ T9 Retire classic board chrome                                       desk   │
 │────────────────────────────────────────────────────────────────────────────────│
 │ 2 done                                                                         │
 │ enter open · ctrl+d done · ctrl+b block · : palette · ? help · + capture · f a…│

--- a/tests/fixtures/queue_board/help.txt
+++ b/tests/fixtures/queue_board/help.txt
@@ -1,26 +1,26 @@
 ┌────────────────────────────────────────────────────────────────────────────────┐
 │                                                                                │
-│ desk  · ┌─ help ──────────────────────────────────────────────── [x]─┐         │
+│ desk  · ┌─ help ──────────────────────────────────────────────── [x]─┐   all ▾ │
 │         │                                                            │         │
-│ IN MOTIO│  ctrl+q quit | Esc close                                   │───────2 │
+│ NEEDS YO│  ctrl+q quit | Esc close                                   │───────2 │
 │         │  j/k · ↑/↓ move | ctrl+s primary                           │         │
-│  ▸ T1 Sm│  ctrl+d done | ctrl+o reopen                               │tsk · 3m │
-│  ▸ T2 Ed│  ctrl+b block | enter open                                 │dr · 12m │
+│  ■ T5 Wi│  ctrl+d done | ctrl+o reopen                               │   herdr │
+│  ▲ T6 Do│  ctrl+b block | enter open                                 │   herdr │
 │         │  →/← peek | + capture                                      │         │
-│ desk ───│  ctrl+e title | ctrl+x/Delete delete                       │───────1 │
+│ IN MOTIO│  ctrl+e title | ctrl+x/Delete delete                       │───────2 │
 │         │  ctrl+u undo | ctrl+f file                                 │         │
-│  ○ T7 Gl│  z drawer | : palette                                      │      2d │
-│         │  ? help | P project                                        │         │
-│         │  ctrl+g groups                                             │         │
+│  ▸ T1 Sm│  z drawer | : palette                                      │     tsk │
+│  ▸ T2 Ed│  ? help | P project                                        │   herdr │
+│         │  t threads | v views                                       │         │
+│ ON DECK │  ctrl+g groups                                             │───────1 │
 │         │                                                            │         │
-│         │  task page                                                 │         │
+│  ○ T7 Gl│  task page                                                 │    desk │
 │         │  ctrl+e title | ctrl+n notes                               │         │
 │         │  ctrl+a step | tab/↓ steps                                 │         │
 │         │  shift+enter save edit | esc close                         │         │
 │         │                                                            │         │
 │         ├────────────────────────────────────────────────────────────┤         │
-│         │ any key close                                              │         │
-│─────────└────────────────────────────────────────────────────────────┘─────────│
-│ 2 done                                                                         │
+│─────────│ any key close                                              │─────────│
+│ 2 done  └────────────────────────────────────────────────────────────┘         │
 │                                                                                │
 └────────────────────────────────────────────────────────────────────────────────┘

--- a/tests/fixtures/queue_board/palette.txt
+++ b/tests/fixtures/queue_board/palette.txt
@@ -1,20 +1,20 @@
 ┌────────────────────────────────────────────────────────────────────────────────┐
 │                                                                                │
-│ desk  ·  projects  ·  threads                                                  │
+│ desk  ·  tsk ▾  ·  projects                                              all ▾ │
 │                                                                                │
-│ IN MOTION ───────────────────────────────────────────────────────────────────2 │
+│ NEEDS YOU ───────────────────────────────────────────────────────────────────2 │
 │                                                                                │
-│  ▸ T1 Sm┌─ command ───────────────────────────────────────────── [x]─┐tsk · 3m │
-│  ▸ T2 Ed│                                                            │dr · 12m │
+│  ■ T5 Wi┌─ command ───────────────────────────────────────────── [x]─┐   herdr │
+│  ▲ T6 Do│                                                            │   herdr │
 │         │   set status: ready                                        │         │
-│ desk ───│   set status: started                                      │───────1 │
+│ IN MOTIO│   set status: started                                      │───────2 │
 │         │ ▸ set status: blocked                                      │         │
-│  ○ T7 Gl│   set status: review                                       │      2d │
-│         │                                                            │         │
+│  ▸ T1 Sm│   set status: review                                       │     tsk │
+│  ▸ T2 Ed│                                                            │   herdr │
 │         ├────────────────────────────────────────────────────────────┤         │
-│         │ ↑/↓ move · enter run · esc close                           │         │
+│ ON DECK │ ↑/↓ move · enter run · esc close                           │───────1 │
 │         └────────────────────────────────────────────────────────────┘         │
-│                                                                                │
+│  ○ T7 Global backlog note                                                 desk │
 │                                                                                │
 │                                                                                │
 │                                                                                │

--- a/tests/host_scripts.rs
+++ b/tests/host_scripts.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tsk_tui::app::MODE_ENV;
 
 fn repo_root() -> PathBuf {
@@ -23,6 +24,102 @@ fn open_capture_path() -> PathBuf {
 
 fn read(path: &Path) -> String {
     fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn open_board_exercises_context_handoff_before_focus_and_new_pane_paths() {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let root = std::env::temp_dir().join(format!(
+        "tsk-host-launcher-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir_all(&root).expect("temp root");
+    let stub = root.join("herdr");
+    let log = root.join("calls.log");
+    fs::write(
+        &stub,
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$STUB_LOG"
+if [ "$1" = pane ] && [ "$2" = list ]; then
+  if [ "${STUB_MODE:-existing}" = existing ]; then
+    printf '%s' '{"result":{"panes":[{"pane_id":"w0:p1","label":"tsk"}]}}'
+  else
+    printf '%s' '{"result":{"panes":[]}}'
+  fi
+fi
+if [ "$1" = plugin ] && [ "$2" = pane ] && [ "$3" = focus ] && [ ! -f "$STUB_STATE/reopen.json" ]; then
+  exit 1
+fi
+"#,
+    )
+    .expect("stub");
+    let mut permissions = fs::metadata(&stub).expect("stub metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&stub, permissions).expect("stub executable");
+    let state = root.join("state");
+    fs::create_dir_all(&state).expect("state");
+    let run = |mode: &str| {
+        Command::new("bash")
+            .arg(open_board_path())
+            .env("HERDR_BIN_PATH", &stub)
+            .env("TSK_BIN", env!("CARGO_BIN_EXE_tsk"))
+            .env("TSK_STATE_DIR", &state)
+            .env("STUB_LOG", &log)
+            .env("STUB_STATE", &state)
+            .env("STUB_MODE", mode)
+            .env(
+                "HERDR_PLUGIN_CONTEXT_JSON",
+                r#"{"focused_pane_cwd":"/tmp"}"#,
+            )
+            .output()
+            .expect("launcher")
+    };
+    let existing = run("existing");
+    assert!(
+        existing.status.success(),
+        "existing launcher: {:?}",
+        existing
+    );
+    let calls = read(&log);
+    assert!(calls.contains("pane list"));
+    assert!(calls.contains("plugin pane focus w0:p1"));
+    assert!(
+        !calls.lines().any(|line| line == "plugin pane open"),
+        "existing pane must not be reopened"
+    );
+    assert!(calls.find("pane list").unwrap() < calls.find("plugin pane focus").unwrap());
+    assert!(state.join("reopen.json").exists(), "context was published");
+
+    let absent = run("absent");
+    assert!(absent.status.success(), "new-pane launcher: {:?}", absent);
+    let calls = read(&log);
+    assert!(calls.contains("plugin pane open"));
+
+    let before = calls.lines().count();
+    let failed = Command::new("bash")
+        .arg(open_board_path())
+        .env("HERDR_BIN_PATH", &stub)
+        .env("TSK_BIN", env!("CARGO_BIN_EXE_tsk"))
+        .env("TSK_STATE_DIR", &state)
+        .env("STUB_LOG", &log)
+        .env("STUB_STATE", &state)
+        .env("STUB_MODE", "existing")
+        .env("HERDR_PLUGIN_CONTEXT_JSON", "not json")
+        .output()
+        .expect("failing launcher");
+    assert!(!failed.status.success());
+    let after = read(&log);
+    assert_eq!(
+        after.lines().count(),
+        before + 1,
+        "failed handoff must not focus"
+    );
+    assert!(!after
+        .lines()
+        .skip(before)
+        .any(|line| line == "plugin pane focus w0:p1"));
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Non-comment, non-empty lines of a shell script (strip `# ...` full-line comments).

--- a/tests/queue_board_edit.rs
+++ b/tests/queue_board_edit.rs
@@ -463,6 +463,32 @@ fn task_form_unifies_palette_field_routes_scope_dropdown_and_atomic_save() {
     assert_eq!(saved.notes.as_deref(), Some("old\nnew"));
     assert_eq!(saved.scope, TaskScope::Global);
 
+    // The saved task left this project board for the desk: navigation is the user's
+    // move now (no auto-reveal), so go there before the palette routes.
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectNavTab(tsk_tui::ui::queue::NavTab::Desk),
+        None,
+    )
+    .expect("move to the desk");
+    assert!(
+        model.visible_ids().contains(&id),
+        "the saved desk task is visible from the desk"
+    );
+    let saved_row = model
+        .visible_ids()
+        .iter()
+        .position(|&visible| visible == id)
+        .expect("saved row");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectIndex(saved_row),
+        None,
+    )
+    .expect("pin the saved task");
+
     let palette_notes_route = model
         .available_commands()
         .into_iter()
@@ -1186,6 +1212,9 @@ fn task_page_footer_hits_use_display_columns_and_stay_within_the_painted_row() {
         )
         .expect("create");
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from(
+        "/repos/\u{30d7}\u{30ed}\u{30b8}\u{30a7}\u{30af}\u{30c8}",
+    )));
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
 
     let width = 40;
@@ -1231,6 +1260,9 @@ fn task_page_header_identifier_precedes_the_title_and_footer_scope() {
     let mut persisted = domain.get(id).expect("task").clone();
     persisted.number = Some(1);
     let mut model = BoardModel::from_tasks(vec![persisted], Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
+    apply_intent(&mut domain, &mut model, BoardIntent::SelectIndex(0), None)
+        .expect("select the task");
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
 
     let (width, height) = (80, 24);
@@ -1508,6 +1540,7 @@ fn task_page_scope_dropdown_omits_archived_projects_but_keeps_the_current_scope(
         .expect("create stranded");
     domain.archive_project("/repos/filed").expect("archive it");
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from("/repos/other")));
 
     // Editing a live task: the archived project is not on offer.
     let index = model

--- a/tests/queue_board_model.rs
+++ b/tests/queue_board_model.rs
@@ -6,13 +6,17 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
+use std::collections::BTreeSet;
 use tsk_tui::domain::{
     DomainState, HumanStatus, ProvenanceOrigin, Task, TaskEvent, TaskEventKind, TaskScope,
 };
+use tsk_tui::scope::paths_equivalent;
 use tsk_tui::store::TaskStore;
 use tsk_tui::ui::board::{apply_intent, draw_board, BoardModel, ProjectScopeOption};
 use tsk_tui::ui::input::BoardIntent;
-use tsk_tui::ui::queue::{query_lens, BoardLens, BoardTab, SectionKind};
+use tsk_tui::ui::queue::{
+    query_board, query_lens, BoardLens, ProjectRow, QueueView, SectionKind, ThreadFilter,
+};
 use uuid::Uuid;
 
 const THIS_REPO: &str = "/repos/app";
@@ -72,6 +76,23 @@ fn on_deck(view: &tsk_tui::ui::queue::QueueView) -> &tsk_tui::ui::queue::QueueSe
         .expect("ON DECK section")
 }
 
+fn section_ids(view: &QueueView, kind: SectionKind) -> Vec<Uuid> {
+    view.sections
+        .iter()
+        .filter(|section| section.kind == kind)
+        .flat_map(|section| section.task_ids.iter().copied())
+        .collect()
+}
+
+#[allow(unused)]
+fn project_row(view: &QueueView, path: &str) -> ProjectRow {
+    view.projects
+        .iter()
+        .find(|row| paths_equivalent(&row.path, path))
+        .expect("index row")
+        .clone()
+}
+
 fn temp_dir(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -114,10 +135,11 @@ fn list_files_recursive(root: &Path) -> Vec<PathBuf> {
     out
 }
 
-/// First open: pin selection on the first IN MOTION row, else the first ON DECK row.
+/// First open pins the first NEEDS YOU / IN MOTION / ON DECK row of the startup
+/// destination: the project board inside a repo, the desk anywhere else.
 #[test]
-fn from_domain_seeds_selection_on_first_in_motion_else_first_deck_row() {
-    // Case A: IN MOTION present → first motion id (updated_at desc).
+fn from_domain_seeds_selection_on_first_needs_you_else_motion_else_deck_row() {
+    // Case A: startup in a repo opens its project board and seeds by lane order.
     let motion_newer = task(
         1,
         "motion-new",
@@ -135,12 +157,7 @@ fn from_domain_seeds_selection_on_first_in_motion_else_first_deck_row() {
     let deck = task(3, "deck", HumanStatus::Ready, project(THIS_REPO), 200);
     let tasks = vec![motion_newer.clone(), motion_older.clone(), deck.clone()];
     let model = BoardModel::from_tasks(tasks.clone(), Some(PathBuf::from(THIS_REPO)));
-    let view = query_lens(
-        &tasks,
-        Some(Path::new(THIS_REPO)),
-        BoardLens::Home(BoardTab::Desk),
-        false,
-    );
+    let view = query_lens(&tasks, Some(Path::new(THIS_REPO)), BoardLens::Desk, false);
     let first_motion = view
         .sections
         .iter()
@@ -193,21 +210,14 @@ fn from_domain_seeds_selection_on_first_in_motion_else_first_deck_row() {
         "from_domain seeds an IN MOTION task when any exist"
     );
 
-    // Case B: desk tab with only project ON DECK rows opens on Projects instead.
+    // Case B: a ready-only project opens its own board and seeds the first ON DECK row.
     let deck_a = task(10, "a", HumanStatus::Ready, project("/repos/a"), 30);
     let deck_b = task(11, "b", HumanStatus::Ready, project(THIS_REPO), 40);
     let deck_tasks = vec![deck_a.clone(), deck_b.clone()];
-    let model = BoardModel::from_tasks(deck_tasks.clone(), Some(PathBuf::from(THIS_REPO)));
-    assert_eq!(model.home_tab(), BoardTab::Projects);
-    assert_eq!(
-        model.selected_id(),
-        Some(Uuid::from_u128(11)),
-        "project-only boards open on Projects and seed the first ON DECK row"
-    );
     let view = query_lens(
         &deck_tasks,
         Some(Path::new(THIS_REPO)),
-        BoardLens::Home(BoardTab::Projects),
+        BoardLens::Project(Path::new(THIS_REPO)),
         false,
     );
     let first_deck = view
@@ -218,9 +228,109 @@ fn from_domain_seeds_selection_on_first_in_motion_else_first_deck_row() {
         .next();
     assert_eq!(first_deck, Some(Uuid::from_u128(11)));
 
+    let mut domain = DomainState::new();
+    let deck_id = domain
+        .create(
+            "b",
+            None,
+            project(THIS_REPO),
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .unwrap();
+    let model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    assert_eq!(model.nav_tab(), tsk_tui::ui::queue::NavTab::ProjectBoard);
+    assert_eq!(
+        model.selected_id(),
+        Some(deck_id),
+        "startup opens the invocation project's board and seeds its first row"
+    );
+
     // Case C: empty → no selection.
     let empty = BoardModel::from_tasks(vec![], Some(PathBuf::from(THIS_REPO)));
     assert_eq!(empty.selected_id(), None);
+}
+
+/// Directory-aware startup: a live repo opens its project board, an archived repo
+/// stays on the desk behind the launch card, no repo means the desk.
+#[test]
+fn from_domain_opens_the_invocation_project_unless_archived() {
+    let mut domain = DomainState::new();
+    let live_id = domain
+        .create(
+            "live",
+            None,
+            project(THIS_REPO),
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .unwrap();
+    domain
+        .create(
+            "elsewhere",
+            None,
+            project("/repos/other"),
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .unwrap();
+
+    let model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    assert_eq!(
+        model.selected_project(),
+        Some(Path::new(THIS_REPO)),
+        "launch inside a repo opens that project's board"
+    );
+    assert_eq!(model.visible_ids(), vec![live_id]);
+    assert_eq!(model.nav_tab(), tsk_tui::ui::queue::NavTab::ProjectBoard);
+
+    // Empty project: same destination, useful empty state (no fallback lens).
+    let empty_repo = format!("{THIS_REPO}-empty");
+    let model = BoardModel::from_domain(&DomainState::new(), Some(PathBuf::from(&empty_repo)));
+    assert_eq!(
+        model.selected_project(),
+        Some(Path::new(empty_repo.as_str()))
+    );
+    assert!(model.visible_ids().is_empty());
+    let view = model.queue_view();
+    assert!(
+        view.sections
+            .iter()
+            .any(|section| section.kind == SectionKind::OnDeck && section.empty_hint),
+        "an empty project board keeps a hinted deck section"
+    );
+
+    // Archived invocation repo: the launch card owns it; the board stays on the desk.
+    let mut domain = DomainState::new();
+    let archived_id = domain
+        .create(
+            "archived repo task",
+            None,
+            project(THIS_REPO),
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .unwrap();
+    domain.archive_project(THIS_REPO).expect("archive project");
+    let model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
+    assert_eq!(model.selected_project(), None);
+    assert_eq!(model.nav_tab(), tsk_tui::ui::queue::NavTab::Desk);
+    assert!(!model.visible_ids().contains(&archived_id));
+
+    // No repo at all: desk.
+    let mut domain = DomainState::new();
+    let desk_id = domain
+        .create(
+            "desk",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .unwrap();
+    let model = BoardModel::from_domain(&domain, None);
+    assert_eq!(model.nav_tab(), tsk_tui::ui::queue::NavTab::Desk);
+    assert_eq!(model.selected_id(), Some(desk_id));
 }
 
 /// Confirming a project selector choice narrows ON DECK to that project.
@@ -246,7 +356,11 @@ fn confirming_project_choice_changes_visible_queue_sections() {
         )
         .unwrap();
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
-    assert_eq!(model.visible_ids(), vec![app_id, other_id]);
+    assert_eq!(
+        model.visible_ids(),
+        vec![app_id],
+        "startup sits on the invocation project's board"
+    );
 
     apply_intent(
         &mut domain,
@@ -311,13 +425,6 @@ fn sync_from_domain_reanchors_by_id() {
         .unwrap();
 
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
-    apply_intent(
-        &mut domain,
-        &mut model,
-        BoardIntent::SelectHomeTab(BoardTab::Projects),
-        None,
-    )
-    .unwrap();
     let visible = model.visible_ids();
     assert!(visible.contains(&id_doing));
     assert!(visible.contains(&id_todo));
@@ -351,7 +458,7 @@ fn sync_from_domain_reanchors_by_id() {
 }
 
 #[test]
-fn deck_group_emits_thread_blocks_with_open_counts_iff_open_tasks() {
+fn project_deck_lists_tasks_flat_with_thread_filter_across_statuses() {
     let tasks = vec![
         threaded_task(
             1,
@@ -379,22 +486,82 @@ fn deck_group_emits_thread_blocks_with_open_counts_iff_open_tasks() {
         ),
     ];
 
-    let view = query_lens(
+    // The unfiltered project deck is flat: threads are row labels, never headers.
+    let view = query_board(
         &tasks,
+        &BTreeSet::new(),
         Some(Path::new(THIS_REPO)),
         BoardLens::Project(Path::new(THIS_REPO)),
         true,
+        &ThreadFilter::All,
     );
     let deck = on_deck(&view);
+    assert_eq!(
+        deck.task_ids,
+        vec![Uuid::from_u128(1)],
+        "only the ready task is on deck; threads do not group rows"
+    );
 
-    assert_eq!(deck.thread_blocks.len(), 1);
-    assert_eq!(deck.thread_blocks[0].name, "release");
-    assert_eq!(deck.thread_blocks[0].open_count, 1);
-    assert_eq!(deck.thread_blocks[0].task_ids, vec![Uuid::from_u128(1)]);
+    // The filter narrows every status section, drawer included.
+    let filtered = query_board(
+        &tasks,
+        &BTreeSet::new(),
+        Some(Path::new(THIS_REPO)),
+        BoardLens::Project(Path::new(THIS_REPO)),
+        true,
+        &ThreadFilter::Named("release".to_string()),
+    );
+    assert_eq!(
+        section_ids(&filtered, SectionKind::InMotion),
+        vec![Uuid::from_u128(3)]
+    );
+    assert_eq!(
+        section_ids(&filtered, SectionKind::Done),
+        vec![Uuid::from_u128(2)],
+        "the done drawer respects the active thread filter"
+    );
 }
 
 #[test]
-fn unthreaded_tasks_list_after_thread_blocks() {
+fn project_deck_orders_ready_tasks_by_updated_desc_across_threads() {
+    let tasks = vec![
+        threaded_task(
+            1,
+            "alpha older",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            20,
+            "alpha",
+        ),
+        task(3, "loose", HumanStatus::Ready, project(THIS_REPO), 40),
+        threaded_task(
+            2,
+            "alpha newer",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            50,
+            "alpha",
+        ),
+    ];
+
+    let view = query_board(
+        &tasks,
+        &BTreeSet::new(),
+        Some(Path::new(THIS_REPO)),
+        BoardLens::Project(Path::new(THIS_REPO)),
+        false,
+        &ThreadFilter::All,
+    );
+    let deck = on_deck(&view);
+    assert_eq!(
+        deck.task_ids,
+        vec![Uuid::from_u128(2), Uuid::from_u128(3), Uuid::from_u128(1)],
+        "one flat recency order; no thread blocks, no loose lane"
+    );
+}
+
+#[test]
+fn without_a_thread_filter_keeps_only_unthreaded_tasks() {
     let tasks = vec![
         task(
             1,
@@ -411,119 +578,24 @@ fn unthreaded_tasks_list_after_thread_blocks() {
             20,
             "release",
         ),
-        task(3, "loose older", HumanStatus::Ready, project(THIS_REPO), 10),
     ];
 
-    let view = query_lens(
+    let view = query_board(
         &tasks,
+        &BTreeSet::new(),
         Some(Path::new(THIS_REPO)),
         BoardLens::Project(Path::new(THIS_REPO)),
         false,
-    );
-    let deck = on_deck(&view);
-
-    assert_eq!(deck.thread_blocks[0].task_ids, vec![Uuid::from_u128(2)]);
-    assert_eq!(
-        deck.loose_task_ids,
-        vec![Uuid::from_u128(1), Uuid::from_u128(3)]
+        &ThreadFilter::Without,
     );
     assert_eq!(
-        deck.task_ids,
-        vec![Uuid::from_u128(2), Uuid::from_u128(1), Uuid::from_u128(3)]
+        section_ids(&view, SectionKind::OnDeck),
+        vec![Uuid::from_u128(1)]
     );
 }
 
 #[test]
-fn thread_blocks_order_by_recency_and_tasks_within_by_updated_desc() {
-    let tasks = vec![
-        threaded_task(
-            1,
-            "alpha older",
-            HumanStatus::Ready,
-            project(THIS_REPO),
-            20,
-            "alpha",
-        ),
-        threaded_task(
-            2,
-            "alpha newer",
-            HumanStatus::Ready,
-            project(THIS_REPO),
-            50,
-            "alpha",
-        ),
-        threaded_task(
-            3,
-            "beta",
-            HumanStatus::Ready,
-            project(THIS_REPO),
-            40,
-            "beta",
-        ),
-    ];
-
-    let view = query_lens(
-        &tasks,
-        Some(Path::new(THIS_REPO)),
-        BoardLens::Project(Path::new(THIS_REPO)),
-        false,
-    );
-    let deck = on_deck(&view);
-
-    assert_eq!(
-        deck.thread_blocks
-            .iter()
-            .map(|block| block.name.as_str())
-            .collect::<Vec<_>>(),
-        vec!["alpha", "beta"]
-    );
-    assert_eq!(
-        deck.thread_blocks[0].task_ids,
-        vec![Uuid::from_u128(2), Uuid::from_u128(1)]
-    );
-}
-
-#[test]
-fn flat_task_ids_equal_block_then_loose_concatenation() {
-    let tasks = vec![
-        threaded_task(
-            1,
-            "alpha",
-            HumanStatus::Ready,
-            project(THIS_REPO),
-            10,
-            "alpha",
-        ),
-        threaded_task(
-            2,
-            "beta",
-            HumanStatus::Ready,
-            project(THIS_REPO),
-            30,
-            "beta",
-        ),
-        task(3, "loose", HumanStatus::Ready, project(THIS_REPO), 40),
-    ];
-
-    let view = query_lens(
-        &tasks,
-        Some(Path::new(THIS_REPO)),
-        BoardLens::Project(Path::new(THIS_REPO)),
-        false,
-    );
-    let deck = on_deck(&view);
-    let expected: Vec<_> = deck
-        .thread_blocks
-        .iter()
-        .flat_map(|block| block.task_ids.iter().copied())
-        .chain(deck.loose_task_ids.iter().copied())
-        .collect();
-
-    assert_eq!(deck.task_ids, expected);
-}
-
-#[test]
-fn same_thread_name_in_two_scopes_forms_independent_groups() {
+fn same_thread_name_joins_only_in_the_global_view_not_the_local_filter() {
     let tasks = vec![
         threaded_task(
             1,
@@ -543,33 +615,113 @@ fn same_thread_name_in_two_scopes_forms_independent_groups() {
         ),
     ];
 
-    let project_view = query_lens(
+    // Local filter: only the project's own match.
+    let local = query_board(
         &tasks,
+        &BTreeSet::new(),
         Some(Path::new(THIS_REPO)),
         BoardLens::Project(Path::new(THIS_REPO)),
         false,
+        &ThreadFilter::Named("release".to_string()),
     );
-    let global_view = query_lens(&tasks, None, BoardLens::Home(BoardTab::Desk), false);
-    let project_deck = on_deck(&project_view);
-    let global_deck = on_deck(&global_view);
-
     assert_eq!(
-        project_deck.thread_blocks[0].task_ids,
+        section_ids(&local, SectionKind::OnDeck),
         vec![Uuid::from_u128(1)]
     );
+
+    // Global View: both scopes join under one thread name.
+    let view = query_board(
+        &tasks,
+        &BTreeSet::new(),
+        None,
+        BoardLens::ThreadView("release"),
+        false,
+        &ThreadFilter::All,
+    );
     assert_eq!(
-        global_deck.thread_blocks[0].task_ids,
-        vec![Uuid::from_u128(2)]
+        section_ids(&view, SectionKind::OnDeck),
+        vec![Uuid::from_u128(2), Uuid::from_u128(1)]
     );
 }
 
 #[test]
-fn all_scope_in_motion_and_drawer_emit_no_blocks() {
+fn thread_view_covers_needs_you_motion_deck_and_drawer() {
     let tasks = vec![
         threaded_task(
             1,
+            "blocked",
+            HumanStatus::Blocked,
+            project(THIS_REPO),
+            10,
+            "release",
+        ),
+        threaded_task(
+            2,
+            "review",
+            HumanStatus::Review,
+            project(THIS_REPO),
+            15,
+            "release",
+        ),
+        threaded_task(
+            3,
+            "motion",
+            HumanStatus::Started,
+            project(THIS_REPO),
+            20,
+            "release",
+        ),
+        threaded_task(
+            4,
             "deck",
             HumanStatus::Ready,
+            project(THIS_REPO),
+            25,
+            "release",
+        ),
+        threaded_task(
+            5,
+            "done",
+            HumanStatus::Done,
+            project(THIS_REPO),
+            30,
+            "release",
+        ),
+    ];
+
+    let view = query_board(
+        &tasks,
+        &BTreeSet::new(),
+        None,
+        BoardLens::ThreadView("release"),
+        true,
+        &ThreadFilter::All,
+    );
+    assert_eq!(
+        section_ids(&view, SectionKind::NeedsYou),
+        vec![Uuid::from_u128(2), Uuid::from_u128(1)]
+    );
+    assert_eq!(
+        section_ids(&view, SectionKind::InMotion),
+        vec![Uuid::from_u128(3)]
+    );
+    assert_eq!(
+        section_ids(&view, SectionKind::OnDeck),
+        vec![Uuid::from_u128(4)]
+    );
+    assert_eq!(
+        section_ids(&view, SectionKind::Done),
+        vec![Uuid::from_u128(5)]
+    );
+}
+
+#[test]
+fn projects_index_rows_carry_open_work_counts() {
+    let tasks = vec![
+        threaded_task(
+            1,
+            "blocked",
+            HumanStatus::Blocked,
             project(THIS_REPO),
             10,
             "release",
@@ -584,6 +736,14 @@ fn all_scope_in_motion_and_drawer_emit_no_blocks() {
         ),
         threaded_task(
             3,
+            "deck",
+            HumanStatus::Ready,
+            project(THIS_REPO),
+            25,
+            "release",
+        ),
+        threaded_task(
+            4,
             "done",
             HumanStatus::Done,
             project(THIS_REPO),
@@ -592,32 +752,26 @@ fn all_scope_in_motion_and_drawer_emit_no_blocks() {
         ),
     ];
 
-    let home_projects = query_lens(
+    let view = query_board(
         &tasks,
+        &BTreeSet::new(),
         Some(Path::new(THIS_REPO)),
-        BoardLens::Home(BoardTab::Projects),
-        true,
+        BoardLens::Projects,
+        false,
+        &ThreadFilter::All,
     );
-    assert!(home_projects
-        .sections
-        .iter()
-        .all(|section| section.thread_blocks.is_empty() && section.loose_task_ids.is_empty()));
-
-    let scoped = query_lens(
-        &tasks,
-        Some(Path::new(THIS_REPO)),
-        BoardLens::Project(Path::new(THIS_REPO)),
-        true,
-    );
-    assert!(scoped
-        .sections
-        .iter()
-        .filter(|section| section.kind != SectionKind::OnDeck)
-        .all(|section| section.thread_blocks.is_empty() && section.loose_task_ids.is_empty()));
+    assert_eq!(view.sections, Vec::new(), "the index never lists tasks");
+    assert_eq!(view.projects.len(), 1);
+    let row = &view.projects[0];
+    assert_eq!(row.path, THIS_REPO);
+    assert_eq!(row.needs_you, 1);
+    assert_eq!(row.in_motion, 1);
+    assert_eq!(row.ready, 1, "done tasks stay out of the counts");
+    assert!(row.current, "the invocation project is marked current");
 }
 
 #[test]
-fn selection_stays_on_task_id_across_thread_block_reorder() {
+fn selection_stays_on_task_id_across_deck_reorder() {
     let mut domain = DomainState::new();
     let alpha = domain
         .create(
@@ -638,20 +792,9 @@ fn selection_stays_on_task_id_across_thread_block_reorder() {
         )
         .unwrap();
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
-    model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
 
     let before = model.queue_view();
-    let before_deck = on_deck(&before);
-    assert_eq!(before_deck.thread_blocks.len(), 2);
-    assert_eq!(
-        before_deck
-            .thread_blocks
-            .iter()
-            .map(|block| block.name.as_str())
-            .collect::<Vec<_>>(),
-        vec!["beta", "alpha"]
-    );
-    assert_eq!(before_deck.task_ids, vec![beta, alpha]);
+    assert_eq!(on_deck(&before).task_ids, vec![beta, alpha]);
 
     let beta_index = model
         .visible_ids()
@@ -678,21 +821,14 @@ fn selection_stays_on_task_id_across_thread_block_reorder() {
     model.sync_from_domain(&domain);
 
     let after = model.queue_view();
-    let after_deck = on_deck(&after);
-    assert_eq!(after_deck.thread_blocks.len(), 2);
-    assert_eq!(
-        after_deck
-            .thread_blocks
-            .iter()
-            .map(|block| block.name.as_str())
-            .collect::<Vec<_>>(),
-        vec!["alpha", "beta"]
-    );
-    assert_eq!(after_deck.task_ids, vec![alpha, beta]);
+    assert_eq!(on_deck(&after).task_ids, vec![alpha, beta]);
     assert_eq!(model.selected_id(), Some(beta));
-    assert_eq!(model.visible_ids(), after_deck.task_ids);
+    assert_eq!(model.visible_ids(), on_deck(&after).task_ids);
     assert_eq!(model.selected_index(), Some(1));
-    assert_eq!(after_deck.task_ids[model.selected_index().unwrap()], beta);
+    assert_eq!(
+        on_deck(&after).task_ids[model.selected_index().unwrap()],
+        beta
+    );
 }
 
 /// Two fresh models from the same store share no UI state and write no UI-state files.
@@ -716,49 +852,50 @@ fn board_rows(model: &BoardModel, width: u16, height: u16) -> Vec<String> {
 #[test]
 fn arrow_navigation_crosses_painted_header_task_to_task() {
     let mut domain = DomainState::new();
-    domain
+    let review = domain
         .create(
-            "alpha task",
+            "review task",
             None,
             project(THIS_REPO),
             ProvenanceOrigin::Manual,
-            Some("alpha".to_string()),
+            None,
         )
-        .expect("create alpha");
+        .expect("create review");
     domain
+        .set_status(review, HumanStatus::Review)
+        .expect("review");
+    let ready = domain
         .create(
-            "beta task",
+            "ready task",
             None,
             project(THIS_REPO),
             ProvenanceOrigin::Manual,
-            Some("beta".to_string()),
+            None,
         )
-        .expect("create beta");
+        .expect("create ready");
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
     model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
     let ids = model.visible_ids();
-    assert_eq!(ids.len(), 2, "two threaded tasks are visible");
+    assert_eq!(ids, vec![review, ready], "needs-you first, then on deck");
     apply_intent(&mut domain, &mut model, BoardIntent::SelectIndex(0), None)
         .expect("select first task");
 
     let rows = board_rows(&model, 80, 24);
-    let first_title = domain.get(ids[0]).expect("first task").title.clone();
-    let second = domain.get(ids[1]).expect("second task");
     let first_y = rows
         .iter()
-        .position(|row| row.contains(&first_title))
+        .position(|row| row.contains("review task"))
         .expect("first task paints");
     let header_y = rows
         .iter()
-        .position(|row| row.contains(&format!("#{}", second.thread.as_deref().unwrap())))
-        .expect("second block header paints");
+        .position(|row| row.contains("NEEDS YOU"))
+        .expect("the NEEDS YOU header paints");
     let second_y = rows
         .iter()
-        .position(|row| row.contains(&second.title))
+        .position(|row| row.contains("ready task"))
         .expect("second task paints");
     assert!(
-        first_y < header_y && header_y < second_y,
-        "a painted header must physically sit between the tasks:\n{}",
+        header_y < first_y && first_y < second_y,
+        "a painted header must physically sit above its tasks:\n{}",
         rows.join("\n")
     );
 
@@ -766,7 +903,7 @@ fn arrow_navigation_crosses_painted_header_task_to_task() {
         .expect("arrow navigation moves to next task");
     assert_eq!(
         model.selected_id(),
-        Some(ids[1]),
+        Some(ready),
         "selection must skip decorative headers and land on the next task"
     );
 }
@@ -823,13 +960,13 @@ fn two_fresh_models_from_same_store_share_no_ui_state_and_no_ui_writes_under_sta
     );
     assert_eq!(
         b_fresh.selected_project(),
-        None,
-        "fresh model starts with the all-projects deck scope"
+        Some(Path::new(THIS_REPO)),
+        "fresh model starts on the invocation project's board"
     );
     assert_eq!(
         b_fresh.visible_ids(),
         vec![id],
-        "fresh model starts with the all-projects deck scope"
+        "the startup board renders that project's rows"
     );
 
     let after_state = list_files_recursive(&state_dir);

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -218,8 +218,8 @@ fn hit_map_covers_selection_rows_verbs_drawer_selector_chip_dropdown_palette_row
     assert!(
         hits.regions
             .iter()
-            .any(|hit| matches!(hit.target, QueueHitTarget::ProjectChip)),
-        "no selector chip hit region: {hits:?}"
+            .any(|hit| matches!(hit.target, QueueHitTarget::NavTab(_))),
+        "no navigation tab hit region: {hits:?}"
     );
 
     // Drawer: only painted while the done drawer is open.
@@ -281,54 +281,46 @@ fn hit_map_covers_selection_rows_verbs_drawer_selector_chip_dropdown_palette_row
 }
 
 #[test]
-fn projects_tab_group_header_double_click_scopes_the_board_to_that_project() {
+fn projects_index_row_click_selects_and_opens_the_project() {
     let (mut domain, mut model, _id) = scoped_board();
-    assert_eq!(model.selected_project(), None, "fixture starts at home");
     apply_intent(
         &mut domain,
         &mut model,
-        BoardIntent::SelectHomeTab(tsk_tui::ui::board::BoardTab::Projects),
+        BoardIntent::SelectNavTab(tsk_tui::ui::queue::NavTab::Desk),
         None,
     )
-    .expect("open projects tab");
+    .expect("start from the desk");
+    assert_eq!(
+        model.selected_project(),
+        Some(Path::new("/repos/app")),
+        "slot 2 retains its project while Desk is active"
+    );
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectNavTab(tsk_tui::ui::queue::NavTab::Projects),
+        None,
+    )
+    .expect("open projects index");
     let hits = board_hit_map(STANDARD, &model);
     let view = model.queue_view();
-    let header = hits
+    let row = hits
         .regions
         .iter()
         .find(|hit| match hit.target {
-            QueueHitTarget::SectionProject(index) => {
-                view.sections
-                    .get(index)
-                    .and_then(|section| section.project_label.as_deref())
-                    == Some(OTHER_REPO)
-            }
+            QueueHitTarget::ProjectRow(index) => view
+                .projects
+                .get(index)
+                .is_some_and(|row| row.path == OTHER_REPO),
             _ => false,
         })
-        .unwrap_or_else(|| panic!("no group header hit region for {OTHER_REPO}: {hits:?}"));
-    let intent = click(header, &model, &hits).expect("header click maps to an intent");
-    apply_intent(&mut domain, &mut model, intent.clone(), None).expect("apply first header click");
-    assert_eq!(
-        model.selected_project(),
-        None,
-        "one header click collapses the group but stays at home"
-    );
-    apply_intent(&mut domain, &mut model, intent, None).expect("apply second header click");
+        .unwrap_or_else(|| panic!("no index row hit region for {OTHER_REPO}: {hits:?}"));
+    let intent = click(row, &model, &hits).expect("row click maps to an intent");
+    apply_intent(&mut domain, &mut model, intent, None).expect("apply row click");
     assert_eq!(
         model.selected_project(),
         Some(Path::new(OTHER_REPO)),
-        "header double-click narrows the session deck scope to the clicked project"
-    );
-
-    // Scoped to one project the header reads plain ON DECK, so it stops being a scope
-    // control: no SectionProject target may be pushed at all.
-    let hits = board_hit_map(STANDARD, &model);
-    assert!(
-        !hits
-            .regions
-            .iter()
-            .any(|hit| matches!(hit.target, QueueHitTarget::SectionProject(_))),
-        "scoped view must not offer group-header scope controls: {hits:?}"
+        "a direct index-row click opens that project in slot 2"
     );
 }
 
@@ -353,8 +345,8 @@ fn scoped_project_named_all_projects_has_no_group_header_hit_target() {
         !hits
             .regions
             .iter()
-            .any(|hit| matches!(hit.target, QueueHitTarget::SectionProject(_))),
-        "actual scoped state, not its colliding display label, must keep ON DECK inert: {hits:?}"
+            .any(|hit| matches!(hit.target, QueueHitTarget::ProjectRow(_))),
+        "project focus is a task board: it must offer no index rows at all: {hits:?}"
     );
 }
 
@@ -687,13 +679,22 @@ fn click_and_wheel_match_keyboard_effects_for_each_control() {
     )
     .expect("direct open");
     let hits = board_hit_map(STANDARD, &model_mouse);
-    let chip_hit = hits
+    let tab_hit = hits
         .regions
         .iter()
-        .find(|hit| matches!(hit.target, QueueHitTarget::ProjectChip))
-        .expect("selector chip hit region");
-    let mouse_intent = click(chip_hit, &model_mouse, &hits).expect("chip click intent");
-    assert_eq!(mouse_intent, BoardIntent::OpenProjectSelector);
+        .find(|hit| {
+            matches!(
+                hit.target,
+                QueueHitTarget::NavTab(tsk_tui::ui::queue::NavTab::ProjectBoard)
+            )
+        })
+        .expect("slot-2 tab hit region");
+    let mouse_intent = click(tab_hit, &model_mouse, &hits).expect("tab click intent");
+    assert_eq!(
+        mouse_intent,
+        BoardIntent::SelectNavTab(tsk_tui::ui::queue::NavTab::ProjectBoard),
+        "slot 2's click routes through the tab intent; the reducer opens the picker"
+    );
     apply_intent(&mut domain_mouse, &mut model_mouse, mouse_intent, None).expect("mouse open");
     assert_eq!(
         model_direct.project_picker_index(),
@@ -724,7 +725,13 @@ fn click_and_wheel_match_keyboard_effects_for_each_control() {
     );
     let next_key = map_key(BoardInputMode::ProjectPicker, press(KeyCode::Down))
         .expect("project picker down key");
-    for _ in 0..target_index {
+    // The picker opens highlighting the current destination; step from there.
+    let start = model_key
+        .project_picker_index()
+        .expect("highlighted option");
+    let options_len = model_key.project_options().len();
+    let steps = (target_index + options_len - start) % options_len;
+    for _ in 0..steps {
         apply_intent(&mut domain_key, &mut model_key, next_key.clone(), None)
             .expect("step to option");
     }
@@ -918,6 +925,19 @@ fn a_dropdown_option_over_a_task_row_still_selects_that_option_not_the_task_unde
             None,
         )
         .expect("create third project for a longer selector");
+    // The project board lists only its own rows; fill it deep enough that the picker's
+    // later options sit over real task rows.
+    for i in 0..12 {
+        domain
+            .create(
+                format!("filler {i}"),
+                None,
+                project(THIS_REPO),
+                ProvenanceOrigin::Manual,
+                None,
+            )
+            .expect("create filler rows");
+    }
     model.sync_from_domain(&domain);
     apply_intent(
         &mut domain,
@@ -1201,9 +1221,9 @@ fn wheel_scrolls_the_open_command_surface_so_every_command_becomes_reachable() {
     let commands = model.visible_commands();
     assert_eq!(
         commands.len(),
-        13,
-        "this ready fixture must expose all 13 M1 palette commands (reopen needs a done \
-         selection, AC-17): {commands:?}"
+        12,
+        "this ready fixture must expose every palette command a ready selection has \
+         (reopen joins only for a done selection, AC-17): {commands:?}"
     );
     let last = commands.len() - 1;
     assert_eq!(commands[last].label, "quit");
@@ -1413,7 +1433,7 @@ fn non_left_clicks_over_a_live_control_are_ignored() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn header_line_registers_no_hit_target() {
+fn section_header_rows_register_no_hit_target_and_thread_labels_stay_in_task_rows() {
     let mut domain = DomainState::new();
     domain
         .create(
@@ -1427,20 +1447,32 @@ fn header_line_registers_no_hit_target() {
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
     model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
     let rows = page_rows(&model);
+    // The thread label is part of the task row's meta now, not a header of its own.
+    let task_row = rows
+        .iter()
+        .position(|row| row.contains("threaded row") && row.contains("#release"))
+        .expect("thread label paints beside its task row");
     let header_y = rows
         .iter()
-        .position(|row| row.contains("#release"))
-        .expect("thread header paints");
+        .position(|row| row.contains("ON DECK"))
+        .expect("the ON DECK header paints");
     let hits = board_hit_map(STANDARD, &model);
 
     assert!(
         hits.regions.iter().all(|hit| hit.area.y != header_y as u16),
-        "decorative thread header must register no hit target: {hits:?}"
+        "section header rows must register no hit target: {hits:?}"
     );
     assert_eq!(
         map_board_mouse(&model, &hits, left_click(0, header_y as u16)),
         None,
         "clicking the decorative header must be inert"
+    );
+    assert!(
+        hits.regions
+            .iter()
+            .any(|hit| matches!(hit.target, QueueHitTarget::Task(_))
+                && hit.area.y == task_row as u16),
+        "the row carrying the thread label is the task row itself"
     );
 }
 
@@ -1489,7 +1521,8 @@ fn task_identifier_click_copies_without_falling_through_to_row_or_page_actions()
     let (domain, _model, id) = board_with_task("Copy this identifier", HumanStatus::Ready);
     let mut task = domain.get(id).expect("task").clone();
     task.number = Some(30);
-    let model = BoardModel::from_tasks(vec![task], Some(PathBuf::from(THIS_REPO)));
+    let mut model = BoardModel::from_tasks(vec![task], Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
 
     let hits = board_hit_map(STANDARD, &model);
     let identifier = hits
@@ -1515,6 +1548,7 @@ fn quick_add_identifier_click_copies_without_discarding_the_draft() {
     let mut task = domain.get(id).expect("task").clone();
     task.number = Some(30);
     let mut model = BoardModel::from_tasks(vec![task], Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
     apply_intent(&mut domain, &mut model, BoardIntent::OpenCapture, None).expect("open draft");
 
     let hits = board_hit_map(STANDARD, &model);
@@ -1566,6 +1600,7 @@ fn task_page_identifier_click_copies_instead_of_hitting_the_title_region() {
     let mut task = domain.get(id).expect("task").clone();
     task.number = Some(31);
     let mut model = BoardModel::from_tasks(vec![task], Some(PathBuf::from(THIS_REPO)));
+    model.set_selected_project(Some(PathBuf::from(THIS_REPO)));
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open page");
     assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
 
@@ -1795,7 +1830,7 @@ fn page_step_add_footer_chip_routes_to_begin_add_step() {
     let (mut domain, mut model) = deck_of(1);
     let id = model.selected_id().expect("task");
     domain.add_step(id, "existing step").expect("add step");
-    model = BoardModel::from_domain(&domain, None);
+    model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open");
     apply_intent(&mut domain, &mut model, BoardIntent::BeginEditTitle, None)
         .expect("enter task edit mode");
@@ -1882,7 +1917,7 @@ fn step_editor_verb_chips_follow_their_keyboard_intents() {
     let (mut domain, mut model) = deck_of(1);
     let id = model.selected_id().expect("task");
     domain.add_step(id, "existing step").expect("add step");
-    model = BoardModel::from_domain(&domain, None);
+    model = BoardModel::from_domain(&domain, Some(PathBuf::from(THIS_REPO)));
     apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("open");
     apply_intent(&mut domain, &mut model, BoardIntent::BeginEditTitle, None)
         .expect("enter edit session");

--- a/tests/queue_board_render.rs
+++ b/tests/queue_board_render.rs
@@ -1,6 +1,5 @@
 //! Queue Board Renderer frame goldens.
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
@@ -14,10 +13,10 @@ use tsk_tui::domain::{
     DomainState, HumanStatus, ProvenanceOrigin, Task, TaskEvent, TaskEventKind, TaskScope,
 };
 use tsk_tui::ui::input::map_key;
-use tsk_tui::ui::queue::{self, BoardLens, BoardTab, QueueView, ThreadProjectCollapseKey};
+use tsk_tui::ui::queue::{self, BoardLens, NavTab, QueueView, ThreadFilter};
 use tsk_tui::ui::render::{
-    assert_buffer_mono, assert_no_color_sgr, draw_queue_frame, BottomInputSlot, PaletteCommandRow,
-    QueueFrameModel, QueueOverlay, VerbEntry,
+    assert_buffer_mono, assert_no_color_sgr, draw_queue_frame, BottomInputSlot, NavChipPaint,
+    NavPaint, PaletteCommandRow, QueueFrameModel, QueueOverlay, VerbEntry,
 };
 use tsk_tui::ui::tier::{self, Tier, TierGeometry};
 use tsk_tui::ui::{
@@ -146,13 +145,22 @@ fn fixture_tasks() -> Vec<Task> {
 /// task 1 ("Smoke-test worktree dispatch", Doing) [`fixture_model`] hardcodes as its
 /// selection.
 fn base_board_model() -> BoardModel {
-    let model = BoardModel::from_tasks(fixture_tasks(), Some(PathBuf::from("/repos/tsk")));
-    assert_eq!(
-        model.selected_id(),
-        Some(Uuid::from_u128(1)),
-        "base_board_model's auto-selection drifted from the render fixture's hardcoded \
-         selection -- keep them in sync or `fixture_verbs` binds the wrong row's legend"
-    );
+    let mut model = BoardModel::from_tasks(fixture_tasks(), Some(PathBuf::from("/repos/tsk")));
+    // The desk's NEEDS YOU lane is global now, so seeding no longer lands on task 1
+    // (the started /repos/tsk row): the render fixtures pin task 1's legend explicitly.
+    let pinned_index = model
+        .visible_ids()
+        .iter()
+        .position(|&id| id == Uuid::from_u128(1))
+        .expect("fixture task 1 must be visible for the pinned selection");
+    apply_intent(
+        &mut DomainState::new(),
+        &mut model,
+        BoardIntent::SelectIndex(pinned_index),
+        None,
+    )
+    .expect("pin task 1");
+    assert_eq!(model.selected_id(), Some(Uuid::from_u128(1)));
     model
 }
 
@@ -174,13 +182,7 @@ fn fixture_verbs() -> &'static [VerbEntry<'static>] {
 fn todo_verbs() -> Vec<VerbEntry<'static>> {
     let mut model = base_board_model();
     let mut domain = DomainState::new();
-    apply_intent(
-        &mut domain,
-        &mut model,
-        BoardIntent::SelectHomeTab(BoardTab::Projects),
-        None,
-    )
-    .expect("projects tab for fixture todo task");
+    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
     let target = Uuid::from_u128(10);
     let visible = model.visible_ids();
     for _ in 0..visible.len() {
@@ -282,58 +284,58 @@ fn palette_commands() -> Vec<PaletteCommandRow<'static>> {
         .collect()
 }
 
-fn empty_projects() -> &'static HashSet<String> {
-    static SET: OnceLock<HashSet<String>> = OnceLock::new();
-    SET.get_or_init(HashSet::new)
-}
-
-fn empty_threads() -> &'static HashSet<String> {
-    static SET: OnceLock<HashSet<String>> = OnceLock::new();
-    SET.get_or_init(HashSet::new)
-}
-
-fn empty_thread_projects() -> &'static HashSet<ThreadProjectCollapseKey> {
-    static SET: OnceLock<HashSet<ThreadProjectCollapseKey>> = OnceLock::new();
-    SET.get_or_init(HashSet::new)
-}
-
 fn fixture_view(tasks: &[Task], drawer_open: bool) -> QueueView {
-    queue::query_lens(
+    queue::query_board(
         tasks,
+        &std::collections::BTreeSet::new(),
         Some(Path::new("/repos/tsk")),
-        BoardLens::Home(BoardTab::Desk),
+        BoardLens::Desk,
         drawer_open,
+        &ThreadFilter::All,
     )
 }
 
 fn fixture_view_projects(tasks: &[Task], drawer_open: bool) -> QueueView {
-    queue::query_lens(
+    queue::query_board(
         tasks,
+        &std::collections::BTreeSet::new(),
         Some(Path::new("/repos/tsk")),
-        BoardLens::Home(BoardTab::Projects),
+        BoardLens::Project(Path::new("/repos/tsk")),
         drawer_open,
+        &ThreadFilter::All,
     )
 }
 
 fn fixture_model<'a>(tasks: &'a [Task], view: &'a QueueView) -> QueueFrameModel<'a> {
-    fixture_model_on_tab(tasks, view, BoardTab::Desk)
+    fixture_model_on_tab(tasks, view, NavTab::Desk)
 }
 
 fn fixture_model_on_tab<'a>(
     tasks: &'a [Task],
     view: &'a QueueView,
-    home_tab: BoardTab,
+    active: NavTab,
 ) -> QueueFrameModel<'a> {
     QueueFrameModel {
         tasks,
         view,
         selection_id: Some(Uuid::from_u128(1)),
-        at_home: true,
-        home_tab,
-        scope_label: "",
-        collapsed_projects: empty_projects(),
-        collapsed_threads: empty_threads(),
-        collapsed_thread_projects: empty_thread_projects(),
+        nav: NavPaint {
+            active,
+            slot2_label: "tsk".to_string(),
+            slot2_project: true,
+            chip: Some(NavChipPaint {
+                label: "all".to_string(),
+                kind: tsk_tui::ui::render::NavChipKind::ThreadFilter,
+            }),
+        },
+        surface: tsk_tui::ui::render::BoardSurface::Desk,
+        thread_labels: false,
+        show_project_meta: true,
+        projects: &[],
+        projects_index: false,
+        projects_cursor: 0,
+        projects_query: "",
+        summary: None,
         status_message: None,
         status_undo_offset: None,
         verb_items: fixture_verbs(),
@@ -416,17 +418,124 @@ fn inactive_home_tabs_are_dimmed() {
             (y, row)
         })
         .find(|(_, row)| {
-            row.contains("desk") && row.contains("projects") && row.contains("threads")
+            row.contains("desk") && row.contains("projects") && !row.contains("1 desk")
         })
-        .expect("tab row");
-    for label in ["projects", "threads"] {
-        let x = row.find(label).expect("tab label") as u16;
+        .expect("tab row without visible shortcut digits");
+    let label = "projects";
+    let x = row.find(label).expect("tab label") as u16;
+    assert!(
+        buffer[(x, tab_y)]
+            .style()
+            .add_modifier
+            .contains(Modifier::DIM),
+        "inactive {label} tab must be dimmed"
+    );
+}
+
+#[test]
+fn project_rows_show_full_thread_metadata_without_relative_age() {
+    let mut tasks = fixture_tasks();
+    tasks[0].thread = Some("a".repeat(32));
+    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
+    model.apply_reopen_project(Some(PathBuf::from("/repos/tsk")));
+    let rows = board_rows(&model, 80, 24);
+    let joined = rows.join("\n");
+    assert!(
+        joined.contains("#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        "full thread attribution missing: {joined}"
+    );
+    assert!(
+        !joined.contains("ago"),
+        "task rows must not paint relative ages: {joined}"
+    );
+}
+
+#[test]
+fn full_thread_selector_and_dropdown_values_are_not_capped_to_the_old_prefix_budget() {
+    let tasks = fixture_tasks();
+    let view = fixture_view_projects(&tasks, false);
+    let thread = "a".repeat(32);
+    for (width, height) in [(40, 10), (40, 24), (78, 24), (110, 24), (162, 24)] {
+        let mut model = fixture_model_on_tab(&tasks, &view, NavTab::ProjectBoard);
+        model.nav.chip = Some(NavChipPaint {
+            label: format!("#{thread}"),
+            kind: tsk_tui::ui::render::NavChipKind::ThreadFilter,
+        });
+        let body_rows = paint(width, height, &model).0;
+        if width == 40 {
+            let tabs_y = body_rows
+                .iter()
+                .position(|row| row.contains("desk"))
+                .expect("tabs");
+            let thread_y = body_rows
+                .iter()
+                .position(|row| row.contains(&format!("#{thread}")))
+                .expect("thread selector");
+            assert_eq!(
+                thread_y,
+                tabs_y + 2,
+                "wrapped selector needs one blank row above it"
+            );
+            assert!(body_rows[tabs_y + 1].trim().is_empty());
+        }
+        let body = body_rows.join("\n");
         assert!(
-            buffer[(x, tab_y)]
-                .style()
-                .add_modifier
-                .contains(Modifier::DIM),
-            "inactive {label} tab must be dimmed"
+            body.contains(&format!("#{thread}")),
+            "active selector clipped at {width} columns:\n{body}"
+        );
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+        let mut hits = None;
+        terminal
+            .draw(|frame| {
+                hits = Some(
+                    draw_queue_frame(
+                        frame,
+                        &model,
+                        &tier::resolve(width, height),
+                        Rect::new(0, 0, width, height),
+                    )
+                    .0,
+                );
+            })
+            .expect("draw selector hit map");
+        let chip_hit = hits
+            .expect("hit map")
+            .regions
+            .into_iter()
+            .find(|hit| hit.target == tsk_tui::ui::render::QueueHitTarget::NavChip)
+            .expect("active selector hit");
+        assert!(
+            chip_hit.area.width >= 33,
+            "active selector hit must cover the full valid thread at {width}: {:?}",
+            chip_hit.area
+        );
+        if width == 40 {
+            assert_eq!(
+                chip_hit.area.y,
+                tier::resolve(width, height).selector_row.expect("tabs") + 2,
+                "mouse target must follow the spaced selector"
+            );
+        }
+
+        let options = vec![
+            "All tasks".to_string(),
+            format!("#{thread}  1"),
+            "Without a thread".to_string(),
+        ];
+        // Do not let the already-tested selector behind the popup satisfy this
+        // assertion: the option inside the popup must paint the whole name itself.
+        model.nav.chip = None;
+        model.overlay = QueueOverlay::ScopeDropdown {
+            options: &options,
+            selected: 1,
+            tabs: None,
+            title: Some("thread"),
+            query: None,
+        };
+        let dropdown = paint(width, height, &model).0.join("\n");
+        assert!(
+            dropdown.contains(&format!("#{thread}")),
+            "dropdown clipped the full thread at {width} columns:\n{dropdown}"
         );
     }
 }
@@ -491,8 +600,8 @@ fn standard_78x24_fixture_has_selector_list_rule_status_verb_and_no_other_chrome
     assert_eq!(geo.verb_row, Some(23));
     assert_eq!(geo.viewport_top, 2);
     assert_eq!(geo.viewport_height, 19);
-    assert_eq!(geo.meta_column_width, 28);
-    assert_eq!(geo.title_width, 50);
+    assert_eq!(geo.meta_column_width, 36);
+    assert_eq!(geo.title_width, 42);
 
     assert!(trimmed(&rows[0]).is_empty(), "row above tabs stays blank");
 
@@ -502,12 +611,16 @@ fn standard_78x24_fixture_has_selector_list_rule_status_verb_and_no_other_chrome
         "selector must not paint a view switcher: {selector:?}"
     );
     assert!(
-        selector.contains("desk") && selector.contains("projects") && selector.contains("threads"),
-        "selector must show home tabs: {selector:?}"
+        selector.contains("desk")
+            && selector.contains("projects")
+            && !selector.contains("1 desk")
+            && !selector.contains("2 tsk")
+            && !selector.contains("3 projects"),
+        "selector must show the persistent tabs without shortcut digits: {selector:?}"
     );
     assert!(
-        !selector.contains('▾'),
-        "home tabs do not paint the project chip: {selector:?}"
+        selector.contains("tsk"),
+        "slot 2 names the selected project: {selector:?}"
     );
 
     let list: String = rows
@@ -522,7 +635,7 @@ fn standard_78x24_fixture_has_selector_list_rule_status_verb_and_no_other_chrome
     );
     assert!(
         list.lines()
-            .any(|line| line.trim_start().starts_with("desk ─")),
+            .any(|line| line.trim_start().starts_with("ON DECK · desk ─")),
         "desk tab must include the desk ON DECK header:\n{list}"
     );
     assert!(
@@ -533,14 +646,26 @@ fn standard_78x24_fixture_has_selector_list_rule_status_verb_and_no_other_chrome
         list.contains("Smoke-test worktree dispatch"),
         "task titles must appear:\n{list}"
     );
-    // Standard trailing meta includes ages (fixture ages are known).
+    // Standard trailing meta keeps scope/thread identity without relative ages.
     assert!(
-        list.contains("3m") || list.contains("1h") || list.contains("1d"),
-        "standard tier must paint age meta:\n{list}"
+        list.contains("herdr") && list.contains("tsk") && list.contains("desk"),
+        "standard tier must paint task attribution:\n{list}"
     );
     assert!(
-        !list.contains("need you") && !list.contains("NEEDS YOU"),
-        "default desk fixture has no global blocked/review, so no NEEDS YOU:\n{list}"
+        !list.contains("ago"),
+        "task rows must not paint relative ages:\n{list}"
+    );
+    // NEEDS YOU is the desk's global attention lane: the fixture's blocked/review
+    // rows from /repos/herdr paint here with project attribution.
+    assert!(
+        list.contains("NEEDS YOU")
+            && list.contains("Wire dispatch cleanup receipts")
+            && list.contains("herdr"),
+        "desk NEEDS YOU must gather blocked/review from every live scope:\n{list}"
+    );
+    assert!(
+        list.contains("Docs refresh pass after F9 ships"),
+        "review rows join blocked rows in the global lane:\n{list}"
     );
     assert!(
         !list.contains("claude") && !list.contains("grok") && !list.contains("agent"),
@@ -741,11 +866,16 @@ fn every_section_header_has_symmetric_spacing_and_scrolls_with_its_selected_task
     let projects_view = fixture_view_projects(&tasks, true);
     let desk_cases = [
         (
+            "NEEDS YOU",
+            Uuid::from_u128(20),
+            "Wire dispatch cleanup receipts",
+        ),
+        (
             "IN MOTION",
             Uuid::from_u128(1),
             "Smoke-test worktree dispatch",
         ),
-        ("desk", Uuid::from_u128(30), "Global backlog note"),
+        ("ON DECK · desk", Uuid::from_u128(30), "Global backlog note"),
         (
             "DONE",
             Uuid::from_u128(40),
@@ -753,8 +883,16 @@ fn every_section_header_has_symmetric_spacing_and_scrolls_with_its_selected_task
         ),
     ];
     let project_cases = [
-        ("tsk", Uuid::from_u128(1), "Smoke-test worktree dispatch"),
-        ("herdr", Uuid::from_u128(2), "Edit target binding pin"),
+        (
+            "IN MOTION",
+            Uuid::from_u128(1),
+            "Smoke-test worktree dispatch",
+        ),
+        (
+            "ON DECK",
+            Uuid::from_u128(10),
+            "Prototype the queue-style board UI",
+        ),
     ];
 
     for &(width, height) in &[(78u16, 24u16), (77u16, 24u16), (40u16, 10u16)] {
@@ -779,7 +917,12 @@ fn every_section_header_has_symmetric_spacing_and_scrolls_with_its_selected_task
             assert_visible_chrome(&rows, geo, &dimensions);
         }
         for &(header, selected_id, selected_title) in &project_cases {
-            let mut model = fixture_model_on_tab(&tasks, &projects_view, BoardTab::Projects);
+            if width == 40 && header == "ON DECK" {
+                // The fixture's long project titles wrap at 40 columns, which is the
+                // compact wrap test's own subject, not header spacing.
+                continue;
+            }
+            let mut model = fixture_model_on_tab(&tasks, &projects_view, NavTab::ProjectBoard);
             model.selection_id = Some(selected_id);
             let (rows, geo) = paint(width, height, &model);
             assert_exact_header_spacing(&rows, geo, header, selected_title, &dimensions);
@@ -834,7 +977,7 @@ fn quick_add_refusal_message_uses_the_reserved_blank_row_without_color_or_overfl
                 above_rows: Vec::new(),
                 cursor_row_offset: 0,
             },
-            project_scope: false,
+            destination: "desk".to_string(),
             recovery: false,
         };
         let (rows, geo) = paint(width, height, &model);
@@ -955,6 +1098,8 @@ fn overlay_rows_are_padded_exact_no_base_bleed() {
             options: &scope_opts,
             selected: 0,
             tabs: None,
+            title: None,
+            query: None,
         };
         let (rows, _geo) = paint(80, 24, &model);
         let desk_row = rows
@@ -1096,7 +1241,7 @@ fn board_row_leads_title_with_uppercase_t_identifier() {
 }
 
 #[test]
-fn standard_row_meta_keeps_age_when_long_project_competes() {
+fn standard_row_meta_keeps_full_project_without_relative_age() {
     let mut tasks = fixture_tasks();
     tasks[0].number = Some(7);
     tasks[0].scope = project("/src/customer-portal-api");
@@ -1110,8 +1255,12 @@ fn standard_row_meta_keeps_age_when_long_project_competes() {
         .expect("started fixture row");
     assert!(row.contains('7'), "number must remain visible:\n{row}");
     assert!(
-        row.contains("12m"),
-        "age must remain visible when a long project shares the meta column:\n{row}"
+        row.contains("customer-portal-api"),
+        "full project attribution must remain visible:\n{row}"
+    );
+    assert!(
+        !row.contains("12m"),
+        "task rows must not paint relative ages:\n{row}"
     );
 }
 
@@ -2287,7 +2436,7 @@ fn standard_accordion_on_a_task_below_the_fold_scrolls_the_whole_block_into_view
     }
     let last_id = Uuid::from_u128(2000 + 29);
     let view = fixture_view_projects(&tasks, false);
-    let mut model = fixture_model_on_tab(&tasks, &view, BoardTab::Projects);
+    let mut model = fixture_model_on_tab(&tasks, &view, NavTab::ProjectBoard);
     model.detail_open = Some(last_id);
 
     let (rows, geo) = paint(80, 24, &model);
@@ -2330,7 +2479,7 @@ fn plain_selection_on_a_task_below_the_fold_scrolls_it_into_view_in_both_tiers()
         .collect();
     let last_id = Uuid::from_u128(5000 + 39);
     let view = fixture_view_projects(&tasks, false);
-    let mut model = fixture_model_on_tab(&tasks, &view, BoardTab::Projects);
+    let mut model = fixture_model_on_tab(&tasks, &view, NavTab::ProjectBoard);
     model.selection_id = Some(last_id);
 
     for &(width, height) in &[(80u16, 24u16), (77u16, 24u16), (40u16, 10u16)] {
@@ -2468,8 +2617,13 @@ fn compact_paints_no_takeover_for_a_detail_open_task_excluded_by_the_current_sco
     );
     let model = QueueFrameModel {
         detail_open: Some(excluded_id),
-        at_home: false,
-        scope_label: "tsk",
+        surface: tsk_tui::ui::render::BoardSurface::Project,
+        nav: NavPaint {
+            active: NavTab::ProjectBoard,
+            slot2_label: "tsk".to_string(),
+            slot2_project: true,
+            chip: None,
+        },
         ..fixture_model(&tasks, &scoped_view)
     };
 
@@ -2777,33 +2931,10 @@ fn footer_lists_the_step_add_verb() {
     );
 }
 
-/// T-4: scoped ON DECK thread blocks paint one dim decorative header before their task rows.
+/// Thread labels are row meta on the project board: they paint beside their own task
+/// row, never as a decorative header block, and rows stay flush left.
 #[test]
-fn scoped_board_paints_thread_header_above_its_tasks() {
-    let mut tasks = fixture_tasks();
-    tasks[2].thread = Some("release".to_string());
-    tasks[3].thread = Some("release".to_string());
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
-    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
-
-    let rows = board_rows(&model, 80, 24);
-    let header = rows
-        .iter()
-        .position(|row| row.contains("#release"))
-        .expect("scoped thread block must paint its header");
-    let first_task = rows
-        .iter()
-        .position(|row| row.contains("Prototype the queue-style board UI"))
-        .expect("threaded task must paint");
-    assert!(
-        header < first_task,
-        "the thread header must precede its task rows:\n{}",
-        rows.join("\n")
-    );
-}
-
-#[test]
-fn threaded_task_rows_indent_under_headers_while_unthreaded_rows_stay_flush() {
+fn thread_labels_paint_beside_rows_without_headers_or_indent() {
     let mut tasks = fixture_tasks();
     tasks[2].thread = Some("release".to_string());
     tasks[3].thread = Some("release".to_string());
@@ -2818,15 +2949,6 @@ fn threaded_task_rows_indent_under_headers_while_unthreaded_rows_stay_flush() {
     model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
 
     let rows = board_rows(&model, 80, 24);
-    let leading_spaces = |row: &str| {
-        row.chars()
-            .take_while(|character| *character == ' ')
-            .count()
-    };
-    let header = rows
-        .iter()
-        .find(|row| row.contains("#release"))
-        .expect("thread header paints");
     let threaded = rows
         .iter()
         .find(|row| row.contains("Prototype the queue-style board UI"))
@@ -2836,123 +2958,81 @@ fn threaded_task_rows_indent_under_headers_while_unthreaded_rows_stay_flush() {
         .find(|row| row.contains("Loose project task"))
         .expect("unthreaded task paints");
 
-    assert_eq!(
-        leading_spaces(header),
-        leading_spaces(loose),
-        "headers and loose rows keep their existing left edge"
+    assert!(
+        threaded.contains("#release"),
+        "the thread label paints on its task row's meta:\n{threaded:?}"
     );
+    assert!(
+        rows.iter()
+            .all(|row| !row.trim_start().starts_with("#release")),
+        "no decorative thread header row paints:\n{}",
+        rows.join("\n")
+    );
+    let leading_spaces = |row: &str| {
+        row.chars()
+            .take_while(|character| *character == ' ')
+            .count()
+    };
     assert_eq!(
         leading_spaces(threaded),
-        leading_spaces(loose) + 2,
-        "threaded rows indent beneath their header:\n{}",
+        leading_spaces(loose),
+        "threaded and unthreaded rows stay flush left:\n{}",
         rows.join("\n")
     );
 }
 
+/// Selecting a thread filter removes the labels (every row would carry the same word)
+/// and narrows the rows to that thread across statuses.
 #[test]
-fn thread_blocks_leave_a_blank_row_before_loose_tasks() {
-    let mut tasks = fixture_tasks();
-    tasks[2].thread = Some("release".to_string());
-    tasks[3].thread = Some("release".to_string());
-    tasks.push(task(
-        12,
-        "Loose project task",
-        HumanStatus::Ready,
-        project("/repos/tsk"),
-        30,
-    ));
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
-    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
-
-    let rows = board_rows(&model, 80, 24);
-    let last_threaded_task = rows
-        .iter()
-        .position(|row| row.contains("Cut rust-toolchain pin into CI docs"))
-        .expect("last threaded task paints");
-    let loose_task = rows
-        .iter()
-        .position(|row| row.contains("Loose project task"))
-        .expect("loose task paints");
-
-    assert!(
-        rows[last_threaded_task + 1].trim().is_empty(),
-        "a thread block leaves a spacer before following content:\n{}",
-        rows.join("\n")
-    );
-    assert!(
-        last_threaded_task + 1 < loose_task,
-        "the loose task follows the thread spacer:\n{}",
-        rows.join("\n")
-    );
-}
-
-#[test]
-fn every_thread_block_leaves_a_spacer_before_following_content() {
-    let mut tasks = fixture_tasks();
-    tasks[2].thread = Some("alpha".to_string());
-    tasks[3].thread = Some("beta".to_string());
-    tasks.push(task(
-        12,
-        "Loose project task",
-        HumanStatus::Ready,
-        project("/repos/tsk"),
-        30,
-    ));
-    let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
-    model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
-
-    let rows = board_rows(&model, 80, 24);
-    for title in [
-        "Prototype the queue-style board UI",
-        "Cut rust-toolchain pin into CI docs",
-    ] {
-        let task = rows
-            .iter()
-            .position(|row| row.contains(title))
-            .unwrap_or_else(|| panic!("threaded task {title:?} paints"));
-        assert!(
-            rows[task + 1].trim().is_empty(),
-            "each thread block leaves a spacer after {title:?}:\n{}",
-            rows.join("\n")
-        );
-    }
-}
-
-#[test]
-fn header_shows_name_and_open_count() {
+fn a_selected_thread_filter_hides_redundant_labels_and_narrows_the_board() {
     let mut tasks = fixture_tasks();
     tasks[2].thread = Some("release".to_string());
     tasks[3].thread = Some("release".to_string());
     let mut model = BoardModel::from_tasks(tasks, Some(PathBuf::from("/repos/tsk")));
     model.set_selected_project(Some(PathBuf::from("/repos/tsk")));
-    let deck_index = model
-        .visible_ids()
-        .iter()
-        .position(|id| *id == Uuid::from_u128(10))
-        .expect("threaded task is visible");
     let mut domain = DomainState::new();
     apply_intent(
         &mut domain,
         &mut model,
-        BoardIntent::SelectIndex(deck_index),
+        BoardIntent::OpenThreadFilterPicker,
         None,
     )
-    .expect("select threaded task");
+    .expect("open the thread filter");
+    apply_intent(&mut domain, &mut model, BoardIntent::ListPickerNext, None)
+        .expect("select the release thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmListPicker,
+        None,
+    )
+    .expect("apply the filter");
 
-    let standard = board_rows(&model, 80, 24).join("\n");
+    let rows = board_rows(&model, 80, 24);
+    let joined = rows.join("\n");
     assert!(
-        standard.contains("#release") && standard.contains("2 open"),
-        "standard thread header must name its block and its open count:\n{standard}"
+        joined.contains("Prototype the queue-style board UI"),
+        "matching rows stay visible:\n{joined}"
     );
-    let compact = board_rows(&model, 40, 12).join("\n");
+    // The chip names the active filter; the task rows drop the redundant labels.
     assert!(
-        compact.contains("#release 2") && !compact.contains("2 open"),
-        "compact thread header must retain name/count in its compressed form:\n{compact}"
+        joined.contains("#release ▾"),
+        "the selector chip names the active filter:\n{joined}"
+    );
+    assert!(
+        rows.iter()
+            .filter(|row| row.contains("Prototype") || row.contains("rust-toolchain"))
+            .all(|row| !row.contains("#release")),
+        "a selected thread filter drops the now-redundant labels:\n{joined}"
+    );
+    assert!(
+        !joined.contains("Loose project task"),
+        "the fixture's unthreaded rows are hidden by the filter"
     );
 }
 
 #[test]
-fn board_with_headers_paints_within_40x10_and_all_tasks_reachable() {
+fn board_with_thread_labels_paints_within_40x10_and_all_tasks_reachable() {
     let mut tasks = vec![
         task(
             100,
@@ -3014,26 +3094,15 @@ fn board_with_headers_paints_within_40x10_and_all_tasks_reachable() {
             .into_iter()
             .find(|task| task.id == id)
             .expect("selected task stays visible");
-        let header = format!(
-            "#{} 2",
-            task.thread.as_deref().expect("threaded fixture task")
-        );
-        let header_y = rows
-            .iter()
-            .position(|row| row.contains(&header))
-            .expect("selected task's header must occupy a painted row");
-        let task_y = rows
-            .iter()
-            .position(|row| row.contains(&task.title))
-            .expect("selected task must be reachable at 40x10");
         assert!(
-            header_y < task_y,
-            "the header must consume its own row before the selected task:\n{}",
+            rows.iter()
+                .any(|row| row.contains(task.title.split(' ').next().expect("title word"))),
+            "selected task must be reachable at 40x10:\n{}",
             rows.join("\n")
         );
         assert!(
             rows.iter().all(|row| row_display_width(row) == 40),
-            "thread headers and rows must stay within 40 columns"
+            "thread-labelled rows must stay within 40 columns"
         );
     }
 }
@@ -3459,7 +3528,7 @@ fn overflowing_board_list_paints_a_scrollbar() {
         .collect();
     let last_id = Uuid::from_u128(7000 + 39);
     let view = fixture_view_projects(&tasks, false);
-    let mut model = fixture_model_on_tab(&tasks, &view, BoardTab::Projects);
+    let mut model = fixture_model_on_tab(&tasks, &view, NavTab::ProjectBoard);
     model.selection_id = Some(last_id);
 
     let (rows, geo) = paint(80, 24, &model);
@@ -3501,7 +3570,7 @@ fn overflowing_board_list_does_not_clip_task_rows_to_ellipsis() {
         })
         .collect();
     let view = fixture_view_projects(&tasks, false);
-    let model = fixture_model_on_tab(&tasks, &view, BoardTab::Projects);
+    let model = fixture_model_on_tab(&tasks, &view, NavTab::ProjectBoard);
     let (rows, geo) = paint(80, 24, &model);
     let top = geo.viewport_top as usize;
     let bottom = (geo.viewport_top + geo.viewport_height) as usize;
@@ -3632,15 +3701,16 @@ fn archived_task_paints_in_no_working_lens_in_any_status_at_any_tier() {
         domain.archive_task(archived_id).expect("archive it");
         let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/lens")));
 
-        // Lens setups: desk, projects, threads (home tabs) and project focus.
-        let lens_names = ["desk", "projects", "threads", "project focus"];
+        // Lens setups: desk, the projects index, a cross-project thread view, and the
+        // project board.
+        let lens_names = ["desk", "projects", "thread view", "project board"];
         for (lens_index, lens) in lens_names.iter().enumerate() {
             match lens_index {
                 0 => {
                     apply_intent(
                         &mut domain,
                         &mut model,
-                        BoardIntent::SelectHomeTab(BoardTab::Desk),
+                        BoardIntent::SelectNavTab(NavTab::Desk),
                         None,
                     )
                     .expect("desk tab");
@@ -3649,19 +3719,28 @@ fn archived_task_paints_in_no_working_lens_in_any_status_at_any_tier() {
                     apply_intent(
                         &mut domain,
                         &mut model,
-                        BoardIntent::SelectHomeTab(BoardTab::Projects),
+                        BoardIntent::SelectNavTab(NavTab::Projects),
                         None,
                     )
-                    .expect("projects tab");
+                    .expect("projects index");
                 }
                 2 => {
                     apply_intent(
                         &mut domain,
                         &mut model,
-                        BoardIntent::SelectHomeTab(BoardTab::Threads),
+                        BoardIntent::OpenProjectsViewPicker,
                         None,
                     )
-                    .expect("threads tab");
+                    .expect("open view picker");
+                    apply_intent(&mut domain, &mut model, BoardIntent::ListPickerNext, None)
+                        .expect("first thread");
+                    apply_intent(
+                        &mut domain,
+                        &mut model,
+                        BoardIntent::ConfirmListPicker,
+                        None,
+                    )
+                    .expect("thread view");
                 }
                 _ => {
                     apply_intent(
@@ -3775,8 +3854,9 @@ fn archived_group_paints_below_done_with_its_count_and_no_header_when_empty() {
     model.sync_from_domain(&domain);
     let rows = board_rows(&model, 80, 24);
     assert!(
-        !rows.iter().any(|row| row.contains("archived")),
-        "no archived group with zero archived tasks:\n{}",
+        !rows.iter().any(|row| row.contains("archived ·")),
+        "no archived group header with zero archived tasks (the unarchived rows are \
+         ordinary ON DECK rows now):\n{}",
         rows.join("\n")
     );
 }
@@ -4070,24 +4150,50 @@ fn archived_project_paints_nowhere_on_home_tabs_or_the_picker_main_list() {
     domain.archive_project("/repos/gone").expect("archive gone");
     let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/here")));
 
-    for tab in [BoardTab::Desk, BoardTab::Projects, BoardTab::Threads] {
+    for tab in [NavTab::Desk, NavTab::Projects, NavTab::ProjectBoard] {
         apply_intent(
             &mut domain,
             &mut model,
-            BoardIntent::SelectHomeTab(tab),
+            BoardIntent::SelectNavTab(tab),
             None,
         )
-        .expect("switch tab");
+        .or_else(|_| {
+            apply_intent(
+                &mut domain,
+                &mut model,
+                BoardIntent::OpenProjectSelector,
+                None,
+            )
+        })
+        .expect("switch destination");
+        if tab == NavTab::ProjectBoard {
+            // No project is selected: the tab intent opens the picker; close it and
+            // test the desk/index surfaces, then choose the live project explicitly.
+            apply_intent(
+                &mut domain,
+                &mut model,
+                BoardIntent::CancelProjectPicker,
+                None,
+            )
+            .expect("close picker");
+            let rows = board_rows(&model, 80, 24);
+            assert!(
+                !rows.iter().any(|row| row.contains("gone started task")),
+                "{tab:?}: the archived project's task paints:\n{}",
+                rows.join("\n")
+            );
+            continue;
+        }
         let rows = board_rows(&model, 80, 24);
         assert!(
             !rows.iter().any(|row| row.contains("gone started task")),
             "{tab:?}: the archived project's task paints:\n{}",
             rows.join("\n")
         );
-        if tab == BoardTab::Projects {
+        if tab == NavTab::Projects {
             assert!(
                 !rows.iter().any(|row| row.contains("gone")),
-                "{tab:?}: the archived project paints a group:\n{}",
+                "{tab:?}: the archived project paints an index row:\n{}",
                 rows.join("\n")
             );
         }
@@ -4474,4 +4580,440 @@ fn picker_list_capacity_counts_the_rule_row_on_a_short_frame() {
         frame.contains(&format!("\u{25b8} {label}")),
         "the selected last option paints on a short frame:\n{frame}"
     );
+}
+
+#[test]
+fn real_quick_add_paints_its_destination() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "existing",
+            None,
+            TaskScope::Project {
+                path: "/repos/beta".into(),
+            },
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("task");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/beta")));
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenCapture, None).expect("quick add");
+    let text = board_rows(&model, 162, 43).join("\n");
+    assert!(
+        text.contains("add to beta"),
+        "quick-add destination missing:\n{text}"
+    );
+}
+
+#[test]
+fn project_and_cross_project_thread_views_omit_count_summaries() {
+    let mut domain = DomainState::new();
+    for (title, path, thread) in [
+        ("desk release", None, Some("release")),
+        ("alpha release", Some("/repos/alpha"), Some("release")),
+        ("alpha other", Some("/repos/alpha"), Some("other")),
+    ] {
+        domain
+            .create(
+                title,
+                None,
+                path.map(|path| TaskScope::Project { path: path.into() })
+                    .unwrap_or(TaskScope::Global),
+                ProvenanceOrigin::Manual,
+                thread.map(str::to_string),
+            )
+            .expect("task");
+    }
+    let done = domain
+        .create(
+            "done desk release",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            Some("release".into()),
+        )
+        .expect("done task");
+    domain
+        .set_status(done, HumanStatus::Done)
+        .expect("complete task");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/alpha")));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenThreadFilterPicker,
+        None,
+    )
+    .expect("open picker");
+    apply_intent(&mut domain, &mut model, BoardIntent::ListPickerNext, None).expect("thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmListPicker,
+        None,
+    )
+    .expect("filter");
+    let local = board_rows(&model, 162, 43).join("\n");
+    assert!(
+        !local.contains("of 2 open tasks"),
+        "project filter must not paint a task-count summary:\n{local}"
+    );
+    assert!(
+        local.contains("alpha other"),
+        "matching task missing:\n{local}"
+    );
+    assert!(
+        !local.contains("alpha release"),
+        "filter stopped narrowing tasks:\n{local}"
+    );
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectNavTab(NavTab::Projects),
+        None,
+    )
+    .expect("projects");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenProjectsViewPicker,
+        None,
+    )
+    .expect("view picker");
+    apply_intent(&mut domain, &mut model, BoardIntent::ListPickerNext, None).expect("thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmListPicker,
+        None,
+    )
+    .expect("view");
+    apply_intent(&mut domain, &mut model, BoardIntent::ToggleDoneDrawer, None)
+        .expect("open done drawer");
+    let cross = board_rows(&model, 162, 43).join("\n");
+    assert!(
+        !cross.contains("tasks ·") && !cross.contains("projects + desk"),
+        "cross-project count summary must not be painted:\n{cross}"
+    );
+    for title in ["alpha release", "desk release", "done desk release"] {
+        assert!(
+            cross.contains(title),
+            "thread task missing: {title}\n{cross}"
+        );
+    }
+    assert!(
+        cross.contains("desk"),
+        "cross-project desk attribution missing:\n{cross}"
+    );
+}
+
+#[test]
+fn short_panes_keep_identity_when_standard_width_is_available() {
+    let mut item = task(
+        991,
+        "Scope row",
+        HumanStatus::Started,
+        TaskScope::Project {
+            path: "/repos/alpha".into(),
+        },
+        0,
+    );
+    item.thread = Some("ship".into());
+    for width in [78, 80, 162] {
+        let mut model = BoardModel::from_tasks(vec![item.clone()], None);
+        let desk = board_rows(&model, width, 20);
+        let row = desk
+            .iter()
+            .find(|row| row.contains("Scope row"))
+            .expect("desk task row");
+        assert!(
+            row.contains("alpha"),
+            "project attribution missing at {width}: {row}"
+        );
+        model.set_selected_project(Some(PathBuf::from("/repos/alpha")));
+        let project = board_rows(&model, width, 20);
+        let row = project
+            .iter()
+            .find(|row| row.contains("Scope row"))
+            .expect("project task row");
+        assert!(
+            row.contains("#ship"),
+            "thread attribution missing at {width}: {row}"
+        );
+    }
+}
+
+#[test]
+fn wide_compact_rows_keep_project_and_thread_identity() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "desk item",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            Some("release".into()),
+        )
+        .expect("desk task");
+    domain
+        .create(
+            "project item",
+            None,
+            TaskScope::Project {
+                path: "/repos/alpha".into(),
+            },
+            ProvenanceOrigin::Manual,
+            Some("release".into()),
+        )
+        .expect("project task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    let desk = board_rows(&model, 162, 20).join("\n");
+    assert!(desk.contains("desk"), "desk attribution missing:\n{desk}");
+    model.set_selected_project(Some(PathBuf::from("/repos/alpha")));
+    let project = board_rows(&model, 162, 20).join("\n");
+    assert!(
+        project.contains("#release"),
+        "thread attribution missing in wide compact mode:\n{project}"
+    );
+}
+
+fn searchable_thread_picker(global: bool) -> (DomainState, BoardModel) {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "Thread lookup task",
+            None,
+            TaskScope::Project {
+                path: "/repos/alpha".into(),
+            },
+            ProvenanceOrigin::Manual,
+            Some("abcdefghijklmnopqrstuvwxyz123456".into()),
+        )
+        .expect("task");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/alpha")));
+    if global {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::SelectNavTab(NavTab::Projects),
+            None,
+        )
+        .expect("projects");
+    }
+    let open = if global {
+        BoardIntent::OpenProjectsViewPicker
+    } else {
+        BoardIntent::OpenThreadFilterPicker
+    };
+    apply_intent(&mut domain, &mut model, open, None).expect("picker");
+    (domain, model)
+}
+
+#[test]
+fn thread_picker_search_accepts_every_letter_and_digit() {
+    for global in [false, true] {
+        let (mut domain, mut model) = searchable_thread_picker(global);
+        let name = "abcdefghijklmnopqrstuvwxyz123456";
+        for character in name.chars() {
+            let intent = map_key(
+                model.input_mode(),
+                KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE),
+            )
+            .expect("search key");
+            apply_intent(&mut domain, &mut model, intent, None).expect("type query");
+        }
+        assert_eq!(model.list_picker_query(), Some(name));
+        assert_eq!(model.visible_list_picker_options().len(), 1);
+        assert_eq!(
+            model.visible_list_picker_options()[0].1.label,
+            format!("#{name}")
+        );
+    }
+}
+
+#[test]
+fn thread_picker_search_accepts_bracketed_paste() {
+    for global in [false, true] {
+        let (mut domain, mut model) = searchable_thread_picker(global);
+        let name = "abcdefghijklmnopqrstuvwxyz123456";
+        let intent =
+            tsk_tui::ui::input::map_edit_paste(model.input_mode(), name).expect("paste accepted");
+        apply_intent(&mut domain, &mut model, intent, None).expect("paste query");
+        assert_eq!(model.list_picker_query(), Some(name));
+        assert_eq!(model.visible_list_picker_options().len(), 1);
+    }
+}
+
+#[test]
+fn empty_thread_search_keeps_its_query_and_menu_visible() {
+    for global in [false, true] {
+        let (mut domain, mut model) = searchable_thread_picker(global);
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::ListPickerQueryInsertText("nomatches".into()),
+            None,
+        )
+        .expect("query");
+        for width in [40, 80, 162] {
+            let text = board_rows(&model, width, 20).join("\n");
+            assert!(
+                text.contains("nomatches"),
+                "query disappeared at {width}:\n{text}"
+            );
+            assert!(
+                text.contains("no matching options"),
+                "empty-state missing at {width}:\n{text}"
+            );
+        }
+    }
+}
+
+#[test]
+fn real_thread_picker_paints_query_and_options() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "release task",
+            None,
+            TaskScope::Project {
+                path: "/repos/alpha".into(),
+            },
+            ProvenanceOrigin::Manual,
+            Some("release".into()),
+        )
+        .expect("task");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/alpha")));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenThreadFilterPicker,
+        None,
+    )
+    .expect("open picker");
+    let rows = board_rows(&model, 162, 43).join("\n");
+    assert!(
+        rows.contains("thread filter"),
+        "picker title missing:\n{rows}"
+    );
+    assert!(
+        rows.contains("All tasks"),
+        "picker options missing:\n{rows}"
+    );
+    assert!(rows.contains("#release"), "thread option missing:\n{rows}");
+}
+
+#[test]
+fn projects_index_paints_aligned_counts_search_hint_and_duplicate_paths() {
+    let mut domain = DomainState::new();
+    for path in ["/one/alpha", "/two/alpha"] {
+        domain
+            .create(
+                "project task",
+                None,
+                TaskScope::Project { path: path.into() },
+                ProvenanceOrigin::Manual,
+                None,
+            )
+            .expect("task");
+    }
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/one/alpha")));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectNavTab(NavTab::Projects),
+        None,
+    )
+    .expect("projects index");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::FocusProjectsSearch,
+        None,
+    )
+    .expect("focus search");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ProjectsQueryInsertText("alpha".into()),
+        None,
+    )
+    .expect("type search");
+    let rows = board_rows(&model, 162, 43);
+    assert!(
+        rows.iter().any(|row| row.contains("▎ alpha")),
+        "visible footer search query missing:\n{}",
+        rows.join("\n")
+    );
+    let text = rows.join("\n");
+    assert!(
+        !rows[..10.min(rows.len())]
+            .iter()
+            .any(|row| row.contains("search projects")),
+        "search hint must not remain above the project table:\n{text}"
+    );
+    assert!(
+        text.contains("/one/alpha") && text.contains("/two/alpha"),
+        "paths missing:\n{text}"
+    );
+    assert!(
+        text.contains("current directory"),
+        "current project indicator missing:\n{text}"
+    );
+    let header = rows
+        .iter()
+        .find(|row| row.contains("NEEDS YOU"))
+        .expect("header");
+    let first = rows
+        .iter()
+        .find(|row| row.contains("/one/alpha"))
+        .expect("row");
+    assert_eq!(
+        header.chars().position(|ch| ch == 'N'),
+        first.chars().position(|ch| ch == '0'),
+        "numeric count starts under NEEDS YOU"
+    );
+
+    for width in [40, 80, 162] {
+        let rows = board_rows(&model, width, 20);
+        let text = rows.join("\n");
+        assert!(
+            text.contains("alpha"),
+            "project basename is visible at {width}:\n{text}"
+        );
+        let project_rows: Vec<&String> = rows
+            .iter()
+            .filter(|row| {
+                row.contains("alpha (/") || row.contains("/one/alpha") || row.contains("/two/alpha")
+            })
+            .collect();
+        assert_eq!(
+            project_rows.len(),
+            2,
+            "both duplicate rows paint at {width}:\n{text}"
+        );
+        assert!(
+            project_rows.iter().any(|row| row.contains("0")),
+            "a count remains visible at minimum width {width}:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn persistent_slot_keeps_selected_project_label_on_home_tabs() {
+    let domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/alpha")));
+    for tab in [NavTab::Desk, NavTab::Projects] {
+        apply_intent(
+            &mut domain.clone(),
+            &mut model,
+            BoardIntent::SelectNavTab(tab),
+            None,
+        )
+        .expect("switch tab");
+        let text = board_rows(&model, 80, 24).join("\n");
+        assert!(
+            text.contains("alpha ▾"),
+            "slot label missing on {tab:?}:\n{text}"
+        );
+    }
 }

--- a/tests/queue_board_verbs.rs
+++ b/tests/queue_board_verbs.rs
@@ -10,7 +10,7 @@ use tsk_tui::context::InvocationSnapshot;
 use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, TaskEventKind, TaskScope};
 use tsk_tui::ui::board::{
     apply_intent, board_hit_map, board_intent_may_persist, board_verb_items, draw_board,
-    resolve_board_command, BoardInputMode, BoardModel, BoardTab, CommandSurface, IntentOutcome,
+    resolve_board_command, BoardInputMode, BoardModel, CommandSurface, IntentOutcome,
     ProjectScopeOption,
 };
 use tsk_tui::ui::capture::CaptureField;
@@ -372,9 +372,12 @@ fn esc_closes_transient_then_detail_then_quit_and_q_quits_only_in_normal() {
     assert_eq!(outcome, IntentOutcome::None);
     assert_eq!(model.detail_open(), None);
 
-    // Nothing open → quit
+    // Nothing open → the board-level Esc is a no-op; quitting is explicit (ctrl+q).
     let outcome =
-        apply_intent(&mut domain, &mut model, BoardIntent::CloseLayer, None).expect("esc quit");
+        apply_intent(&mut domain, &mut model, BoardIntent::CloseLayer, None).expect("esc no-op");
+    assert_eq!(outcome, IntentOutcome::None);
+    let outcome =
+        apply_intent(&mut domain, &mut model, BoardIntent::Quit, None).expect("ctrl+q quits");
     assert_eq!(outcome, IntentOutcome::Quit);
 
     // ctrl+q quits from normal only; bare q is dead
@@ -469,13 +472,13 @@ fn palette_lists_exactly_m1_commands_for_selection_filters_by_subsequence_and_di
         "delete",
         "undo",
         "done drawer",
-        "toggle groups",
         "help",
         "quit",
     ];
     assert_eq!(
         labels, expected,
-        "M1 palette catalog with a selection must match AC-17 exactly"
+        "palette catalog with a selection must match exactly (no toggle-groups entry: \
+         the destinations have no collapsible task groups)"
     );
     // / the `o` key: reopen is only valid for a done selection, so a ready selection's
     // catalog must not offer it at all (not merely filtered out above by the exact-match).
@@ -836,17 +839,23 @@ fn project_scope_chip_and_dropdown_filter_all_visible_sections_matching_ac5() {
     assert_eq!(model.popup(), BoardPopup::ProjectPicker);
 
     let frame = rendered_board(&model, 80, 24);
-    let home_row = frame
+    // The dropdown marks its highlighted option (the current project at open) and
+    // paints the desk choice plus every project option around it.
+    let marked_row = frame
         .lines()
-        .position(|line| line.contains("desk") && line.contains('▸'))
-        .expect("scope dropdown must paint the home/desk option");
+        .position(|line| line.contains('▸'))
+        .expect("scope dropdown must mark the highlighted option");
+    assert!(
+        frame.lines().any(|line| line.contains("desk")),
+        "scope dropdown must paint the home/desk option: {frame:?}"
+    );
     assert!(
         frame
             .lines()
-            .skip(home_row + 1)
-            .take(3)
+            .skip(marked_row.saturating_sub(2))
+            .take(5)
             .any(|line| line.contains("other") || line.contains("app") || line.contains("empty")),
-        "scope dropdown must paint project options after home: {frame:?}"
+        "scope dropdown must paint the project options: {frame:?}"
     );
 
     // Move to /repos/other and confirm (session-only deck scope).
@@ -930,7 +939,7 @@ fn project_scope_chip_and_dropdown_filter_all_visible_sections_matching_ac5() {
     )
     .expect("scope home");
     assert!(model.at_home());
-    assert_eq!(model.home_tab(), tsk_tui::ui::board::BoardTab::Desk);
+    assert_eq!(model.nav_tab(), tsk_tui::ui::queue::NavTab::Desk);
     let home_view = model.queue_view();
     assert_eq!(home_view.counts.in_motion, 3);
     assert!(model.visible_ids().contains(&motion_global));
@@ -3939,8 +3948,8 @@ fn ctrl_u_in_read_only_focus_unarchives_in_place() {
 fn leaving_read_only_focus_hides_the_archived_projects_tasks_again() {
     for leave in [
         BoardIntent::CancelEdit,
-        BoardIntent::SelectHomeTab(BoardTab::Desk),
-        BoardIntent::SelectHomeTab(BoardTab::Projects),
+        BoardIntent::SelectNavTab(tsk_tui::ui::queue::NavTab::Desk),
+        BoardIntent::SelectNavTab(tsk_tui::ui::queue::NavTab::Projects),
     ] {
         let (mut domain, mut model, inside) = read_only_focus();
         assert!(model.visible_ids().contains(&inside));
@@ -4152,14 +4161,7 @@ fn toggle_all_groups_folds_and_unfolds_the_archived_group_with_the_others_when_t
         )
         .expect("create filed");
     domain.archive_task(filed).expect("archive");
-    let mut model = BoardModel::from_domain(&domain, None);
-    apply_intent(
-        &mut domain,
-        &mut model,
-        BoardIntent::SelectHomeTab(BoardTab::Projects),
-        None,
-    )
-    .expect("projects tab");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repos/app")));
     apply_intent(&mut domain, &mut model, BoardIntent::ToggleDoneDrawer, None).expect("drawer");
     // Expand the archived group on its own, the way Enter on the header does.
     apply_intent(
@@ -4169,7 +4171,7 @@ fn toggle_all_groups_folds_and_unfolds_the_archived_group_with_the_others_when_t
         None,
     )
     .expect("expand archived");
-    assert!(model.visible_ids().contains(&live), "project group open");
+    assert!(model.visible_ids().contains(&live), "live rows open");
     assert!(model.visible_ids().contains(&filed), "archived group open");
 
     let toggle_all =
@@ -4182,29 +4184,26 @@ fn toggle_all_groups_folds_and_unfolds_the_archived_group_with_the_others_when_t
 
     apply_intent(&mut domain, &mut model, toggle_all.clone(), None).expect("fold all");
     let visible = model.visible_ids();
-    assert!(!visible.contains(&live), "the project group folded");
     assert!(
         !visible.contains(&filed),
-        "and the archived group folded with it"
+        "the archived group folded with the drawer open"
+    );
+    assert!(
+        visible.contains(&live),
+        "live rows never fold; they are not a group"
     );
 
     apply_intent(&mut domain, &mut model, toggle_all.clone(), None).expect("unfold all");
-    let visible = model.visible_ids();
-    assert!(visible.contains(&live), "the project group unfolded");
     assert!(
-        visible.contains(&filed),
-        "and the archived group unfolded with it"
+        model.visible_ids().contains(&filed),
+        "and the archived group unfolded again"
     );
 
-    // Drawer closed: a single toggle-all folds the project group but leaves the archived
-    // group's own state alone (one press, so a regression cannot cancel itself out).
+    // Drawer closed: no group answers the chord, and the archived group's own state
+    // is left alone (one press, so a regression cannot cancel itself out).
     apply_intent(&mut domain, &mut model, BoardIntent::ToggleDoneDrawer, None)
         .expect("close drawer");
-    apply_intent(&mut domain, &mut model, toggle_all, None).expect("fold all");
-    assert!(
-        !model.visible_ids().contains(&live),
-        "the project group folded with the drawer shut"
-    );
+    apply_intent(&mut domain, &mut model, toggle_all, None).expect("inert with the drawer shut");
     apply_intent(&mut domain, &mut model, BoardIntent::ToggleDoneDrawer, None)
         .expect("reopen drawer");
     assert!(

--- a/tests/quick_add_capture.rs
+++ b/tests/quick_add_capture.rs
@@ -273,10 +273,31 @@ fn expanded_quick_add_keeps_the_selected_project_scope_through_esc_and_tab() {
 fn quick_add_save_selects_the_new_task_and_navigation_stays_relative_to_it() {
     let mut domain = DomainState::new();
     create_project_fixture(&mut domain, "/repos/existing");
+    domain
+        .create(
+            "desk fixture",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("desk fixture");
     let mut model = BoardModel::from_domain(&domain, None);
-    let prior_selection = model.selected_id().expect("fixture is selected");
+    let prior_selection = model.selected_id().expect("desk fixture is selected");
 
-    save_quick_add(&mut domain, &mut model, "new task");
+    let desk_snapshot = InvocationSnapshot {
+        default_scope: TaskScope::Global,
+        this_repo: None,
+        title_prefill: None,
+        provenance: ProvenanceOrigin::Capture,
+    };
+    open(&mut domain, &mut model, &desk_snapshot);
+    type_title(&mut domain, &mut model, "new task");
+    assert_eq!(
+        apply(&mut domain, &mut model, BoardIntent::QuickAddSave, None),
+        IntentOutcome::Persist
+    );
+    model.sync_from_domain(&domain);
     let saved = domain.tasks().last().expect("saved task").id;
     assert_eq!(model.selected_id(), Some(saved));
     assert_ne!(saved, prior_selection);
@@ -451,7 +472,11 @@ fn shift_enter_uses_the_same_project_basename_resolution() {
             path: "/work/ctrl-target".into()
         }
     );
-    assert_eq!(model.selected_id(), Some(task.id));
+    assert_eq!(
+        model.selected_id(),
+        None,
+        "saved project task is outside the desk lens"
+    );
     assert_eq!(model.message(), None);
 }
 
@@ -1039,7 +1064,7 @@ fn capture_bar_renders_spaced_three_row_block_and_stays_bounded_without_color_sg
     for text in [
         "visible task",
         "title…   !p = desk · !p name = project · !t name = thread",
-        "enter save · shift+enter save+next · tab details · esc close",
+        "Enter save · esc cancel · tab expand · add to invocation",
     ] {
         assert!(standard.contains(text), "missing {text:?}: {standard}");
     }
@@ -1057,7 +1082,7 @@ fn capture_bar_renders_spaced_three_row_block_and_stays_bounded_without_color_sg
 
     let compact_rows = render_rows(&model, 40, 10);
     let compact = compact_rows.concat();
-    for text in ["visible task", "title…", "enter save"] {
+    for text in ["visible task", "title…", "save"] {
         assert!(compact.contains(text), "missing {text:?}: {compact}");
     }
     assert!(compact_rows.iter().all(|row| row.chars().count() == 40));

--- a/tests/reopen.rs
+++ b/tests/reopen.rs
@@ -59,6 +59,39 @@ fn reopen_watch_reads_one_atomic_request_and_acknowledges_it_once() {
 }
 
 #[test]
+fn reopen_watch_keeps_the_latest_request_and_does_not_acknowledge_a_replacement() {
+    let dir = state_dir();
+    let store = TaskStore::new(&dir);
+    let mut watch = ReopenWatch::seeded(&store);
+    ReopenRequest::new(Some(PathBuf::from("/repo/a")))
+        .write(&dir)
+        .expect("request a");
+    let first = watch.poll().expect("first request");
+    ReopenRequest::new(Some(PathBuf::from("/repo/b")))
+        .write(&dir)
+        .expect("request b");
+    let second = watch.poll().expect("replacement request");
+    assert_eq!(
+        second.project.as_deref(),
+        Some(std::path::Path::new("/repo/b"))
+    );
+    ReopenRequest::new(Some(PathBuf::from("/repo/c")))
+        .write(&dir)
+        .expect("request c");
+    watch.acknowledge();
+    assert!(
+        dir.join("reopen.json").exists(),
+        "ack must not delete newer request"
+    );
+    assert_ne!(first.project, second.project);
+    assert_eq!(
+        watch.poll().expect("latest remains").project.as_deref(),
+        Some(std::path::Path::new("/repo/c"))
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn resolve_context_rejects_malformed_json_without_publishing_a_request() {
     let dir = state_dir();
     let binary = env!("CARGO_BIN_EXE_tsk");
@@ -118,6 +151,67 @@ fn resolve_context_publishes_project_and_desk_requests_without_using_process_cwd
     );
     let request = fs::read_to_string(dir.join("reopen.json")).expect("request");
     assert!(request.contains(&repo.display().to_string()));
+
+    // A host invocation outside any repository must publish an explicit Desk
+    // request, even though this test process itself runs from the repository.
+    let outside = dir.join("outside");
+    fs::create_dir_all(&outside).expect("outside");
+    // Keep the process cwd in-repo while the host JSON supplies the outside cwd.
+    let mut child = Command::new(binary)
+        .arg("--resolve-context")
+        .env("TSK_STATE_DIR", &dir)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("resolve desk context");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(
+            format!(
+                r#"{{"focused_pane_cwd":{}}}"#,
+                serde_json::to_string(&outside).unwrap()
+            )
+            .as_bytes(),
+        )
+        .expect("context");
+    let output = child.wait_with_output().expect("output");
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let request = fs::read_to_string(dir.join("reopen.json")).expect("desk request");
+    assert!(request.contains(r#""project":null"#));
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn board_reopen_refuses_archived_canonical_and_alias_projects_to_desk() {
+    use std::os::unix::fs::symlink;
+    let dir = state_dir();
+    let real = dir.join("archived");
+    let alias = dir.join("alias");
+    fs::create_dir_all(&real).expect("real project");
+    symlink(&real, &alias).expect("project alias");
+    let real_text = real.to_string_lossy().into_owned();
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "archived",
+            None,
+            TaskScope::Project {
+                path: real_text.clone(),
+            },
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("task");
+    domain.archive_project(&real_text).expect("archive");
+    let mut model = BoardModel::from_domain(&domain, None);
+    assert!(model.apply_reopen_project(Some(real.clone())));
+    assert!(model.selected_project().is_none());
+    assert!(model.apply_reopen_project(Some(alias)));
+    assert!(model.selected_project().is_none());
     let _ = fs::remove_dir_all(dir);
 }
 

--- a/tests/reopen.rs
+++ b/tests/reopen.rs
@@ -1,0 +1,369 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tsk_tui::context::InvocationSnapshot;
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::reopen::{ReopenRequest, ReopenWatch};
+use tsk_tui::store::TaskStore;
+use tsk_tui::ui::board::{apply_intent, BoardModel};
+use tsk_tui::ui::input::BoardIntent;
+
+static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+fn state_dir() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "tsk-reopen-test-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir_all(&dir).expect("state dir");
+    dir
+}
+
+#[test]
+fn reopen_watch_ignores_stale_request_seeded_before_board_start() {
+    let dir = state_dir();
+    let store = TaskStore::new(&dir);
+    ReopenRequest::new(Some(PathBuf::from("/repo/old")))
+        .write(&dir)
+        .expect("write request");
+    let mut watch = ReopenWatch::seeded(&store);
+    assert_eq!(watch.poll(), None);
+    assert!(
+        !dir.join("reopen.json").exists(),
+        "stale request is retired"
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn reopen_watch_reads_one_atomic_request_and_acknowledges_it_once() {
+    let dir = state_dir();
+    let store = TaskStore::new(&dir);
+    let mut watch = ReopenWatch::seeded(&store);
+    ReopenRequest::new(Some(PathBuf::from("/repo/new")))
+        .write(&dir)
+        .expect("write request");
+    let request = watch.poll().expect("request");
+    assert_eq!(
+        request.project.as_deref(),
+        Some(std::path::Path::new("/repo/new"))
+    );
+    assert_eq!(watch.poll(), Some(request.clone()));
+    watch.acknowledge();
+    assert_eq!(watch.poll(), None);
+    assert!(!dir.join("reopen.json").exists());
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn resolve_context_rejects_malformed_json_without_publishing_a_request() {
+    let dir = state_dir();
+    let binary = env!("CARGO_BIN_EXE_tsk");
+    let mut child = Command::new(binary)
+        .arg("--resolve-context")
+        .env("TSK_STATE_DIR", &dir)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("resolve context");
+    use std::io::Write;
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(b"not json")
+        .expect("context");
+    let output = child.wait_with_output().expect("output");
+    assert!(!output.status.success());
+    assert!(!dir.join("reopen.json").exists());
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn resolve_context_publishes_project_and_desk_requests_without_using_process_cwd() {
+    let dir = state_dir();
+    let repo = dir.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo");
+    let binary = env!("CARGO_BIN_EXE_tsk");
+    let mut child = Command::new(binary)
+        .arg("--resolve-context")
+        .env("TSK_STATE_DIR", &dir)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("resolve context");
+    use std::io::Write;
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(
+            format!(
+                r#"{{"focused_pane_cwd":{}}}"#,
+                serde_json::to_string(&repo).unwrap()
+            )
+            .as_bytes(),
+        )
+        .expect("context");
+    let output = child.wait_with_output().expect("output");
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        repo.display().to_string()
+    );
+    let request = fs::read_to_string(dir.join("reopen.json")).expect("request");
+    assert!(request.contains(&repo.display().to_string()));
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn board_reopen_updates_quick_add_defaults_for_project_and_desk() {
+    let mut domain = DomainState::new();
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repo/a")));
+    let snapshot = InvocationSnapshot {
+        default_scope: TaskScope::Project {
+            path: "/repo/a".into(),
+        },
+        this_repo: Some(PathBuf::from("/repo/a")),
+        title_prefill: None,
+        provenance: ProvenanceOrigin::Capture,
+    };
+    assert!(model.apply_reopen_project(Some(PathBuf::from("/repo/b"))));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenCapture,
+        Some(&snapshot),
+    )
+    .expect("open add");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddInsertText("project b".into()),
+        Some(&snapshot),
+    )
+    .expect("type");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddSave,
+        Some(&snapshot),
+    )
+    .expect("save");
+    model.sync_from_domain(&domain);
+    assert_eq!(
+        domain.tasks()[0].scope,
+        TaskScope::Project {
+            path: "/repo/b".into()
+        }
+    );
+
+    assert!(model.apply_reopen_project(None));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenCapture,
+        Some(&snapshot),
+    )
+    .expect("open add");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddInsertText("desk after reopen".into()),
+        Some(&snapshot),
+    )
+    .expect("type");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddSave,
+        Some(&snapshot),
+    )
+    .expect("save");
+    model.sync_from_domain(&domain);
+    assert_eq!(domain.tasks()[1].scope, TaskScope::Global);
+}
+
+#[test]
+fn reopen_keeps_an_earlier_archived_launch_override_on_desk_capture() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "archived task",
+            None,
+            TaskScope::Project {
+                path: "/repo/a".into(),
+            },
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("task");
+    domain.archive_project("/repo/a").expect("archive");
+    let snapshot = InvocationSnapshot {
+        default_scope: TaskScope::Project {
+            path: "/repo/a".into(),
+        },
+        this_repo: Some(PathBuf::from("/repo/a")),
+        title_prefill: None,
+        provenance: ProvenanceOrigin::Capture,
+    };
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repo/a")));
+    assert!(model.offer_launch_card(&domain, &snapshot));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::LaunchKeepArchived,
+        Some(&snapshot),
+    )
+    .expect("keep archived");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenCapture,
+        Some(&snapshot),
+    )
+    .expect("open add");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddInsertText("desk task".into()),
+        Some(&snapshot),
+    )
+    .expect("type");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddSave,
+        Some(&snapshot),
+    )
+    .expect("save");
+    model.sync_from_domain(&domain);
+    assert_eq!(
+        domain.tasks().last().expect("desk task").scope,
+        TaskScope::Global
+    );
+}
+
+#[test]
+fn board_reopen_switches_project_or_desk_and_clears_local_filter() {
+    let mut domain = DomainState::new();
+    let id = domain
+        .create(
+            "project task",
+            None,
+            TaskScope::Project {
+                path: "/repo/a".into(),
+            },
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("task");
+    let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from("/repo/a")));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::OpenThreadFilterPicker,
+        None,
+    )
+    .expect("thread picker");
+    apply_intent(&mut domain, &mut model, BoardIntent::ListPickerNext, None).expect("thread");
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::ConfirmListPicker,
+        None,
+    )
+    .expect("filter");
+    assert!(model.apply_reopen_project(Some(PathBuf::from("/repo/b"))));
+    assert_eq!(
+        model.selected_project(),
+        Some(std::path::Path::new("/repo/b"))
+    );
+    assert_eq!(
+        model.thread_filter(),
+        &tsk_tui::ui::queue::ThreadFilter::All
+    );
+    assert_ne!(
+        model.selected_id(),
+        Some(id),
+        "selection cannot pin an invisible task"
+    );
+    assert!(model.apply_reopen_project(None));
+    assert!(model.selected_project().is_none());
+}
+
+#[test]
+fn board_reopen_dismisses_clean_page_picker_search_and_wide_stage() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "task",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenTaskPage, None).expect("page");
+    for _ in 0..3 {
+        apply_intent(&mut domain, &mut model, BoardIntent::StageRight, None).expect("stage");
+    }
+    assert_ne!(model.wide_stage(), tsk_tui::ui::tier::WideStage::FullBoard);
+    assert!(model.apply_reopen_project(Some(PathBuf::from("/repo/new"))));
+    assert_eq!(
+        model.input_mode(),
+        tsk_tui::ui::board::BoardInputMode::Normal
+    );
+    assert_eq!(model.wide_stage(), tsk_tui::ui::tier::WideStage::FullBoard);
+    assert!(model.selected_project().is_some());
+}
+
+#[test]
+fn board_reopen_defers_while_dirty_editor_is_open() {
+    let mut domain = DomainState::new();
+    domain
+        .create(
+            "task",
+            None,
+            TaskScope::Global,
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .expect("task");
+    let mut model = BoardModel::from_domain(&domain, None);
+    apply_intent(&mut domain, &mut model, BoardIntent::BeginEditTitle, None).expect("edit");
+    apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('x'), None).expect("type");
+    assert!(model.has_unsaved_work());
+    assert!(!model.apply_reopen_project(Some(PathBuf::from("/repo/new"))));
+    assert!(model.selected_project().is_none());
+    assert!(model
+        .message()
+        .is_some_and(|message| message.contains("save or cancel")));
+}
+
+#[test]
+fn reopen_request_rejects_oversized_or_symlinked_state_payload() {
+    let dir = state_dir();
+    let too_long = "x".repeat(5000);
+    assert!(ReopenRequest::new(Some(PathBuf::from(too_long)))
+        .write(&dir)
+        .is_err());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        let target = dir.join("target");
+        fs::write(&target, b"safe").expect("target");
+        symlink(&target, dir.join("reopen.json")).expect("symlink");
+        assert!(ReopenRequest::new(Some(PathBuf::from("/repo/new")))
+            .write(&dir)
+            .is_ok());
+        assert_eq!(fs::read(&target).expect("target bytes"), b"safe");
+    }
+    let _ = fs::remove_dir_all(dir);
+}

--- a/tests/v1_keymap_guard.rs
+++ b/tests/v1_keymap_guard.rs
@@ -45,6 +45,8 @@ fn normal_mode_keymap_equals_the_readme_and_queue_board_v1_set() {
         (KeyCode::Char(':'), BoardIntent::OpenCommandPalette),
         (KeyCode::Char('?'), BoardIntent::OpenHelp),
         (KeyCode::Char('P'), BoardIntent::OpenProjectSelector),
+        (KeyCode::Char('t'), BoardIntent::OpenThreadFilterPicker),
+        (KeyCode::Char('v'), BoardIntent::OpenProjectsViewPicker),
     ];
     assert_eq!(
         normal_mode_keymap(),
@@ -72,9 +74,7 @@ fn normal_mode_keymap_equals_the_readme_and_queue_board_v1_set() {
         }
     }
 
-    for retired in [
-        'a', 'v', 'p', 'r', 'l', 'c', 'n', 's', 't', 'i', '1', '2', '3', '[', ']',
-    ] {
+    for retired in ['a', 'p', 'r', 'l', 'c', 'n', 'i', '1', '2', '3', '[', ']'] {
         assert_eq!(
             normal(KeyCode::Char(retired)),
             None,

--- a/tests/wide_task_split.rs
+++ b/tests/wide_task_split.rs
@@ -260,7 +260,7 @@ fn stage_zero_and_full_task_render_the_standard_tier_at_130x24() {
     let (rows, hits) = render(&model, 130, 24);
     assert!(rows[0].trim().is_empty(), "row 0 blank");
     assert!(
-        rows[1].contains("desk  ·  projects  ·  threads"),
+        rows[1].contains("desk  ·  tsk ▾  ·  projects"),
         "selector row"
     );
     assert!(rows[2].trim().is_empty(), "blank above IN MOTION");
@@ -268,12 +268,12 @@ fn stage_zero_and_full_task_render_the_standard_tier_at_130x24() {
     assert!(rows[4].trim().is_empty(), "blank between header and rows");
     assert!(rows[5].starts_with("  ▸ T12 Frame the wide task view"));
     assert!(
-        rows[5].trim_end().ends_with("tsk · 0s"),
+        rows[5].trim_end().ends_with("tsk"),
         "meta column: {}",
         rows[5]
     );
     assert!(rows[6].trim().is_empty());
-    assert!(rows[7].starts_with(" desk ─"));
+    assert!(rows[7].starts_with(" ON DECK · desk ─"));
     assert!(rows[9].starts_with("  ○ T15 Renew domain"));
     let verbs = hits
         .regions
@@ -362,7 +362,7 @@ fn stage_a_board_keeps_its_meta_column() {
     let (rows, _) = render(&model, 130, 24);
     let row = column_text(&rows, geometry.board, 5);
     assert!(row.starts_with("  ▸ T12 Frame"), "{row}");
-    assert!(row.trim_end().ends_with("tsk · 0s"), "meta column: {row}");
+    assert!(row.trim_end().ends_with("tsk"), "meta column: {row}");
     assert_eq!(rows[5].chars().nth(geometry.rule.x as usize), Some('│'));
 }
 
@@ -410,11 +410,13 @@ fn rail_wraps_titles_with_indent_four_and_dims_every_cell() {
             "│",
             "rule column at row {y}"
         );
-        assert_eq!(
-            buffer[(rail.width - 1, y)].symbol(),
-            " ",
-            "no glyph touches the rule at row {y}"
-        );
+        if y != 1 {
+            assert_eq!(
+                buffer[(rail.width - 1, y)].symbol(),
+                " ",
+                "no glyph touches the rule at row {y}"
+            );
+        }
         for x in 0..rail.width {
             assert!(
                 buffer[(x, y)].modifier.contains(Modifier::DIM),
@@ -427,7 +429,7 @@ fn rail_wraps_titles_with_indent_four_and_dims_every_cell() {
     assert!(!rail_text.contains("DONE"), "rail drops the done drawer");
     assert!(rail_text.contains(" IN MOTION ─"));
     assert!(rail_text.contains(" desk ─"));
-    assert!(rail_text.contains("desk  ·  projects  ·  threads"));
+    assert!(rail_text.contains("desk  ·  tsk"));
 }
 
 #[test]
@@ -753,7 +755,11 @@ fn stage_a_preview_paints_controls_for_the_focus_router_only() {
 fn narrow_board_is_unchanged_by_the_stage_model() {
     let (mut domain, mut model) = fixture();
     let (rows, _) = render(&model, 109, 24);
-    assert!(rows[1].contains("desk  ·  projects  ·  threads"));
+    assert!(
+        rows[1].contains("desk  ·  tsk ▾  ·  projects"),
+        "selector: {:?}",
+        rows[1]
+    );
     assert!(rows[5].starts_with("  ▸ T12 Frame the wide task view"));
     assert!(
         !rows[22].contains("→ pane"),
@@ -1167,7 +1173,7 @@ fn shrinking_and_growing_keeps_every_stage_and_its_session() {
                 None,
             )
             .expect("create other");
-        let mut model = BoardModel::from_domain(&domain, Some(PathBuf::from(REPO)));
+        let mut model = BoardModel::from_domain(&domain, None);
         let survivor = domain
             .tasks()
             .iter()
@@ -1203,7 +1209,10 @@ fn shrinking_and_growing_keeps_every_stage_and_its_session() {
         match stage.focused_surface() {
             FocusedSurface::Board => {
                 assert_eq!(narrow.presentation, ResponsivePresentation::SingleBoard);
-                assert!(narrow_rows[1].contains("desk  ·  projects"), "{stage:?}");
+                assert!(
+                    narrow_rows[1].contains("desk  ·  select project"),
+                    "{stage:?}"
+                );
             }
             FocusedSurface::Task => {
                 assert_eq!(narrow.presentation, ResponsivePresentation::SingleTask);


### PR DESCRIPTION
## Status
Implemented, repair commits pushed, and verified locally. Not merged.

## Changes
- Open and explicitly reopen into the invocation project, including empty repositories; use Desk outside a repository. Reuse the existing plugin pane through a bounded, atomic context handoff, deferring dirty edits and save recovery.
- Keep Desk / selected project / Projects navigation persistent. Desk collects attention and active work across projects, with a desk-only ready backlog. Projects provides a selectable index with aligned status counts and footer search.
- Move thread browsing into local project filters and cross-project selectors. Preserve archived-project protections, completed work, selection, capture defaults, and wide/narrow navigation.
- Simplify chrome: unnumbered tab labels with unchanged shortcuts, no task-row ages or selector prefixes, complete long thread names, blank spacing above wrapped selectors, and no standalone filtered-task/project summaries. Update docs and the interactive demo.

## Verification
- Rust: fmt, clippy all-targets with warnings denied, 928 passing tests (5 ignored), release build.
- Site: 14 passing tests and production build. Live Herdr checks used isolated task/config state, including footer search, directory reopening, maximum-length thread names, narrow layouts and bracketed paste. Regression tests were observed failing before their fixes.

Native host shortcut context generation and real mouse clicks were not live-tested; launcher handoff with supplied host context, plugin focus, and automated mouse/stage coverage were checked. An earlier smoke plugin pane disappeared without an established cause; subsequent instrumented shell-pane checks were stable and exited cleanly.

No store migration, real task edits, plugin relinking or deployment.
