### PR TITLE
Document installer PATH safety rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,14 @@ For scriptable board work, use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, 
   are separate from release publication. Installer-only changes run the packaging
   tests and ShellCheck via `.github/workflows/installer.yml`; Rust CI also exercises
   binary-dependent packaging/PTY tests after building the release executable.
+- The install script appends a duplicate-safe PATH entry for Bash (`.bashrc` plus
+  the first existing login profile, default `.profile`) or Zsh (`$ZDOTDIR/.zshrc`,
+  otherwise `~/.zshrc`) only when the install directory is absent from PATH.
+  It never sources startup files; symlinked, non-regular, or unwritable files are
+  skipped with manual guidance. Partial success preserves completed edits and names
+  skipped files. Successful setup prints reopen-terminal/export instructions.
+  Tests must isolate HOME and ZDOTDIR, never edit the caller's startup files.
+  Website installer updates do not replace an already-published release's assets.
 
 - Build: `cargo build --release`
 - `herdr-plugin.toml` launches `./target/release/tsk`. Rebuild in-repo


### PR DESCRIPTION
Update agent instructions to match the merged installer behavior and test-isolation requirements. Documentation only; no product code changes. The known Ubuntu reopen test failure on 962e12f is recorded in the local handoff for the next session, not repaired here.