### PR TITLE
Reuse the task page in quick-capture popups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,15 @@ For scriptable board work, use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, 
   32 characters. A refusal names the rule (start character, allowed characters, or length). Tokens are stripped from the saved title. A saved task becomes the
   selection. Success has no status message: the row flash is the feedback. Refusals
   paint while the line is open and clear when it closes.
-- There is no inline board capture form. Creation detail lives on the task page;
-  the standalone Capture UI (`AppMode::Capture`, `src/ui/capture.rs`) is a
-  separate surface reached through the host launcher.
+- There is no inline board capture form and no standalone capture-form surface.
+  Creation detail lives on the task page. Quick capture (`tsk capture`,
+  or `TSK_MODE=capture`) runs the same board session seeded onto the expanded
+  quick-add page (title focused, launch card skipped): a persisted save or an
+  explicit discard exits the process (which closes the host popup), and a failed
+  save keeps the draft editable through the usual recovery. The host launcher opens
+  it as a fixed-size popup below the wide threshold (`scripts/open-capture.sh`);
+  the legacy Capture form module (`src/ui/capture.rs`) is no longer reachable from
+  the binary.
 - Below 110 columns, row click peeks, clicking the same row again closes peek, and
   a fast double-click opens the page. At wide widths there is no peek: a board or rail
   row click selects it in place (a rail click lands the board in stage A), and a fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+Quick capture opens the expanded quick-add page in a herdr popup instead of the old
+capture form. It is the same page as `+` then `Tab` on the board, opening with the
+cursor in Title: scope and selected-text prefill from the focused pane, `Shift+Enter`
+saves and closes the popup, `Esc` cancels and closes without creating a task, and a
+failed save keeps the draft editable with retry/cancel. `tsk capture` (or
+`TSK_MODE=capture`) opens the same page.
+
 Thread names accept dots (`v0.0.6`). A refusal names the rule instead of `invalid thread name`.
 
 Expanded quick-add can set thread and add steps. Enter on a new step saves it and opens the next empty row; Shift+Enter saves the step and the task-edit session. An empty new-step row discards if you click elsewhere. Deleting a task asks `press ctrl+x again to delete` first.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It ships as a [herdr](https://herdr.dev) plugin, and the `tsk` binary also runs
 standalone against `~/.tsk`.
 
 - Queue board with desk, a selected project, a projects index, and cross-project thread views
-- Quick-add on the board, plus a herdr capture overlay
+- Quick-add on the board, plus a herdr quick-capture popup
 - Task page for notes, thread, scope, and steps
 - Headless `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`
 

--- a/scripts/open-capture.sh
+++ b/scripts/open-capture.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# Quick-capture launcher: short-lived popup (overlay) in capture mode.
+# Quick-capture launcher: short-lived popup holding the expanded quick-add page.
 #
-# Opens the board entrypoint as an overlay and sets TSK_MODE=capture so
-# the binary can enter Capture UI without first opening a persistent split board.
-# Capture surfaces are short-lived. Board focus idempotency is in open-board.sh.
+# Opens the board entrypoint as a fixed-size popup (width/height in cells) and sets
+# TSK_MODE=capture so the binary seeds the capture session: the task page with the
+# cursor in Title. Saving or discarding the draft exits the process, which closes the
+# popup; a single Esc discards. Board focus idempotency is in open-board.sh.
+#
+# 80x15 content keeps the popup inside the compact board's operable range (40x10
+# floor) and below the 110-column wide threshold, so no stage rail is offered.
 #
 # herdr injects $HERDR_BIN_PATH; fall back to `herdr` on PATH.
 set -uo pipefail
@@ -15,6 +19,8 @@ entrypoint="board"
 exec "$herdr_bin" plugin pane open \
   --plugin "$plugin_id" \
   --entrypoint "$entrypoint" \
-  --placement overlay \
+  --placement popup \
+  --width 80 \
+  --height 15 \
   --focus \
   --env TSK_MODE=capture

--- a/site/src/content/docs/docs/capture.md
+++ b/site/src/content/docs/docs/capture.md
@@ -1,6 +1,6 @@
 ---
 title: Capture
-description: Quick-add on the board, title tokens, and the capture overlay.
+description: Quick-add on the board, title tokens, and the herdr quick-capture popup.
 ---
 
 Press `+` for a one-line title on the status-row slot. The list stays visible. Its
@@ -46,24 +46,24 @@ error code `project-archived`.
 
 ## Quick capture (herdr)
 
-**Quick capture** opens the capture form as a short-lived overlay, without first
-opening a split board:
+**Quick capture** opens the expanded quick-add page in a short-lived popup, without
+first opening a split board:
 
 ```bash
 herdr plugin action invoke quick-capture --plugin herdr-tsk
 ```
 
-Tab through Title, Notes, Thread, Scope. `Enter` in Title or Thread saves. `Enter`
-in Notes inserts a line. `Ctrl+Enter` saves from Title, Notes, or Thread, with
-`Alt+Enter` as the legacy-terminal fallback; on Scope, plain `Enter` saves. `Esc`
-cancels and leaves.
+It is the same expanded page you get with `+` then `Tab` on the board, but it opens
+with the cursor in Title. Type the title on the page header, notes under it; thread
+and `+ step` are on the page. `Shift+Enter` saves and closes the popup. `Esc` cancels:
+one press discards the draft and closes the popup without creating a task. If the
+save fails, the popup stays open with the draft editable and the usual retry/cancel
+recovery.
 
-If text is selected in the pane you invoked it from, it arrives as the title.
-
-Scope is three chips: **This project** (the repo the focused pane is in; marked
-unavailable outside one), **Desk**, and **Other…**, which discloses a path field.
-`1` `2` `3` pick a chip, `s` or `Space` cycles, `p` or `e` edits the path and `Enter`
-confirms it. Refusals paint in the card: `Title required`, or a thread rule (`thread must start with a letter or number`, `thread: use letters, numbers, hyphens, and dots`, `thread is at most 32 characters`).
+If text is selected in the pane you invoked it from, it arrives as the title. Scope
+defaults to the repo of the focused pane, or the desk outside one; change it on the
+page's scope field, or with `!p` tokens in the title. An archived project is never
+a default: the draft falls back to the desk.
 
 An idle board watching the same `~/.tsk` picks up the new task on the next tick.
 
@@ -72,3 +72,9 @@ An idle board watching the same `~/.tsk` picks up the new task on the next tick.
 From the `+` line, `Tab` opens the task page in notes edit because a draft has
 nothing to view yet. Thread and `+ step` are on that page. `Esc` returns to the
 line. A second `Tab` restores what you typed.
+
+The mouse wheel and page scrollbar can reach `+ step` below long notes without
+leaving the draft. Typing or moving the Notes cursor brings it back into view.
+
+In the capture popup, clicking Title or Notes places the cursor at the clicked
+character, including wrapped and scrolled note lines.

--- a/site/src/content/docs/docs/capture.md
+++ b/site/src/content/docs/docs/capture.md
@@ -78,3 +78,6 @@ leaving the draft. Typing or moving the Notes cursor brings it back into view.
 
 In the capture popup, clicking Title or Notes places the cursor at the clicked
 character, including wrapped and scrolled note lines.
+
+The page scrollbar also works while a new step is being typed. A field click
+that refuses to leave an unfinished step keeps that step’s cursor unchanged.

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -33,7 +33,7 @@ The repo ships the same rules as an agent skill in
 | Command | Does |
 | --- | --- |
 | `tsk` | opens the board |
-| `tsk capture` | opens the capture form (also `TSK_MODE=capture`) |
+| `tsk capture` | opens quick capture: the expanded quick-add page (also `TSK_MODE=capture`) |
 | `tsk add` · `tsk list` · `tsk steps` · `tsk status` · `tsk edit` · `tsk trash` · `tsk archive` · `tsk unarchive` · `tsk project` | headless; below |
 | `tsk --help` | usage, exit 0 |
 | `tsk --find-board-pane` | herdr helper: reads `pane list` JSON on stdin, prints the id of the pane labelled `tsk`; exit 1 when none |

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -8,7 +8,7 @@ work on one board and move it through human status: ready, started, blocked,
 review, done.
 
 It ships as the herdr plugin `herdr-tsk`. The `tsk` binary also runs standalone
-against `~/.tsk`. The pane, the capture overlay, and the CLI edit the same store.
+against `~/.tsk`. The pane, the quick-capture popup, and the CLI edit the same store.
 
 This site is the user guide.
 
@@ -31,7 +31,7 @@ progress. They are not in the current build.
 - Keep a queue with **desk**, a selected project board, and a **projects** index.
   The desk is your own planning space: general to-dos, future projects, anything outside
   a repository. The projects index can show a flat cross-project thread.
-- Capture with `+` on the board, or a herdr overlay
+- Capture with `+` on the board, or the herdr quick-capture popup
 - Open a task page for title, notes, thread, scope, and steps
 - Script the same store with `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`
 

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -73,8 +73,8 @@ herdr plugin action invoke open-board --plugin herdr-tsk
 It opens a **tsk** split beside the current pane. Invoke it again to focus the
 board you already have.
 
-**Quick capture** opens the capture form without a persistent board. Selected text
-in the focused pane becomes the title:
+**Quick capture** opens the expanded quick-add page in a short-lived popup, without
+a persistent board. Selected text in the focused pane becomes the title:
 
 ```bash
 herdr plugin action invoke quick-capture --plugin herdr-tsk

--- a/site/src/content/docs/docs/keys.md
+++ b/site/src/content/docs/docs/keys.md
@@ -133,19 +133,16 @@ Backspace, and paste.
 | `?` help | `↑` `↓`, `j` `k`, page keys, wheel scroll · `Esc`, `?`, or `q` close |
 | save failed | `r` or `Enter` retry · `c` or `Esc` cancel |
 
-## Capture line and form
+## Quick-add and quick capture
 
 | Key | Does |
 | --- | --- |
-| `Tab` / `Shift+Tab` | Title, Notes, Thread, Scope |
-| `Enter` in Title or Thread | save |
-| `Enter` in Notes | new line |
-| `Ctrl+Enter` in Title, Notes, or Thread | save (`Alt+Enter` is the legacy-terminal fallback) |
-| `1` `2` `3` on Scope | this project · desk · other path |
-| `s`, `Space`, `←` `→` on Scope | cycle the scope |
-| `p` or `e` on Scope | type another path; `Enter` confirms it |
-| `Enter` on Scope | save |
-| `Esc` | cancel |
+| `Enter` on the `+` line | save and close |
+| `Shift+Enter` on the `+` line | save and stay open |
+| `Tab` on the `+` line | expand onto the task page (notes edit) |
+| `Esc` | close the line, or return to it from the expanded page |
 
-On the board `+` line: `Enter` saves and closes, `Shift+Enter` saves and stays
-open, `Tab` expands onto the task page.
+The herdr quick-capture popup is that expanded page with the cursor in Title:
+`Shift+Enter` saves and closes the popup, `Esc` cancels and closes in one press. A
+failed save keeps the draft editable with retry/cancel. Editing keys are the task
+page's and the shared text-field set above.

--- a/site/src/content/docs/docs/task-page.md
+++ b/site/src/content/docs/docs/task-page.md
@@ -49,7 +49,9 @@ discards if you click elsewhere. Field `Esc` cancels that
 field, while Esc from task editing restores staged removals.
 
 Notes are multiline, so `Enter` inserts a line. `Shift+Enter` saves and does not
-insert a line.
+insert a line. Mouse-wheel scrolling and the page scrollbar work during field editing,
+so long notes do not hide `+ step`. Scrolling leaves the draft intact; typing or
+moving the Notes cursor brings it back into view.
 
 Thread uses the same name rules as capture `!t`. The field is optional.
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -331,7 +331,7 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
             <article class="pillar">
               <h3>One store. Everyone at the table.</h3>
               <p>
-                You, herdr's quick-capture overlay, and your agents edit the same
+                You, herdr's quick-capture popup, and your agents edit the same
                 <code>~/.tsk</code>. An agent drops a plan in as JSON and the board shows it on
                 the next tick.
               </p>
@@ -516,7 +516,7 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
             <div class="key" role="listitem"><span class="caps"><kbd>Esc</kbd></span><span>close one layer</span></div>
           </div>
           <p class="keynote">
-            Full chord tables for the board, task page, and capture form live in the
+            Full chord tables for the board, task page, and quick capture live in the
             <a href="/docs/keys/">keys reference</a>.
           </p>
         </div>

--- a/src/app.rs
+++ b/src/app.rs
@@ -346,7 +346,7 @@ fn run_board_loop(
     let mut store_watch = StoreWatch::seeded(&store);
     // Focusing an existing plugin pane cannot refresh its inherited host environment. The
     // launcher publishes a one-shot request in the state dir, consumed only on idle ticks.
-    let mut reopen_watch = ReopenWatch::seeded(&store);
+    let mut reopen_watch = (!quick_capture).then(|| ReopenWatch::seeded(&store));
     // the board frame path does no host polling and does not
     // auto-open the walkthrough on launch. `load_board` is the whole open path; the first
     // paint below is of that model, unrefreshed. attention polling (removed),
@@ -419,7 +419,9 @@ fn run_board_loop(
                     drag_gesture.has_autoscroll(),
                 )?;
                 if poll == FramePoll::Idle {
-                    apply_reopen_request(&mut model, &mut reopen_watch, &save_recovery);
+                    if let Some(watch) = reopen_watch.as_mut() {
+                        apply_reopen_request(&mut model, watch, &save_recovery);
+                    }
                     if let Some(auto) = drag_gesture.autoscroll() {
                         let area = terminal_area(terminal)?;
                         let content = drag_content_area(&model, area);
@@ -3711,6 +3713,10 @@ mod tests {
             .collect();
         let frame_text = rows.join("\n");
         assert!(
+            frame_text.contains("+ step"),
+            "expanded page must paint its step target"
+        );
+        assert!(
             frame_text.contains("Popup paint"),
             "the prefill paints on the page: {frame_text}"
         );
@@ -3788,6 +3794,48 @@ mod tests {
     /// The popup's Esc on the expanded draft is one press: the whole draft is discarded
     /// and the session ends, instead of the board's fallback to the retained one-line
     /// draft.
+    #[test]
+    fn popup_step_escape_keeps_the_parent_draft() {
+        let temp = TempStore::new("popup-step-escape");
+        let snapshot = InvocationSnapshot {
+            default_scope: TaskScope::Global,
+            this_repo: None,
+            title_prefill: Some("retained title".into()),
+            provenance: ProvenanceOrigin::Capture,
+        };
+        let mut domain = DomainState::new();
+        let mut model = BoardModel::from_domain(&domain, None);
+        let mut recovery = SaveRecovery::new();
+        seed_quick_capture(&mut domain, &mut model, &snapshot);
+        for intent in [
+            BoardIntent::BeginAddStep,
+            BoardIntent::EditInsertText("unsaved step".into()),
+        ] {
+            apply_intent(&mut domain, &mut model, intent, None).unwrap();
+        }
+        let intent = crate::ui::input::map_key(
+            model.input_mode(),
+            crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Esc,
+                crossterm::event::KeyModifiers::NONE,
+            ),
+        )
+        .expect("Escape maps");
+        let quit = handle_board_intent(
+            &temp.store,
+            &mut domain,
+            &mut model,
+            intent,
+            &mut recovery,
+            true,
+        )
+        .unwrap();
+        assert!(!quit);
+        assert!(model.expanded_capture_open());
+        assert_eq!(model.quick_add_title_value(), "retained title");
+        assert!(!quick_capture_finished(&model));
+    }
+
     #[test]
     fn quick_capture_esc_on_the_expanded_draft_closes_the_popup_in_one_press() {
         let temp = TempStore::new("quick-capture-popup-esc");

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,18 +20,15 @@ use crate::ui::board::{
     apply_intent, board_intent_may_persist, draw_board, resolve_board_command, BoardInputMode,
     BoardModel, IntentOutcome, ProjectsView, SaveResolution, WalkthroughOutcome,
 };
-use crate::ui::capture::{
-    apply_capture_intent, draw_capture, CaptureModel, CaptureOutcome, TITLE_REQUIRED_MESSAGE,
-};
+use crate::ui::capture::{CaptureField, TITLE_REQUIRED_MESSAGE};
 use crate::ui::input::{
-    map_capture_key_state, map_capture_paste_state, map_edit_paste, map_key, map_task_form_key,
-    route_responsive_key, BoardIntent, CaptureIntent, ResponsiveKeyRoute,
+    map_edit_paste, map_key, map_task_form_key, route_responsive_key, BoardIntent,
+    ResponsiveKeyRoute,
 };
 use crate::ui::mouse::{
-    capture_layout_for_model, enable_terminal_input, focused_mouse_area,
-    keyboard_enhancement_supported, map_capture_mouse, map_responsive_board_mouse,
-    map_scrollbar_mouse, press_on_focused_surface, scrollbar_hit_at, wide_mouse_focus_intent,
-    ScrollbarMouse,
+    enable_terminal_input, focused_mouse_area, keyboard_enhancement_supported,
+    map_responsive_board_mouse, map_scrollbar_mouse, press_on_focused_surface, scrollbar_hit_at,
+    wide_mouse_focus_intent, ScrollbarMouse,
 };
 use crate::ui::queue::NavTab;
 use crate::ui::scheduler;
@@ -39,15 +36,16 @@ use crate::ui::text_select::{
     copy_to_clipboard, copyable_line_at, frame_text_rows, selection_text,
 };
 
-/// Env var set by open-capture launcher for Capture UI mode.
+/// Env var set by open-capture launcher for the quick-capture popup session.
 pub const MODE_ENV: &str = "TSK_MODE";
 
-/// One binary, two modes (Board default; Capture for quick-capture).
+/// One binary, two modes (Board default; Capture is quick capture: the board session
+/// seeded onto the expanded quick-add page).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppMode {
     /// Primary Tasks board.
     Board,
-    /// Capture UI form.
+    /// Quick-capture popup (expanded quick-add page).
     Capture,
 }
 
@@ -87,11 +85,28 @@ fn load_snapshot() -> InvocationSnapshot {
 
 /// Load store + snapshot into domain and board view-model (no TTY).
 pub fn load_board() -> Result<(TaskStore, DomainState, BoardModel), Box<dyn Error>> {
+    load_board_inner(true)
+}
+
+/// Load store + snapshot for the quick-capture popup (no TTY).
+///
+/// The launch card is a board-open concern; the popup opens straight onto the draft
+/// page, and its archived-project scope fallback happens when the draft opens.
+pub fn load_board_for_quick_capture() -> Result<(TaskStore, DomainState, BoardModel), Box<dyn Error>>
+{
+    load_board_inner(false)
+}
+
+fn load_board_inner(
+    offer_launch_card: bool,
+) -> Result<(TaskStore, DomainState, BoardModel), Box<dyn Error>> {
     let store = TaskStore::new(default_state_dir());
     let state = store.load()?;
     let snapshot = load_snapshot();
     let mut model = BoardModel::from_domain(&state, snapshot.this_repo.clone());
-    model.offer_launch_card(&state, &snapshot);
+    if offer_launch_card {
+        model.offer_launch_card(&state, &snapshot);
+    }
     Ok((store, state, model))
 }
 
@@ -264,7 +279,8 @@ pub fn load_board_model() -> Result<BoardModel, Box<dyn Error>> {
 
 /// Binary entry used by `main`. Default mode is the Tasks board.
 ///
-/// Pass `capture` argv (or `TSK_MODE=capture`) for popup-style Capture UI.
+/// Pass `capture` argv (or `TSK_MODE=capture`) for the quick-capture popup: the board
+/// session seeded onto the expanded quick-add page (exits after save or cancel).
 pub fn run(args: impl IntoIterator<Item = impl AsRef<str>>) -> Result<(), Box<dyn Error>> {
     match resolve_mode(args) {
         AppMode::Board => run_board(),
@@ -272,27 +288,58 @@ pub fn run(args: impl IntoIterator<Item = impl AsRef<str>>) -> Result<(), Box<dy
     }
 }
 
-/// Standalone capture mode: form loop, exit after save or cancel (popup-style).
-fn run_capture() -> Result<(), Box<dyn Error>> {
-    let store = TaskStore::new(default_state_dir());
-    let mut domain = store.load()?;
-    let snapshot = load_snapshot();
-    let mut model = CaptureModel::from_snapshot(&snapshot);
-    // AC-39: an archived invocation repository is not on offer as a scope.
-    model.mark_archived_projects(&domain.archived_projects());
+/// Seed the quick-capture session onto the expanded quick-add page.
+///
+/// These are the same intents the board routes for `+` then `Tab`, plus one: `OpenCapture`
+/// stages the line from the invocation snapshot (scope and selected-text prefill) and
+/// `ExpandQuickAdd` lifts it onto the task page with Notes focused, then `FocusFormField`
+/// moves the cursor to Title so a name can be typed immediately. Neither of the first two
+/// intents has a failure mode; their Results exist for the mutating arms the shared reducer
+/// serves.
+pub fn seed_quick_capture(
+    domain: &mut DomainState,
+    model: &mut BoardModel,
+    snapshot: &InvocationSnapshot,
+) {
+    let _ = apply_intent(domain, model, BoardIntent::OpenCapture, Some(snapshot));
+    let _ = apply_intent(domain, model, BoardIntent::ExpandQuickAdd, None);
+    let _ = apply_intent(
+        domain,
+        model,
+        BoardIntent::FocusFormField(CaptureField::Title),
+        None,
+    );
+}
 
-    // Query before the alternate screen is entered: it can block on a terminal round-trip,
-    // and a blank alternate screen is what the user would be staring at meanwhile.
-    let keyboard_enhancement = keyboard_enhancement_supported();
-    ratatui::run(|terminal| -> io::Result<()> {
-        let _input = enable_terminal_input(keyboard_enhancement)?;
-        capture_form_loop(terminal, &store, &mut domain, &snapshot, &mut model)
-    })?;
-    Ok(())
+/// Whether the quick-capture popup session has ended: the draft is gone because a save
+/// persisted or the user discarded it. Every other state -- editing, refusals, save
+/// recovery, the retained line stash behind an expanded page -- keeps the popup open.
+pub fn quick_capture_finished(model: &BoardModel) -> bool {
+    !model.quick_add_open() && !model.board_form_open()
+}
+
+/// Quick capture: the board session seeded onto the expanded quick-add page.
+///
+/// The popup lives exactly as long as that draft: a persisted save closes it, an
+/// explicit discard closes it, and a failed save keeps it open in recovery.
+fn run_capture() -> Result<(), Box<dyn Error>> {
+    let (store, mut domain, mut model) = load_board_for_quick_capture()?;
+    let snapshot = load_snapshot();
+    seed_quick_capture(&mut domain, &mut model, &snapshot);
+    run_board_loop(store, domain, model, true)
 }
 
 fn run_board() -> Result<(), Box<dyn Error>> {
-    let (store, mut domain, mut model) = load_board()?;
+    let (store, domain, model) = load_board()?;
+    run_board_loop(store, domain, model, false)
+}
+
+fn run_board_loop(
+    store: TaskStore,
+    mut domain: DomainState,
+    mut model: BoardModel,
+    quick_capture: bool,
+) -> Result<(), Box<dyn Error>> {
     let walkthrough = WalkthroughRecord::new(default_config_dir());
     // `load_board` just read the store, so seed the watch from that snapshot: the first idle
     // tick must not immediately re-merge what is already loaded.
@@ -418,6 +465,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                         &mut model,
                         intent,
                         &mut save_recovery,
+                        quick_capture,
                     )? {
                         break;
                     }
@@ -445,6 +493,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                                 model,
                                 focus,
                                 &mut save_recovery,
+                                quick_capture,
                             )
                         },
                     )?;
@@ -461,6 +510,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                                 &mut model,
                                 intent,
                                 &mut save_recovery,
+                                quick_capture,
                             )? {
                                 break;
                             }
@@ -605,6 +655,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                                 model,
                                 focus,
                                 &mut save_recovery,
+                                quick_capture,
                             )
                         },
                     )?;
@@ -620,6 +671,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                         &mut model,
                         intent,
                         &mut save_recovery,
+                        quick_capture,
                     )? {
                         break;
                     }
@@ -635,6 +687,7 @@ fn run_board() -> Result<(), Box<dyn Error>> {
                         &mut model,
                         intent,
                         &mut save_recovery,
+                        quick_capture,
                     )? {
                         break;
                     }
@@ -1362,17 +1415,6 @@ fn board_mouse_intent(
     resolve_board_command(model, intent)
 }
 
-/// Route a bracketed paste to the Capture intent the focused field accepts.
-///
-/// An unresolved save owns the form until Retry or Cancel, exactly as for a key press, so a
-/// paste is inert there rather than editing a draft the form is not accepting.
-fn capture_paste_intent(model: &CaptureModel, text: &str) -> Option<CaptureIntent> {
-    if model.is_save_recovery() {
-        return None;
-    }
-    map_capture_paste_state(model.focused(), model.is_path_editing(), text)
-}
-
 /// Apply one board intent and present any refusal instead of discarding it.
 ///
 /// A refused intent changes nothing: an open edit keeps its mode, its draft, and its cursor,
@@ -1518,16 +1560,38 @@ fn copy_task_number_with(
 }
 
 /// Apply a board intent. Returns `true` when the board loop should quit.
+///
+/// In the quick-capture popup (`quick_capture`), the loop also quits once the capture
+/// session has ended: the single choke point every key, mouse, and paste dispatch
+/// passes through, so a persisted save or a discard closes the popup no matter which
+/// route ended the draft.
 fn handle_board_intent(
     store: &TaskStore,
     domain: &mut DomainState,
     model: &mut BoardModel,
     intent: BoardIntent,
     save_recovery: &mut SaveRecovery<DomainState>,
+    quick_capture: bool,
 ) -> io::Result<bool> {
     if let BoardIntent::CopyTaskNumber(id) = intent {
         copy_task_number(domain, model, id);
         return Ok(false);
+    }
+
+    // Quick capture: Esc on the expanded draft is the top-level cancel. The board's
+    // collapse-to-line fallback would strand the popup on a retained one-line draft, so
+    // the whole draft is discarded and the popup closes. Nested Escapes keep their own
+    // semantics: an open scope dropdown maps to CancelFormScopeDropdown, the inline step
+    // editor owns its CancelEdit, and an unresolved save routes Esc to CancelSave before
+    // this dispatch.
+    if quick_capture
+        && intent == BoardIntent::CancelEdit
+        && !save_recovery.is_pending()
+        && model.expanded_capture_open()
+        && model.input_mode() != BoardInputMode::EditStep
+    {
+        let _ = apply_intent(domain, model, BoardIntent::CancelQuickAdd, None);
+        return Ok(true);
     }
 
     let baseline = if save_recovery.is_pending() || !board_intent_may_persist(&intent) {
@@ -1572,76 +1636,12 @@ fn handle_board_intent(
         },
     ) {
         IntentOutcome::Quit => Ok(true),
-        IntentOutcome::Persist | IntentOutcome::Persisted => Ok(false),
-        IntentOutcome::None => Ok(false),
+        IntentOutcome::Persist | IntentOutcome::Persisted | IntentOutcome::None => {
+            Ok(quick_capture && quick_capture_finished(model))
+        }
     }
 }
 
-/// Run the capture form until save/cancel.
-///
-/// Standalone capture mode: caller exits the process after this returns (popup closes).
-/// Board-initiated: caller resumes the board loop (same process).
-fn capture_form_loop(
-    terminal: &mut DefaultTerminal,
-    store: &TaskStore,
-    domain: &mut DomainState,
-    snapshot: &InvocationSnapshot,
-    model: &mut CaptureModel,
-) -> io::Result<()> {
-    loop {
-        terminal.draw(|frame| draw_capture(frame, model))?;
-        if !event::poll(Duration::from_millis(250))? {
-            continue;
-        }
-        match event::read()? {
-            Event::Key(key) if key.kind == KeyEventKind::Press => {
-                let Some(intent) = map_capture_key_state(
-                    model.focused(),
-                    model.is_path_editing(),
-                    model.is_save_recovery(),
-                    key,
-                ) else {
-                    continue;
-                };
-                match apply_capture_intent(domain, Some(store), snapshot, model, intent) {
-                    Ok(CaptureOutcome::Saved(_)) | Ok(CaptureOutcome::Cancelled) => break,
-                    Ok(CaptureOutcome::None) => {}
-                    Err(e) => {
-                        // Persist/domain failures after validation: abort form with error.
-                        return Err(io::Error::other(e.to_string()));
-                    }
-                }
-            }
-            Event::Mouse(mouse) => {
-                let area = terminal_area(terminal)?;
-                // One Capture geometry for renderer and live dispatch: scope controls and the
-                // disclosed path row must be clickable exactly where they are painted.
-                let layout = capture_layout_for_model(area, model);
-                let Some(intent) = map_capture_mouse(&layout, mouse) else {
-                    continue;
-                };
-                match apply_capture_intent(domain, Some(store), snapshot, model, intent) {
-                    Ok(CaptureOutcome::Saved(_)) | Ok(CaptureOutcome::Cancelled) => break,
-                    Ok(CaptureOutcome::None) => {}
-                    Err(e) => return Err(io::Error::other(e.to_string())),
-                }
-            }
-            Event::Paste(text) => {
-                let Some(intent) = capture_paste_intent(model, &text) else {
-                    continue;
-                };
-                match apply_capture_intent(domain, Some(store), snapshot, model, intent) {
-                    Ok(CaptureOutcome::Saved(_)) | Ok(CaptureOutcome::Cancelled) => break,
-                    Ok(CaptureOutcome::None) => {}
-                    Err(e) => return Err(io::Error::other(e.to_string())),
-                }
-            }
-            Event::Resize(_, _) => {}
-            _ => {}
-        }
-    }
-    Ok(())
-}
 #[cfg(test)]
 mod save_recovery_tests {
     use super::{apply_reopen_request, board_background_work_allowed};
@@ -2290,8 +2290,8 @@ mod tests {
     use crate::context::InvocationSnapshot;
     use crate::domain::{HumanStatus, ProvenanceOrigin, TaskScope};
     use crate::ui::board::{board_hit_map, CommandSurface};
-    use crate::ui::capture::CaptureField;
-    use crate::ui::input::{map_key, CaptureIntent};
+    use crate::ui::capture::{apply_capture_intent, CaptureField, CaptureModel};
+    use crate::ui::input::{map_capture_paste_state, map_key, CaptureIntent};
     use crate::ui::mouse::{
         focused_mouse_area, left_click, map_board_mouse, map_responsive_board_mouse,
         press_on_focused_surface,
@@ -3181,6 +3181,7 @@ mod tests {
             &mut model,
             BoardIntent::CopyTaskNumber(id),
             &mut recovery,
+            false,
         )
         .expect("copy intent");
 
@@ -3226,6 +3227,7 @@ mod tests {
             &mut model,
             BoardIntent::ConfirmEditNext,
             &mut recovery,
+            false,
         )
         .expect("real shift-enter save");
         assert_eq!(
@@ -3268,6 +3270,7 @@ mod tests {
             &mut model,
             BoardIntent::OpenCapture,
             &mut save_recovery,
+            false,
         )
         .expect("open capture");
         assert!(!quit);
@@ -3281,6 +3284,7 @@ mod tests {
                 &mut model,
                 BoardIntent::QuickAddInsert(ch),
                 &mut save_recovery,
+                false,
             )
             .expect("type title");
         }
@@ -3292,6 +3296,7 @@ mod tests {
             &mut model,
             BoardIntent::QuickAddSave,
             &mut save_recovery,
+            false,
         )
         .expect("save quick add");
         assert!(!quit);
@@ -3642,6 +3647,281 @@ mod tests {
         assert_eq!(model.input_mode(), BoardInputMode::Normal);
         assert!(!model.board_form_open());
         assert_eq!(model.selected_id(), Some(id));
+    }
+
+    /// Quick capture (prefix+c) seeds the popup with the expanded quick-add page and the
+    /// cursor in Title, snapshot defaults intact. The board's `+` then `Tab` keeps its
+    /// Notes focus; the popup opens on the title so a name can be typed immediately.
+    #[test]
+    fn quick_capture_seeds_the_expanded_draft_page_with_snapshot_defaults() {
+        let snapshot = InvocationSnapshot {
+            default_scope: TaskScope::Global,
+            this_repo: None,
+            title_prefill: Some("Popup draft".into()),
+            provenance: ProvenanceOrigin::Selection,
+        };
+        let mut domain = DomainState::new();
+        let mut model = BoardModel::from_domain(&domain, None);
+        seed_quick_capture(&mut domain, &mut model, &snapshot);
+
+        assert_eq!(model.quick_add_title_value(), "Popup draft");
+        assert_eq!(model.form_focus(), Some(CaptureField::Title));
+        assert_eq!(
+            model.input_mode(),
+            BoardInputMode::EditTitle,
+            "the popup opens with the cursor in the title"
+        );
+        assert!(model.board_form_open(), "the expanded page owns the popup");
+        assert!(!quick_capture_finished(&model), "the session is live");
+        assert!(domain.tasks().is_empty(), "seeding never creates a task");
+    }
+
+    /// The popup frame is the task-page takeover painting the expanded draft, not the
+    /// legacy capture form card.
+    #[test]
+    fn quick_capture_popup_paints_the_task_page_takeover() {
+        let snapshot = InvocationSnapshot {
+            default_scope: TaskScope::Global,
+            this_repo: None,
+            title_prefill: Some("Popup paint".into()),
+            provenance: ProvenanceOrigin::Capture,
+        };
+        let mut domain = DomainState::new();
+        let mut model = BoardModel::from_domain(&domain, None);
+        seed_quick_capture(&mut domain, &mut model, &snapshot);
+
+        // Also cover a smaller 50x16 viewport above the compact board's
+        // 40x10 operable floor, so the takeover stays readable there.
+        let width = 50u16;
+        let height = 16u16;
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| {
+                crate::ui::board::draw_board(frame, &model);
+            })
+            .expect("draw popup frame");
+        let buffer = terminal.backend().buffer().clone();
+        let rows: Vec<String> = (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer.cell((x, y)).expect("cell").symbol())
+                    .collect()
+            })
+            .collect();
+        let frame_text = rows.join("\n");
+        assert!(
+            frame_text.contains("Popup paint"),
+            "the prefill paints on the page: {frame_text}"
+        );
+        assert!(
+            frame_text.contains("desk"),
+            "the snapshot's default destination paints: {frame_text}"
+        );
+    }
+
+    #[test]
+    fn quick_capture_save_persists_and_ends_the_popup_session() {
+        let temp = TempStore::new("quick-capture-popup-save");
+        let snapshot = InvocationSnapshot {
+            default_scope: TaskScope::Global,
+            this_repo: None,
+            title_prefill: Some("Popup saved task".into()),
+            provenance: ProvenanceOrigin::Capture,
+        };
+        let mut domain = DomainState::new();
+        let mut model = BoardModel::from_domain(&domain, None);
+        let mut recovery = SaveRecovery::new();
+        seed_quick_capture(&mut domain, &mut model, &snapshot);
+
+        let outcome = apply_board_intent_with_save_recovery(
+            &mut domain,
+            &mut model,
+            &mut recovery,
+            BoardSaveContext {
+                baseline: DomainState::new(),
+                intent: BoardIntent::ConfirmEdit,
+                snapshot: Some(&snapshot),
+            },
+            |working| {
+                temp.store
+                    .reload_merge_save(working)
+                    .map_err(|e| e.to_string())
+            },
+        )
+        .expect("save the popup draft");
+
+        assert_eq!(outcome, IntentOutcome::Persisted);
+        assert!(!recovery.is_pending());
+        assert!(
+            quick_capture_finished(&model),
+            "a persisted save closes the popup"
+        );
+        assert_eq!(temp.store.load().expect("reload").tasks().len(), 1);
+    }
+
+    #[test]
+    fn quick_capture_cancel_closes_without_creating_a_task() {
+        let snapshot = InvocationSnapshot {
+            default_scope: TaskScope::Global,
+            this_repo: None,
+            title_prefill: Some("Popup cancelled".into()),
+            provenance: ProvenanceOrigin::Capture,
+        };
+        let mut domain = DomainState::new();
+        let mut model = BoardModel::from_domain(&domain, None);
+        seed_quick_capture(&mut domain, &mut model, &snapshot);
+
+        // Esc first returns to the retained one-line draft (the board's existing flow).
+        apply_intent(&mut domain, &mut model, BoardIntent::CancelEdit, None)
+            .expect("cancel the page back to the line");
+        assert!(!quick_capture_finished(&model), "the line is still open");
+        assert!(domain.tasks().is_empty());
+
+        // Second Esc discards the line and ends the session.
+        apply_intent(&mut domain, &mut model, BoardIntent::CancelQuickAdd, None)
+            .expect("discard the draft line");
+        assert!(quick_capture_finished(&model), "cancel closes the popup");
+        assert!(domain.tasks().is_empty(), "cancel creates nothing");
+    }
+
+    /// The popup's Esc on the expanded draft is one press: the whole draft is discarded
+    /// and the session ends, instead of the board's fallback to the retained one-line
+    /// draft.
+    #[test]
+    fn quick_capture_esc_on_the_expanded_draft_closes_the_popup_in_one_press() {
+        let temp = TempStore::new("quick-capture-popup-esc");
+        let snapshot = InvocationSnapshot {
+            default_scope: TaskScope::Global,
+            this_repo: None,
+            title_prefill: Some("Popup esc".into()),
+            provenance: ProvenanceOrigin::Capture,
+        };
+        let mut domain = DomainState::new();
+        let mut model = BoardModel::from_domain(&domain, None);
+        let mut recovery = SaveRecovery::new();
+        seed_quick_capture(&mut domain, &mut model, &snapshot);
+
+        let quit = handle_board_intent(
+            &temp.store,
+            &mut domain,
+            &mut model,
+            BoardIntent::CancelEdit,
+            &mut recovery,
+            true,
+        )
+        .expect("cancel the popup draft");
+
+        assert!(quit, "one Esc closes the popup");
+        assert!(
+            quick_capture_finished(&model),
+            "the expanded page and the retained line are both gone"
+        );
+        assert!(domain.tasks().is_empty(), "Esc creates nothing");
+    }
+
+    /// The board keeps its two-press Esc: the expanded page falls back to the retained
+    /// one-line draft, only the second press discards it, and no cancel quits the board.
+    #[test]
+    fn board_esc_from_the_expanded_page_still_returns_to_the_retained_line() {
+        let temp = TempStore::new("board-expanded-esc");
+        let snapshot = InvocationSnapshot {
+            default_scope: TaskScope::Global,
+            this_repo: None,
+            title_prefill: Some("Board esc".into()),
+            provenance: ProvenanceOrigin::Capture,
+        };
+        let mut domain = DomainState::new();
+        let mut model = BoardModel::from_domain(&domain, None);
+        let mut recovery = SaveRecovery::new();
+        seed_quick_capture(&mut domain, &mut model, &snapshot);
+
+        let quit = handle_board_intent(
+            &temp.store,
+            &mut domain,
+            &mut model,
+            BoardIntent::CancelEdit,
+            &mut recovery,
+            false,
+        )
+        .expect("cancel the page");
+
+        assert!(!quit);
+        assert!(model.quick_add_open(), "the one-line draft is retained");
+        assert!(
+            model.board_form_open(),
+            "the page stays stashed so Tab can restore it"
+        );
+        assert_eq!(model.input_mode(), BoardInputMode::QuickAdd);
+
+        let quit = handle_board_intent(
+            &temp.store,
+            &mut domain,
+            &mut model,
+            BoardIntent::CancelQuickAdd,
+            &mut recovery,
+            false,
+        )
+        .expect("discard the line");
+        assert!(!quit, "a draft cancel never quits the board");
+        assert!(domain.tasks().is_empty());
+    }
+
+    #[test]
+    fn quick_capture_failed_save_keeps_the_editable_draft_in_recovery() {
+        let snapshot = InvocationSnapshot {
+            default_scope: TaskScope::Global,
+            this_repo: None,
+            title_prefill: Some("Popup recovery".into()),
+            provenance: ProvenanceOrigin::Capture,
+        };
+        let mut domain = DomainState::new();
+        let mut model = BoardModel::from_domain(&domain, None);
+        let mut recovery = SaveRecovery::new();
+        seed_quick_capture(&mut domain, &mut model, &snapshot);
+
+        let outcome = apply_board_intent_with_save_recovery(
+            &mut domain,
+            &mut model,
+            &mut recovery,
+            BoardSaveContext {
+                baseline: DomainState::new(),
+                intent: BoardIntent::ConfirmEdit,
+                snapshot: Some(&snapshot),
+            },
+            |_| Err("disk full".to_string()),
+        )
+        .expect("the failed save stays in the popup");
+
+        assert_eq!(outcome, IntentOutcome::None);
+        assert!(recovery.is_pending());
+        assert!(
+            !quick_capture_finished(&model),
+            "a failed save keeps the popup"
+        );
+        assert!(model.board_form_open(), "the draft stays editable");
+
+        // Cancel restores the baseline and returns to the retained line; the session is
+        // still live until the draft itself is discarded.
+        apply_board_intent_with_save_recovery(
+            &mut domain,
+            &mut model,
+            &mut recovery,
+            BoardSaveContext {
+                baseline: DomainState::new(),
+                intent: BoardIntent::CancelSave,
+                snapshot: None,
+            },
+            |working| unreachable!("cancelling recovery never persists: {working:?}"),
+        )
+        .expect("cancel the failed save");
+        assert!(!recovery.is_pending());
+        assert!(!quick_capture_finished(&model));
+        assert!(domain.tasks().is_empty(), "the baseline has no new task");
+
+        apply_intent(&mut domain, &mut model, BoardIntent::CancelQuickAdd, None)
+            .expect("discard the draft line");
+        assert!(quick_capture_finished(&model));
     }
 
     /// Without a snapshot, quick-add save must neither call `capture_save` nor report
@@ -4249,13 +4529,16 @@ mod tests {
         assert_eq!(model.focused(), CaptureField::Scope);
         assert!(model.is_path_editing());
 
-        let intent = capture_paste_intent(&model, "/repos/app").expect("a paste into the path");
+        let intent =
+            map_capture_paste_state(model.focused(), model.is_path_editing(), "/repos/app")
+                .expect("a paste into the path");
         apply_capture_intent(&mut domain, None, &snap, &mut model, intent)
             .expect("insert the paste");
         assert_eq!(model.scope_path_edit(), Some("/repos/app"));
 
         // The path is one line: a pasted break folds to a single space, CRLF included.
-        let intent = capture_paste_intent(&model, "\r\nmore").expect("a paste into the path");
+        let intent = map_capture_paste_state(model.focused(), model.is_path_editing(), "\r\nmore")
+            .expect("a paste into the path");
         apply_capture_intent(&mut domain, None, &snap, &mut model, intent)
             .expect("insert the paste");
         assert_eq!(model.scope_path_edit(), Some("/repos/app more"));
@@ -4278,7 +4561,10 @@ mod tests {
         )
         .expect("focus scope");
         assert!(!model.is_path_editing());
-        assert_eq!(capture_paste_intent(&model, "ignored"), None);
+        assert_eq!(
+            map_capture_paste_state(model.focused(), model.is_path_editing(), "ignored"),
+            None
+        );
     }
 
     /// a Capture paste reaches the focused text field, and nowhere else.
@@ -4297,7 +4583,8 @@ mod tests {
         let mut model = CaptureModel::from_snapshot(&snap);
         assert_eq!(model.focused(), CaptureField::Title);
 
-        let intent = capture_paste_intent(&model, "one\ntwo").expect("a paste into Title");
+        let intent = map_capture_paste_state(model.focused(), model.is_path_editing(), "one\ntwo")
+            .expect("a paste into Title");
         assert_eq!(intent, CaptureIntent::InsertText("one\ntwo".to_string()));
         apply_capture_intent(&mut domain, None, &snap, &mut model, intent)
             .expect("insert the paste");
@@ -4313,7 +4600,10 @@ mod tests {
             CaptureIntent::FocusField(CaptureField::Scope),
         )
         .expect("focus scope");
-        assert_eq!(capture_paste_intent(&model, "ignored"), None);
+        assert_eq!(
+            map_capture_paste_state(model.focused(), model.is_path_editing(), "ignored"),
+            None
+        );
         assert_eq!(model.title(), "one two");
     }
 
@@ -4358,12 +4648,15 @@ mod tests {
         assert!(model.is_save_recovery());
         assert_eq!(model.focused(), CaptureField::Title);
 
+        let intent = map_capture_paste_state(model.focused(), model.is_path_editing(), "pasted")
+            .expect("the paste still routes to the focused field");
+        apply_capture_intent(&mut domain, Some(&store), &snap, &mut model, intent)
+            .expect("recovery answers the paste without editing");
         assert_eq!(
-            capture_paste_intent(&model, "pasted"),
-            None,
+            model.title(),
+            "Pending",
             "recovery accepts only Retry or Cancel, by key or by paste"
         );
-        assert_eq!(model.title(), "Pending");
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,9 @@ pub use board_pane::{find_board_pane_from_stdin, find_board_pane_id};
 
 /// Run the tsk binary entrypoint with argv-style arguments.
 ///
-/// Default mode is the Tasks board. Pass `capture` (or set `TSK_MODE=capture`)
-/// for Capture UI mode (form; exits after save/cancel).
+/// Default mode is the Tasks board. Pass `capture` (or set `TSK_MODE=capture`) for
+/// quick capture: the board session seeded onto the expanded quick-add page (exits
+/// after save or cancel).
 ///
 /// `--find-board-pane` is handled by the binary (`main`) before this entry.
 pub fn run(

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -624,7 +624,12 @@ fn apply_board_intent(
                     .map(|row| row.cursor_at(column))
             });
             model.focus_form_field(field);
-            if let Some(cursor) = cursor {
+            let focused = matches!(
+                (field, model.input_mode),
+                (CaptureField::Title, BoardInputMode::EditTitle)
+                    | (CaptureField::Notes, BoardInputMode::EditNotes)
+            );
+            if let Some(cursor) = cursor.filter(|_| focused) {
                 edit_draft(model, |draft| draft.set_cursor(cursor));
             }
             return Ok(IntentOutcome::None);
@@ -1517,6 +1522,7 @@ fn apply_board_intent(
                 if matches!(
                     model.input_mode,
                     BoardInputMode::TaskPage
+                        | BoardInputMode::EditStep
                         | BoardInputMode::EditTitle
                         | BoardInputMode::EditNotes
                         | BoardInputMode::EditScope

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -146,6 +146,7 @@ fn read_only_focus_refuses(intent: &BoardIntent) -> bool {
             | BoardIntent::FormFocusNext
             | BoardIntent::FormFocusPrev
             | BoardIntent::FocusFormField(_)
+            | BoardIntent::FocusFormCursor(_, _, _)
             | BoardIntent::SelectStep(_)
     )
 }
@@ -608,6 +609,23 @@ fn apply_board_intent(
             } else if model.form.is_some() && model.input_mode != BoardInputMode::FormScopeDropdown
             {
                 model.move_form_focus(false);
+            }
+            return Ok(IntentOutcome::None);
+        }
+        BoardIntent::FocusFormCursor(field, row, column) => {
+            let cursor = model.form.as_ref().and_then(|form| {
+                let (draft, width) = match field {
+                    CaptureField::Title => (&form.title, form.title_wrap_width.get()),
+                    CaptureField::Notes => (&form.notes, form.notes_width.get()),
+                    _ => return None,
+                };
+                crate::ui::edit::wrap_text(draft.value(), width.max(1))
+                    .get(row)
+                    .map(|row| row.cursor_at(column))
+            });
+            model.focus_form_field(field);
+            if let Some(cursor) = cursor {
+                edit_draft(model, |draft| draft.set_cursor(cursor));
             }
             return Ok(IntentOutcome::None);
         }
@@ -1492,11 +1510,20 @@ fn apply_board_intent(
             return Ok(IntentOutcome::None);
         }
         BoardIntent::PageScrollTo(offset) => {
-            if model.focused_surface() != FocusedSurface::Task {
+            if model.focused_surface() != FocusedSurface::Task && !model.expanded_capture_open() {
                 return Ok(IntentOutcome::None);
             }
-            if let Some(form) = model.form.as_mut().filter(|form| form.is_task()) {
-                if model.input_mode == BoardInputMode::TaskPage {
+            if let Some(form) = model.form.as_mut() {
+                if matches!(
+                    model.input_mode,
+                    BoardInputMode::TaskPage
+                        | BoardInputMode::EditTitle
+                        | BoardInputMode::EditNotes
+                        | BoardInputMode::EditScope
+                        | BoardInputMode::EditThread
+                        | BoardInputMode::SelectThread
+                ) {
+                    form.manual_page_scroll = true;
                     let horizon = form.notes_max_scroll.get();
                     form.notes_scroll = offset.min(horizon);
                 }
@@ -1504,14 +1531,21 @@ fn apply_board_intent(
             return Ok(IntentOutcome::None);
         }
         BoardIntent::PageWheelScrollUp | BoardIntent::PageWheelScrollDown => {
-            if model.focused_surface() != FocusedSurface::Task {
+            if model.focused_surface() != FocusedSurface::Task && !model.expanded_capture_open() {
                 return Ok(IntentOutcome::None);
             }
-            if let Some(form) = model.form.as_mut().filter(|form| form.is_task()) {
+            if let Some(form) = model.form.as_mut() {
                 if matches!(
                     model.input_mode,
-                    BoardInputMode::TaskPage | BoardInputMode::EditStep
+                    BoardInputMode::TaskPage
+                        | BoardInputMode::EditStep
+                        | BoardInputMode::EditTitle
+                        | BoardInputMode::EditNotes
+                        | BoardInputMode::EditScope
+                        | BoardInputMode::EditThread
+                        | BoardInputMode::SelectThread
                 ) {
+                    form.manual_page_scroll = true;
                     let horizon = form.notes_max_scroll.get();
                     form.notes_scroll = match intent {
                         BoardIntent::PageWheelScrollUp => form.notes_scroll.saturating_sub(1),
@@ -2013,6 +2047,7 @@ fn edit_draft(model: &mut BoardModel, operation: impl FnOnce(&mut EditBuffer)) {
     let Some(form) = model.form.as_mut() else {
         return;
     };
+    form.manual_page_scroll = false;
     match form.focus {
         CaptureField::Title => operation(&mut form.title),
         CaptureField::Notes => operation(&mut form.notes),

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -435,6 +435,7 @@ fn build_task_page_overlay<'a>(
             .min()
             .unwrap_or(page_geo.height);
         let header_cap = page_bottom.saturating_sub(3).max(1) as usize;
+        form.title_wrap_width.set(title_avail);
         if editing_title {
             let (mut rows, cursor_row, cursor_col) = wrapped_edit_rows(&form.title, title_avail);
             let overflowed = rows.len() > header_cap;
@@ -512,16 +513,19 @@ fn build_task_page_overlay<'a>(
     let editing_notes = model.input_mode() == BoardInputMode::EditNotes;
     let (notes_rows, notes_cursor, more_lines, notes_scroll) = if editing_notes {
         let (all_rows, cursor_row, cursor_column) = wrapped_edit_rows(&form.notes, notes_width);
-        // The notes editor owns the page viewport, so wheel and page scrolling stay inert
-        // while the caret is active. Keep the minimal window that shows the caret's wrapped
-        // row; Esc returns to page view, where below-fold steps can be scrolled into view.
-        let follow = form.notes_scroll.clamp(
-            cursor_row.saturating_sub(want.saturating_sub(1)),
-            cursor_row,
-        );
+        // Explicit pointer scrolling may leave the caret offscreen to reach steps.
+        // Typing or moving the caret restores automatic following.
+        let follow = if form.manual_page_scroll {
+            form.notes_scroll
+        } else {
+            form.notes_scroll.clamp(
+                cursor_row.saturating_sub(want.saturating_sub(1)),
+                cursor_row,
+            )
+        };
         (
             all_rows,
-            Some((
+            (!form.manual_page_scroll).then_some((
                 u16::try_from(cursor_row).unwrap_or(u16::MAX),
                 u16::try_from(cursor_column).unwrap_or(u16::MAX),
             )),

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -304,7 +304,9 @@ pub(super) struct BoardForm {
     /// advance independently while the user is editing.
     pub(super) task_snapshot: Option<Box<Task>>,
     /// View-mode scroll of the task page's shared notes-and-steps body, never used by capture.
+    pub(super) title_wrap_width: std::cell::Cell<usize>,
     pub(super) notes_scroll: usize,
+    pub(super) manual_page_scroll: bool,
     /// Page-session steps state (step cursor, window scroll, delete mark, step
     /// editor). Carried by the form so it lives exactly as long as the page does.
     pub(super) steps: StepsPageState,
@@ -402,7 +404,9 @@ impl BoardForm {
             scope_selected,
             binding,
             task_snapshot: None,
+            title_wrap_width: std::cell::Cell::new(0),
             notes_scroll: 0,
+            manual_page_scroll: false,
             steps: StepsPageState::default(),
             notes_max_scroll: std::cell::Cell::new(0),
             notes_width: std::cell::Cell::new(0),
@@ -1986,7 +1990,6 @@ impl BoardModel {
     pub fn page_scroll(&self) -> usize {
         self.form
             .as_ref()
-            .filter(|form| form.is_task())
             .map(|form| form.notes_scroll)
             .unwrap_or(0)
     }
@@ -2078,6 +2081,19 @@ impl BoardModel {
             .as_ref()
             .map(|quick_add| quick_add.title.value())
             .unwrap_or("")
+    }
+
+    /// Whether a quick-add draft is open: the status-row line or its expanded page.
+    /// The quick-capture popup session lives exactly as long as this draft.
+    pub fn quick_add_open(&self) -> bool {
+        self.quick_add.is_some()
+    }
+
+    /// Whether the expanded capture page is open over its retained quick-add line.
+    /// Esc there would collapse the page back to the line, which in the quick-capture
+    /// popup is the top-level draft Escape.
+    pub fn expanded_capture_open(&self) -> bool {
+        self.quick_add.is_some() && self.form.as_ref().is_some_and(|form| !form.is_task())
     }
 
     pub(super) fn clear_saved_task(&mut self) {
@@ -2300,6 +2316,7 @@ impl BoardModel {
     /// Apply the shared cursor-window origin contract whenever form focus enters Notes.
     fn set_form_focus(form: &mut BoardForm, focus: CaptureField) {
         form.focus = focus;
+        form.manual_page_scroll = false;
         // Notes drafts are cursor-windowed rather than a full copy of the shared
         // content stream. Entering the editor therefore returns its window to the
         // visible origin, so a prior reading scroll cannot hide the draft or put

--- a/src/ui/edit.rs
+++ b/src/ui/edit.rs
@@ -410,7 +410,7 @@ impl WrappedRow {
     /// line instead clamps ONTO its last character: its `end_cursor` names the
     /// NEXT row's first character, and returning it would make locate paint the
     /// caret on that row, skipping the one the move targeted.
-    fn cursor_at(&self, column: usize) -> usize {
+    pub(crate) fn cursor_at(&self, column: usize) -> usize {
         if self.cell_of.is_empty() || column < self.cell_of[0] {
             return self.first_raw;
         }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -143,6 +143,8 @@ pub enum BoardIntent {
     FormFocusPrev,
     /// Focus one painted field of the already-open shared form (mouse).
     FocusFormField(CaptureField),
+    /// Focus a text field at a painted wrapped row and display-cell column.
+    FocusFormCursor(CaptureField, usize, usize),
     /// Enter or a second click opens or closes the selected task-page Thread text editor.
     /// It never commits or leaves the enclosing task edit session.
     ToggleThreadEditing,
@@ -1156,6 +1158,7 @@ pub fn intent_primary_action(intent: &BoardIntent) -> Option<PrimaryBoardAction>
         | BoardIntent::FormFocusNext
         | BoardIntent::FormFocusPrev
         | BoardIntent::FocusFormField(_)
+        | BoardIntent::FocusFormCursor(_, _, _)
         | BoardIntent::ToggleThreadEditing
         | BoardIntent::FormCycleScope
         | BoardIntent::OpenFormScopeDropdown

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -571,6 +571,7 @@ pub fn map_scrollbar_mouse(
         mode,
         BoardInputMode::Normal
             | BoardInputMode::TaskPage
+            | BoardInputMode::EditStep
             | BoardInputMode::EditTitle
             | BoardInputMode::EditNotes
             | BoardInputMode::EditScope

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -567,11 +567,20 @@ pub fn map_scrollbar_mouse(
     mouse: MouseEvent,
     dragging: &mut bool,
 ) -> ScrollbarMouse {
-    if !matches!(mode, BoardInputMode::Normal | BoardInputMode::TaskPage) {
+    if !matches!(
+        mode,
+        BoardInputMode::Normal
+            | BoardInputMode::TaskPage
+            | BoardInputMode::EditTitle
+            | BoardInputMode::EditNotes
+            | BoardInputMode::EditScope
+            | BoardInputMode::EditThread
+            | BoardInputMode::SelectThread
+    ) {
         *dragging = false;
         return ScrollbarMouse::Miss;
     }
-    let page = mode == BoardInputMode::TaskPage;
+    let page = mode != BoardInputMode::Normal;
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             let pos = Position::new(mouse.column, mouse.row);
@@ -600,7 +609,13 @@ pub fn map_scrollbar_mouse(
 
 fn wheel_board_intent(model: &BoardModel, kind: MouseEventKind) -> Option<BoardIntent> {
     match model.input_mode() {
-        BoardInputMode::TaskPage | BoardInputMode::EditStep => match kind {
+        BoardInputMode::TaskPage
+        | BoardInputMode::EditTitle
+        | BoardInputMode::EditNotes
+        | BoardInputMode::EditScope
+        | BoardInputMode::EditThread
+        | BoardInputMode::SelectThread
+        | BoardInputMode::EditStep => match kind {
             MouseEventKind::ScrollUp => Some(BoardIntent::PageWheelScrollUp),
             MouseEventKind::ScrollDown => Some(BoardIntent::PageWheelScrollDown),
             _ => None,
@@ -646,6 +661,40 @@ pub fn map_board_mouse(
         _ => return None,
     }
     let pos = point(mouse.column, mouse.row);
+    if model.expanded_capture_open()
+        && matches!(
+            model.input_mode(),
+            BoardInputMode::EditTitle
+                | BoardInputMode::EditNotes
+                | BoardInputMode::EditScope
+                | BoardInputMode::EditThread
+                | BoardInputMode::SelectThread
+                | BoardInputMode::EditStep
+        )
+    {
+        let target = hit_at(hits, pos);
+        if let Some(hit) = hits.regions.iter().find(|hit| {
+            Some(hit.target) == target && hit.area.contains(Position::new(mouse.column, mouse.row))
+        }) {
+            match hit.target {
+                QueueHitTarget::FormTitle => {
+                    return Some(BoardIntent::FocusFormCursor(
+                        CaptureField::Title,
+                        mouse.row.saturating_sub(hit.area.y) as usize,
+                        mouse.column.saturating_sub(hit.area.x + 4) as usize,
+                    ))
+                }
+                QueueHitTarget::FormNotes(row) => {
+                    return Some(BoardIntent::FocusFormCursor(
+                        CaptureField::Notes,
+                        row,
+                        mouse.column.saturating_sub(hit.area.x + 2) as usize,
+                    ))
+                }
+                _ => {}
+            }
+        }
+    }
     match model.input_mode() {
         BoardInputMode::Palette => match hit_at(hits, pos) {
             Some(QueueHitTarget::Command(index)) => model

--- a/tests/host_scripts.rs
+++ b/tests/host_scripts.rs
@@ -275,6 +275,36 @@ fn open_capture_uses_herdr_cli_and_capture_path() {
 }
 
 #[test]
+fn open_capture_opens_a_sized_popup_for_the_capture_session() {
+    let text = read(&open_capture_path());
+    let active = active_script_lines(&text).join("\n");
+    assert!(
+        active.contains("--placement popup"),
+        "open-capture must open a popup pane; active lines: {active}"
+    );
+    assert!(
+        !text.contains("overlay"),
+        "open-capture must not use the retired overlay placement: {text}"
+    );
+    assert!(
+        active.contains("--width") && active.contains("--height"),
+        "a popup needs explicit --width/--height sized for the task page: {active}"
+    );
+    assert!(
+        active.contains("--width 80") && active.contains("--height 15"),
+        "the popup is 80x15 (operable for the task page): {active}"
+    );
+    assert!(
+        active.contains("--focus"),
+        "the popup must take focus when quick capture is invoked: {active}"
+    );
+    assert!(
+        active.contains(&format!("--env {}=capture", MODE_ENV)),
+        "the popup must still launch the binary in the capture session mode"
+    );
+}
+
+#[test]
 fn quick_capture_injects_the_mode_env_var_the_binary_reads() {
     let text = read(&open_capture_path());
     assert!(

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -3149,3 +3149,133 @@ fn draft_text_click_places_title_and_notes_cursor() {
     apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('Y'), None).unwrap();
     assert!(page_rows(&model).join("\n").contains("abYcdef"));
 }
+
+#[test]
+fn popup_step_draft_scrollbar_and_refused_field_click_preserve_editor() {
+    let (mut domain, mut model) = deck_of(1);
+    for intent in [
+        BoardIntent::OpenCapture,
+        BoardIntent::QuickAddInsertText("title".into()),
+        BoardIntent::ExpandQuickAdd,
+        BoardIntent::EditInsertText("long note\n".repeat(40)),
+        BoardIntent::BeginAddStep,
+        BoardIntent::EditInsertText("step draft".into()),
+    ] {
+        apply_intent(&mut domain, &mut model, intent, None).unwrap();
+    }
+    let area = Rect::new(0, 0, 78, 13);
+    let hits = board_hit_map(area, &model);
+    let track = hits
+        .regions
+        .iter()
+        .find(|h| h.target == QueueHitTarget::PageScroll(0))
+        .unwrap();
+    let mut dragging = false;
+    let ScrollbarMouse::Intent(intent) = map_scrollbar_mouse(
+        model.input_mode(),
+        &hits,
+        left_click(track.area.x, track.area.y),
+        &mut dragging,
+    ) else {
+        panic!("step draft scrollbar must work")
+    };
+    apply_intent(&mut domain, &mut model, intent, None).unwrap();
+    assert_eq!(model.page_scroll(), 0);
+    let hits = board_hit_map(area, &model);
+    let title = hits
+        .regions
+        .iter()
+        .find(|h| h.target == QueueHitTarget::FormTitle)
+        .unwrap();
+    let intent =
+        map_board_mouse(&model, &hits, left_click(title.area.x + 4, title.area.y)).unwrap();
+    apply_intent(&mut domain, &mut model, intent, None).unwrap();
+    assert_eq!(model.input_mode(), BoardInputMode::EditStep);
+    apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('X'), None).unwrap();
+    for _ in 0..100 {
+        apply_intent(
+            &mut domain,
+            &mut model,
+            BoardIntent::PageWheelScrollDown,
+            None,
+        )
+        .unwrap();
+    }
+    assert!(
+        page_rows(&model).join("\n").contains("step draftX"),
+        "refused field click must not move the step cursor"
+    );
+}
+
+#[test]
+fn popup_click_uses_scrolled_wrapped_unicode_cells() {
+    let (mut domain, mut model) = deck_of(1);
+    let snapshot = tsk_tui::context::InvocationSnapshot {
+        default_scope: TaskScope::Global,
+        this_repo: None,
+        title_prefill: None,
+        provenance: ProvenanceOrigin::Capture,
+    };
+    for intent in [
+        BoardIntent::OpenCapture,
+        BoardIntent::QuickAddInsertText("界a界b".into()),
+        BoardIntent::ExpandQuickAdd,
+        BoardIntent::EditInsertText(format!("{}界a界b\n{}", "a".repeat(72), "tail\n".repeat(30))),
+    ] {
+        apply_intent(&mut domain, &mut model, intent, Some(&snapshot)).unwrap();
+    }
+    let area = Rect::new(0, 0, 78, 13);
+    board_hit_map(area, &model);
+    apply_intent(&mut domain, &mut model, BoardIntent::PageScrollTo(1), None).unwrap();
+    let hits = board_hit_map(area, &model);
+    let note = hits
+        .regions
+        .iter()
+        .find(|h| h.target == QueueHitTarget::FormNotes(1))
+        .unwrap();
+    let intent = map_board_mouse(&model, &hits, left_click(note.area.x + 5, note.area.y)).unwrap();
+    apply_intent(&mut domain, &mut model, intent, Some(&snapshot)).unwrap();
+    apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('X'), None).unwrap();
+
+    let hits = board_hit_map(area, &model);
+    let title = hits
+        .regions
+        .iter()
+        .find(|h| h.target == QueueHitTarget::FormTitle)
+        .unwrap();
+    let intent =
+        map_board_mouse(&model, &hits, left_click(title.area.x + 7, title.area.y)).unwrap();
+    apply_intent(&mut domain, &mut model, intent, Some(&snapshot)).unwrap();
+    apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('Y'), None).unwrap();
+    apply_intent(&mut domain, &mut model, BoardIntent::ConfirmEdit, None).unwrap();
+    let task = domain
+        .tasks()
+        .iter()
+        .find(|task| task.title == "界aY界b")
+        .expect("title Unicode click")
+        .clone();
+    assert_eq!(
+        task.notes.as_deref(),
+        Some(format!("{}界aX界b\n{}", "a".repeat(72), "tail\n".repeat(30)).as_str())
+    );
+}
+
+#[test]
+fn popup_typing_and_cursor_movement_restore_notes_after_manual_scroll() {
+    for intent in [BoardIntent::EditInsert('X'), BoardIntent::EditMoveLeft] {
+        let (mut domain, mut model) = deck_of(1);
+        for intent in [
+            BoardIntent::OpenCapture,
+            BoardIntent::ExpandQuickAdd,
+            BoardIntent::EditInsertText(format!("{}LASTLINE", "start\n".repeat(40))),
+        ] {
+            apply_intent(&mut domain, &mut model, intent, None).unwrap();
+        }
+        let area = Rect::new(0, 0, 78, 13);
+        board_hit_map(area, &model);
+        apply_intent(&mut domain, &mut model, BoardIntent::PageScrollTo(0), None).unwrap();
+        assert!(!page_rows(&model).join("\n").contains("LASTLINE"));
+        apply_intent(&mut domain, &mut model, intent, None).unwrap();
+        assert!(page_rows(&model).join("\n").contains("LASTLINE"));
+    }
+}

--- a/tests/queue_board_mouse.rs
+++ b/tests/queue_board_mouse.rs
@@ -3046,3 +3046,106 @@ fn the_project_picker_tab_row_click_selects_the_tab() {
         "the click switched to the archived tab"
     );
 }
+
+#[test]
+fn expanded_capture_long_notes_can_scroll_to_add_step_while_editing() {
+    let (mut domain, mut model) = deck_of(1);
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenCapture, None).unwrap();
+    apply_intent(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None).unwrap();
+    let notes = (0..40)
+        .map(|i| format!("note line {i}\n"))
+        .collect::<String>();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsertText(notes),
+        None,
+    )
+    .unwrap();
+    let area = Rect::new(0, 0, 78, 13);
+    for _ in 0..80 {
+        let hits = board_hit_map(area, &model);
+        let intent = map_board_mouse(&model, &hits, wheel_down(5, 5))
+            .expect("wheel works while editing notes");
+        apply_intent(&mut domain, &mut model, intent, None).unwrap();
+    }
+    let hits = board_hit_map(area, &model);
+    assert!(
+        hits.regions
+            .iter()
+            .any(|hit| hit.target == QueueHitTarget::StepAdd),
+        "scroll exposes add step"
+    );
+    assert_eq!(model.input_mode(), BoardInputMode::EditNotes);
+    let mut dragging = false;
+    let track = hits
+        .regions
+        .iter()
+        .find(|hit| matches!(hit.target, QueueHitTarget::PageScroll(0)))
+        .expect("top of scrollbar");
+    let mouse = MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: track.area.x,
+        row: track.area.y,
+        modifiers: KeyModifiers::NONE,
+    };
+    let ScrollbarMouse::Intent(intent) =
+        map_scrollbar_mouse(model.input_mode(), &hits, mouse, &mut dragging)
+    else {
+        panic!("scrollbar works during notes edit")
+    };
+    apply_intent(&mut domain, &mut model, intent, None).unwrap();
+    assert_eq!(model.page_scroll(), 0);
+    let hits = board_hit_map(area, &model);
+    assert!(!hits
+        .regions
+        .iter()
+        .any(|hit| hit.target == QueueHitTarget::StepAdd));
+}
+
+#[test]
+fn draft_text_click_places_title_and_notes_cursor() {
+    let (mut domain, mut model) = deck_of(1);
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenCapture, None).unwrap();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::QuickAddInsertText("abcdef".into()),
+        None,
+    )
+    .unwrap();
+    apply_intent(&mut domain, &mut model, BoardIntent::ExpandQuickAdd, None).unwrap();
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::EditInsertText("abcdef\nsecond".into()),
+        None,
+    )
+    .unwrap();
+    let area = Rect::new(0, 0, 78, 13);
+    let hits = board_hit_map(area, &model);
+    let note = hits
+        .regions
+        .iter()
+        .find(|h| h.target == QueueHitTarget::FormNotes(0))
+        .unwrap();
+    let intent = map_board_mouse(&model, &hits, left_click(note.area.x + 4, note.area.y)).unwrap();
+    apply_intent(&mut domain, &mut model, intent, None).unwrap();
+    apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('X'), None).unwrap();
+    let rows = page_rows(&model).join("\n");
+    assert!(
+        rows.contains("abXcdef"),
+        "click inserts at note character, not end: {rows}"
+    );
+    let hits = board_hit_map(area, &model);
+    let title = hits
+        .regions
+        .iter()
+        .find(|h| h.target == QueueHitTarget::FormTitle)
+        .unwrap();
+    let intent =
+        map_board_mouse(&model, &hits, left_click(title.area.x + 6, title.area.y)).unwrap();
+    apply_intent(&mut domain, &mut model, intent, None).unwrap();
+    apply_intent(&mut domain, &mut model, BoardIntent::EditInsert('Y'), None).unwrap();
+    assert!(page_rows(&model).join("\n").contains("abYcdef"));
+}

--- a/tests/quick_capture_process.rs
+++ b/tests/quick_capture_process.rs
@@ -1,0 +1,173 @@
+//! Real capture entrypoint, isolated PTY and store. Never uses a live Herdr session.
+#![cfg(unix)]
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
+use tsk_tui::reopen::ReopenRequest;
+use tsk_tui::store::TaskStore;
+static SEQ: AtomicU64 = AtomicU64::new(0);
+struct Session {
+    child: Child,
+    tty: File,
+    root: std::path::PathBuf,
+}
+impl Drop for Session {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let mut drain = [0; 8192];
+        while matches!(self.tty.read(&mut drain), Ok(n) if n > 0) {}
+        let _ = self.child.wait();
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+impl Session {
+    fn output_until(&mut self, needle: &str) -> String {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut out = String::new();
+        while Instant::now() < deadline {
+            let mut bytes = [0; 8192];
+            if let Ok(n) = self.tty.read(&mut bytes) {
+                out.push_str(&String::from_utf8_lossy(&bytes[..n]));
+            }
+            if out.contains(needle) {
+                return out;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        panic!("missing {needle}: {out}");
+    }
+}
+#[test]
+fn capture_entrypoint_skips_launch_card_preserves_reopen_and_exits_on_escape() {
+    let root = std::env::temp_dir().join(format!(
+        "tsk-capture-pty-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir_all(root.join("repo/.git")).unwrap();
+    let repo = root.join("repo");
+    let store = TaskStore::new(root.join("state"));
+    let mut state = DomainState::new();
+    state
+        .create(
+            "archived seed",
+            None,
+            TaskScope::Project {
+                path: repo.display().to_string(),
+            },
+            ProvenanceOrigin::Manual,
+            None,
+        )
+        .unwrap();
+    state.archive_project(repo.to_str().unwrap()).unwrap();
+    store.save(&state).unwrap();
+    ReopenRequest::new(None).write(store.path()).unwrap();
+    let request = fs::read(store.path().join("reopen.json")).unwrap();
+    let mut master = -1;
+    let mut slave = -1;
+    let mut size = libc::winsize {
+        ws_row: 13,
+        ws_col: 78,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    // SAFETY: openpty initializes valid descriptors; size is live for the call.
+    assert_eq!(
+        unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &raw mut size,
+            )
+        },
+        0
+    );
+    // SAFETY: each descriptor has one owned File, and is valid after openpty.
+    let tty = unsafe { File::from_raw_fd(master) };
+    let input = unsafe { File::from_raw_fd(slave) };
+    // SAFETY: prevent the child from retaining an extra master/slave across exec.
+    unsafe {
+        assert_ne!(libc::fcntl(master, libc::F_SETFD, libc::FD_CLOEXEC), -1);
+        assert_ne!(libc::fcntl(slave, libc::F_SETFD, libc::FD_CLOEXEC), -1);
+    }
+    let mut command = Command::new(env!("CARGO_BIN_EXE_tsk"));
+    command
+        .arg("capture")
+        .current_dir(&repo)
+        .env("TSK_STATE_DIR", store.path())
+        .env("TSK_CONFIG_DIR", root.join("config"))
+        .env_remove("TSK_MODE")
+        .env("TERM", "xterm-256color")
+        .env(
+            "HERDR_PLUGIN_CONTEXT_JSON",
+            serde_json::json!({"focused_pane_cwd":repo,"selected_text":"PTY capture"}).to_string(),
+        )
+        .stdin(Stdio::from(input.try_clone().unwrap()))
+        .stdout(Stdio::from(input.try_clone().unwrap()))
+        .stderr(Stdio::from(input));
+    // SAFETY: only async-signal-safe system calls run before exec; stdin is the PTY slave.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 || libc::ioctl(0, libc::TIOCSCTTY as _, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let child = command.spawn().unwrap();
+    // SAFETY: fcntl changes only this valid owned PTY descriptor's file status flags.
+    unsafe {
+        let flags = libc::fcntl(tty.as_raw_fd(), libc::F_GETFL);
+        assert_ne!(
+            libc::fcntl(tty.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK),
+            -1
+        );
+    }
+    let mut session = Session { child, tty, root };
+    let output = session.output_until("cancel");
+    assert!(
+        output.contains("+ step"),
+        "capture must open the expanded page: {output}"
+    );
+    assert!(
+        output.contains("desk"),
+        "archived launch falls back to desk: {output}"
+    );
+    assert!(!output.contains("would you like to unarchive"));
+    assert_eq!(
+        fs::read(store.path().join("reopen.json")).unwrap(),
+        request,
+        "popup must not retire board requests"
+    );
+    ReopenRequest::new(None).write(store.path()).unwrap();
+    let fresh = fs::read(store.path().join("reopen.json")).unwrap();
+    std::thread::sleep(Duration::from_millis(350));
+    assert_eq!(fs::read(store.path().join("reopen.json")).unwrap(), fresh);
+    session.tty.write_all(b"\x1b[27u").unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let mut drain = [0; 8192];
+        let _ = session.tty.read(&mut drain);
+        if let Some(status) = session.child.try_wait().unwrap() {
+            assert!(status.success());
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "one Escape must exit real capture loop"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(
+        store.load().unwrap().tasks().len(),
+        1,
+        "cancel saves no task"
+    );
+}


### PR DESCRIPTION
## Summary
Quick capture now opens the existing expanded quick-add task page in an 80x15 Herdr popup, starting in Title. Escape discards and closes directly, while failed saves retain recovery and the draft.

Mouse-wheel and scrollbar navigation reach steps below long notes. Clicking popup Title or Notes positions the text cursor. Normal board quick-add behavior remains unchanged.

## Verification
- Rust fmt, clippy with warnings denied, full tests, release build passed.
- Site tests and build passed.
- Regression tests failed before their fixes.
- Isolated live Herdr pane checks covered save/cancel/recovery, long-note scrolling, and click-to-position. Owner verified the actual popup and scrolling visually.

## Notes
The owner local shortcut was changed from prefix+c to prefix+a; that user config is outside this PR. Legacy capture-form code remains compiled but is no longer the binary capture entrypoint. Review Panel pending.