### PR TITLE
Release v0.6.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ The committed `.gitignore` already covers it.
 board for capture and human-status verbs. It ships as the herdr plugin
 `herdr-tsk`, and the built binary (`tsk`) also runs standalone. Attention,
 park/resume, linking, and dispatch are not in this tree; reference lives on
-`archive/dark-engine-pre-v1`. Crate (`tsk-tui`) and plugin are `0.5.0`.
+`archive/dark-engine-pre-v1`. Crate (`tsk-tui`) and plugin are `0.6.0`.
 
 A gitignored `HANDOFF.md` may hold this clone’s live working state.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.6.0
 
-`tsk setup herdr` registers embedded plugin assets with Herdr 0.9+, sharing the
-installed standalone binary. It adds prefix+t board and prefix+a quick capture,
-asks before replacing conflicting shortcuts, and refuses noninteractive conflicts
-without changes. No source checkout, separate build, or automatic install-time link.
-
-Native distribution: an owner-run draft-release workflow builds four
-macOS/Linux architectures, generates checksums and a version-pinned Homebrew formula.
-The installer downloads stable release assets, verifies SHA-256, and installs to
-~/.local/bin. Homebrew installs from the checksum-pinned smarzban/tap/tsk formula.
-
-Board attribution appears only inside an open peek, on a dim `└─ label` line
-below its notes. Collapsed rows show no labels. Titles wrap two cells before the right edge without a label column.
-
-Quick capture opens the expanded quick-add page in a herdr popup instead of the old
-capture form. It is the same page as `+` then `Tab` on the board, opening with the
-cursor in Title: scope and selected-text prefill from the focused pane, `Shift+Enter`
-saves and closes the popup, `Esc` cancels and closes without creating a task, and a
-failed save keeps the draft editable with retry/cancel. `tsk capture` (or
-`TSK_MODE=capture`) opens the same page.
-
-Thread names accept dots (`v0.0.6`). A refusal names the rule instead of `invalid thread name`.
-
-Expanded quick-add can set thread and add steps. Enter on a new step saves it and opens the next empty row; Shift+Enter saves the step and the task-edit session. An empty new-step row discards if you click elsewhere. Deleting a task asks `press ctrl+x again to delete` first.
-
-NEEDS YOU section: blocked and review tasks sit above IN MOTION on desk and on a
-project board. Desk ON DECK / project ON DECK keep ready work. An empty deck
-header is omitted while NEEDS YOU has rows.
-
-`tsk edit --notes` keeps newlines and tabs, same as `tsk add -n`.
-
-Agent CLI mutations: `tsk status T<n> <status>` sets ready, started, blocked, or
-review, or done (`start` is an alias for `started`; idempotent on repeat), `tsk edit T<n>`
-updates title and/or notes, and `tsk steps` gains `rename` and `remove`.
-
-Human CLI output escapes C0/C1 controls in titles, step text, project names, and usage reasons that echo argv.
-`tsk list T<n>` documents live-store lookup vs `trash.jsonl`. Install docs keep
-`./target/release/tsk` after build, with an optional PATH export.
+- Native macOS/Linux binaries, a checksum-verifying installer, and Homebrew packaging. `tsk setup herdr` connects the same binary to Herdr with board and capture shortcuts.
+- Agent CLI commands to change status, edit tasks, and rename or remove steps.
+- **NEEDS YOU** brings blocked and review tasks to the top of the board.
+- Redesigned projects index with search, status counts, and persistent desk/project navigation.
+- Quick capture opens the task editor in a Herdr popup. Expanded quick-add supports threads and steps.
+- Clearer keyboard controls and help: `Ctrl+R` toggles review, `Enter` toggles stored steps, and `Shift+Enter` saves edits. Task deletion asks for confirmation.
+- Cleaner task rows: project and thread labels appear only in an open peek, leaving more room for titles.
 
 ## 0.5.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tsk-tui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossterm",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-tui"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "tsk: a task board for your terminal"
 license = "MIT"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -2,7 +2,7 @@
 
 id = "herdr-tsk"
 name = "herdr-tsk"
-version = "0.5.0"
+version = "0.6.0"
 description = "Queue board and quick capture inside herdr."
 min_herdr_version = "0.7.5"
 platforms = ["linux", "macos"]

--- a/site/src/version.mjs
+++ b/site/src/version.mjs
@@ -1,2 +1,2 @@
 // Crate and plugin version, shown in the landing and docs headers.
-export const VERSION = '0.5.0';
+export const VERSION = '0.6.0';

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -44,7 +44,7 @@ test("crate, plugin, lockfile, and site share one release version", async () => 
   const pluginVersion = plugin.match(/^version = "([^"]+)"/m)?.[1];
   const lockVersion = lockfile.match(/\[\[package\]\]\nname = "tsk-tui"\nversion = "([^"]+)"/)?.[1];
   const renderedVersion = siteVersion.match(/VERSION = '([^']+)'/)?.[1];
-  assert.equal(cargoVersion, "0.5.0");
+  assert.equal(cargoVersion, "0.6.0");
   assert.deepEqual([pluginVersion, lockVersion, renderedVersion], [cargoVersion, cargoVersion, cargoVersion]);
 });
 


### PR DESCRIPTION
## Summary
- Condense the v0.6.0 changelog to user-facing features only.
- Bump crate, lockfile, plugin, and site versions to 0.6.0.

## Validation
- cargo fmt --check
- release version check
- 19 site tests and site build

After merge, tag v0.6.0 and run the native release workflow. Publish only after all four builds and artifact verification pass.