### PR TITLE
feat: agent-site plumbing (markdown twins, robots, llms, JSON-LD)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,3 +43,7 @@ Canonical terms for this repo. No implementation detail.
 - **NEEDS YOU**: queue section for non-deleted, non-archived blocked and review tasks. Desk shows desk/global ones; project focus shows that project's. Omitted when empty. Sits above IN MOTION.
 - **session**: one board process from launch to quit. Session-only state (collapse, wide stage, the launch card having been shown) resets on relaunch.
 - **hidden**: a task that is archived, or whose project is archived. The single predicate every working lens filters on; distinct from soft-deleted.
+- **guide**: the agent workflow doc, `skills/tsk-cli/SKILL.md`, printed by `tsk guide` and published at `/docs/agents/`.
+- **twin**: the Markdown representation of a docs page at `/docs/<slug>.md`.
+- **bootstrap prompt**: the three-line text a human pastes to an agent to start using tsk.
+- **definition sentence**: `tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tsk
 
-**A task board for you and your agents.**
+tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.
 
 You and your agents put work on one board and move it through human status:
 ready, started, blocked, review, done. Agents reach the board through the CLI.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -35,7 +35,9 @@ export default defineConfig({
     rehypePlugins: [rehypeKbd],
   },
   integrations: [
-    sitemap(),
+    sitemap({
+      filter: (page) => !page.endsWith('.md'),
+    }),
     starlight({
       title: 'tsk',
       description: 'A task board for you and your agents, in your terminal.',

--- a/site/parity/preview.mjs
+++ b/site/parity/preview.mjs
@@ -11,6 +11,8 @@ const mime = {
   ".png": "image/png",
   ".woff2": "font/woff2",
   ".json": "application/json",
+  ".md": "text/markdown; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
 };
 createServer(async (req, res) => {
   try {

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,24 +1,27 @@
 # tsk
 
-> A task board for you and your agents, in your terminal. Both put work on one board and move it through ready, started, blocked, review, done. Agents reach it through the CLI.
+> tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.
 
-Open or reopen from a repository to view that project. Persistent navigation is Desk, selected project, Projects. Desk shows global attention and active work plus its own backlog. Projects offers a searchable index and an Overview selector for threads across projects; project boards have their own thread filter. The index right-aligns NEEDS YOU, IN MOTION, and READY counts (zero paints as a dim dot, a live NEEDS YOU count is bold), shows basenames only with `here` on the launch project, adds a THREADS column at 100 columns or wider, and names the selected project's full path on the status row (above the query while search is open). A click selects an index row; a fast double-click or Enter opens it.
+Install with `curl -fsSL https://gettsk.sh/install.sh | sh` or `brew install smarzban/tap/tsk`.
+Details: https://gettsk.sh/docs/install.md
 
-Keys: mutating verbs take Ctrl (ctrl+s start/reopen, ctrl+d done, ctrl+o reopen, ctrl+b block, ctrl+r review, ctrl+e edit, ctrl+x delete, ctrl+u undo, ctrl+f archive, ctrl+q quit); bare keys navigate (j/k, Enter open, + add, d done drawer, g archived group, p project picker, t threads, v views, 1/2/3 destinations, : palette, ? help). The help card lists every key of every surface and scrolls. On the task page Enter toggles a selected stored step; the status verbs act on the task. Enter in the Title editor moves to Notes; Shift+Enter is the only task-edit save chord. The footer status row names the active lens (desk, project basename plus an active thread, archived focus, or selected Projects path) and carries feedback. Its verb row is a short prompt (open, status verbs, add, help; edit/status/close on the page; save/cancel while editing), not a keymap; a visible delete notice prefixes it with ctrl+u undo.
+## For agents
 
-On Projects, `/` opens the live project search in the shared footer slot, Enter opens the selected match, and Esc clears and closes it. Collapsed task rows show no labels. Project or thread attribution appears only at the bottom of an open peek, on a dim L-shaped line beneath its notes. Titles wrap two cells before the right edge, without reserving an attribution column; task-page dates remain informational. Thread selectors accept typing and paste, including j/k as query text; unmatched queries stay visible. Wrapped selectors have one blank line below the tabs before the selected value. Project and cross-project thread views omit a separate task-count summary.
+- Guide: https://gettsk.sh/docs/agents.md
+- CLI: https://gettsk.sh/docs/cli.md
+- Full docs: https://gettsk.sh/llms-full.txt
 
-User guide: https://gettsk.sh/docs/
+## Docs
 
-- [Overview](https://gettsk.sh/docs/)
-- [Install](https://gettsk.sh/docs/install/)
-- [Board](https://gettsk.sh/docs/board/)
-- [Keys](https://gettsk.sh/docs/keys/)
-- [Capture](https://gettsk.sh/docs/capture/)
-- [Task page](https://gettsk.sh/docs/task-page/)
-- [Steps](https://gettsk.sh/docs/steps/)
-- [CLI](https://gettsk.sh/docs/cli/)
+- Overview: https://gettsk.sh/docs/index.md
+- Install: https://gettsk.sh/docs/install.md
+- Board: https://gettsk.sh/docs/board.md
+- Keys: https://gettsk.sh/docs/keys.md
+- Capture: https://gettsk.sh/docs/capture.md
+- Task page: https://gettsk.sh/docs/task-page.md
+- Steps: https://gettsk.sh/docs/steps.md
+- CLI: https://gettsk.sh/docs/cli.md
 
-Source: https://github.com/smarzban/herdr-tsk
+## Source
 
-Installation: macOS ARM64/Intel and Linux ARM64/x86-64 musl archives; a checksum-verifying installer at /install.sh (latest published stable release, never main; TSK_VERSION pins a stable tag; TSK_INSTALL_DIR overrides ~/.local/bin); and smarzban/tap/tsk on Homebrew (explicit version-pinned URLs/checksums). Install with `curl -fsSL https://gettsk.sh/install.sh | sh` or `brew install smarzban/tap/tsk`. The installer adds a duplicate-safe PATH entry to Bash/Zsh startup files if needed, then asks users to reopen the terminal or run the printed export command. It leaves symlinked/non-regular/unwritable startup files alone; other shells need manual PATH setup. No automatic sudo, plugin linking, or task-data removal. Explicit `tsk setup herdr` registers embedded plugin assets using the same stable installed binary (Herdr 0.9+), and adds prefix+t board / prefix+a capture with confirmation before conflicting bindings are replaced. Noninteractive conflicts abort without changes. Reruns are idempotent; upgrades replace the registration and remove the intact stale managed root. Reload Herdr config or restart to activate bindings. Upgrades use the same installation channel.
+https://github.com/smarzban/herdr-tsk

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,25 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+Sitemap: https://gettsk.sh/sitemap-index.xml

--- a/site/src/components/DocsHead.astro
+++ b/site/src/components/DocsHead.astro
@@ -9,10 +9,16 @@ import {
   twinUrlForSlug,
 } from '../lib/agent-docs.mjs';
 
-const { entry } = Astro.locals.starlightRoute;
+const { entry, lastUpdated } = Astro.locals.starlightRoute;
 const isDocsPage = entry.id !== '404' && !entry.id.endsWith('/404');
 const href = isDocsPage ? twinUrlForSlug(slugFromDocsId(entry.id)) : '';
-const dateModified = entry.filePath ? newestCommitIso(entry.filePath) : undefined;
+const dateModified = isDocsPage
+  ? lastUpdated instanceof Date
+    ? lastUpdated.toISOString()
+    : entry.filePath
+      ? newestCommitIso(entry.filePath)
+      : undefined
+  : undefined;
 const techArticle =
   isDocsPage && dateModified
     ? {

--- a/site/src/components/DocsHead.astro
+++ b/site/src/components/DocsHead.astro
@@ -1,12 +1,18 @@
 ---
 import Head from '@astrojs/starlight/components/Head.astro';
 import SharedHead from './SharedHead.astro';
-import { SITE, slugFromDocsId, twinUrlForSlug } from '../lib/agent-docs.mjs';
+import {
+  newestCommitIso,
+  serializeJsonLd,
+  SITE,
+  slugFromDocsId,
+  twinUrlForSlug,
+} from '../lib/agent-docs.mjs';
 
-const { entry, lastUpdated } = Astro.locals.starlightRoute;
+const { entry } = Astro.locals.starlightRoute;
 const isDocsPage = entry.id !== '404' && !entry.id.endsWith('/404');
 const href = isDocsPage ? twinUrlForSlug(slugFromDocsId(entry.id)) : '';
-const dateModified = lastUpdated instanceof Date ? lastUpdated.toISOString() : undefined;
+const dateModified = entry.filePath ? newestCommitIso(entry.filePath) : undefined;
 const techArticle =
   isDocsPage && dateModified
     ? {
@@ -23,4 +29,4 @@ const techArticle =
 <Head />
 <SharedHead />
 {isDocsPage && <link rel="alternate" type="text/markdown" href={href} />}
-{techArticle && <script type="application/ld+json" set:html={JSON.stringify(techArticle)} />}
+{techArticle && <script type="application/ld+json" set:html={serializeJsonLd(techArticle)} />}

--- a/site/src/components/DocsHead.astro
+++ b/site/src/components/DocsHead.astro
@@ -1,13 +1,26 @@
 ---
 import Head from '@astrojs/starlight/components/Head.astro';
 import SharedHead from './SharedHead.astro';
-import { slugFromDocsId, twinUrlForSlug } from '../lib/agent-docs.mjs';
+import { SITE, slugFromDocsId, twinUrlForSlug } from '../lib/agent-docs.mjs';
 
-const { entry } = Astro.locals.starlightRoute;
+const { entry, lastUpdated } = Astro.locals.starlightRoute;
 const isDocsPage = entry.id !== '404' && !entry.id.endsWith('/404');
 const href = isDocsPage ? twinUrlForSlug(slugFromDocsId(entry.id)) : '';
+const dateModified = lastUpdated instanceof Date ? lastUpdated.toISOString() : undefined;
+const techArticle =
+  isDocsPage && dateModified
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'TechArticle',
+        headline: entry.data.title,
+        description: entry.data.description,
+        dateModified,
+        isPartOf: { '@type': 'WebSite', url: `${SITE}/` },
+      }
+    : null;
 ---
 
 <Head />
 <SharedHead />
 {isDocsPage && <link rel="alternate" type="text/markdown" href={href} />}
+{techArticle && <script type="application/ld+json" set:html={JSON.stringify(techArticle)} />}

--- a/site/src/components/DocsHead.astro
+++ b/site/src/components/DocsHead.astro
@@ -1,7 +1,13 @@
 ---
 import Head from '@astrojs/starlight/components/Head.astro';
 import SharedHead from './SharedHead.astro';
+import { slugFromDocsId, twinUrlForSlug } from '../lib/agent-docs.mjs';
+
+const { entry } = Astro.locals.starlightRoute;
+const isDocsPage = entry.id !== '404' && !entry.id.endsWith('/404');
+const href = isDocsPage ? twinUrlForSlug(slugFromDocsId(entry.id)) : '';
 ---
 
 <Head />
 <SharedHead />
+{isDocsPage && <link rel="alternate" type="text/markdown" href={href} />}

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -3,9 +3,7 @@ title: Overview
 description: What tsk is, who moves the work, and where to read next.
 ---
 
-**tsk** is a task board for you and your agents, in your terminal. You both put
-work on one board and move it through human status: ready, started, blocked,
-review, done.
+**tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.** You both put work on one board and move it through human status: ready, started, blocked, review, done.
 
 It ships as the herdr plugin `herdr-tsk`. The `tsk` binary also runs standalone
 against `~/.tsk`. The pane, the quick-capture popup, and the CLI edit the same store.

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -3,6 +3,9 @@ title: Install
 description: Install tsk, open the board, and connect it to Herdr.
 ---
 
+Install tsk with the installer or Homebrew, then open the board from a
+repository. Optional Herdr setup registers the plugin and shortcuts.
+
 ## Install
 
 ```sh

--- a/site/src/lib/agent-docs.mjs
+++ b/site/src/lib/agent-docs.mjs
@@ -1,0 +1,64 @@
+// Shared helpers for docs markdown twins. Keep this free of astro: imports so
+// site tests can load it with node --test.
+
+import { spawnSync } from "node:child_process";
+import { basename, dirname, resolve } from "node:path";
+
+export const SITE = "https://gettsk.sh";
+export const SOURCE_BASE =
+  "https://github.com/smarzban/herdr-tsk/blob/main/site/src/content/docs/docs";
+
+export function slugFromDocsId(id) {
+  const value = String(id);
+  if (value === "docs" || value === "docs/index" || value === "index") return "index";
+  const rest = value.replace(/^docs\//, "");
+  return rest === "" ? "index" : rest;
+}
+
+export function htmlUrlForSlug(slug) {
+  return slug === "index" ? `${SITE}/docs/` : `${SITE}/docs/${slug}/`;
+}
+
+export function twinUrlForSlug(slug) {
+  return `${SITE}/docs/${slug}.md`;
+}
+
+export function sourceFileName(filePath) {
+  const normalized = String(filePath).replaceAll("\\", "/");
+  const parts = normalized.split("/");
+  return parts[parts.length - 1];
+}
+
+export function stripFrontmatter(source) {
+  const match = String(source).match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  if (!match) return String(source);
+  return String(source).slice(match[0].length).replace(/^\r?\n/, "");
+}
+
+export function newestCommitIso(filePath) {
+  const absolute = resolve(process.cwd(), filePath);
+  const result = spawnSync(
+    "git",
+    ["log", "--format=%ct", "--max-count=1", basename(absolute)],
+    { cwd: dirname(absolute), encoding: "utf-8" },
+  );
+  const timestamp = Number(String(result.stdout || "").trim());
+  if (result.error || !Number.isFinite(timestamp) || timestamp <= 0) {
+    throw new Error(`Failed to retrieve git history for ${filePath}`);
+  }
+  return new Date(timestamp * 1000).toISOString();
+}
+
+export function formatTwin({ title, slug, fileName, updatedIso, body }) {
+  const trimmed = String(body).replace(/^\uFEFF/, "").replace(/\s+$/, "");
+  return [
+    `# ${title}`,
+    "",
+    `- html: ${htmlUrlForSlug(slug)}`,
+    `- source: ${SOURCE_BASE}/${fileName}`,
+    `- updated: ${updatedIso}`,
+    "",
+    trimmed,
+    "",
+  ].join("\n");
+}

--- a/site/src/lib/agent-docs.mjs
+++ b/site/src/lib/agent-docs.mjs
@@ -2,6 +2,7 @@
 // site tests can load it with node --test.
 
 import { spawnSync } from "node:child_process";
+import { statSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 
 export const SITE = "https://gettsk.sh";
@@ -51,14 +52,22 @@ export function newestCommitIso(filePath) {
   const absolute = resolve(process.cwd(), filePath);
   const result = spawnSync(
     "git",
-    ["log", "--format=%ct", "--max-count=1", basename(absolute)],
+    ["log", "--format=%ct", "--max-count=1", "--", basename(absolute)],
     { cwd: dirname(absolute), encoding: "utf-8" },
   );
   const timestamp = Number(String(result.stdout || "").trim());
-  if (result.error || !Number.isFinite(timestamp) || timestamp <= 0) {
-    throw new Error(`Failed to retrieve git history for ${filePath}`);
+  if (!result.error && Number.isFinite(timestamp) && timestamp > 0) {
+    return new Date(timestamp * 1000).toISOString();
   }
-  return new Date(timestamp * 1000).toISOString();
+  try {
+    return statSync(absolute).mtime.toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+export function serializeJsonLd(value) {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
 }
 
 export function formatTwin({ title, slug, fileName, updatedIso, body }) {

--- a/site/src/lib/agent-docs.mjs
+++ b/site/src/lib/agent-docs.mjs
@@ -59,11 +59,7 @@ export function newestCommitIso(filePath) {
   if (!result.error && Number.isFinite(timestamp) && timestamp > 0) {
     return new Date(timestamp * 1000).toISOString();
   }
-  try {
-    return statSync(absolute).mtime.toISOString();
-  } catch {
-    return new Date(0).toISOString();
-  }
+  return statSync(absolute).mtime.toISOString();
 }
 
 export function serializeJsonLd(value) {

--- a/site/src/lib/agent-docs.mjs
+++ b/site/src/lib/agent-docs.mjs
@@ -5,6 +5,18 @@ import { spawnSync } from "node:child_process";
 import { basename, dirname, resolve } from "node:path";
 
 export const SITE = "https://gettsk.sh";
+export const DEFINITION_SENTENCE =
+  "tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.";
+export const SIDEBAR_SLUGS = [
+  "index",
+  "install",
+  "board",
+  "keys",
+  "capture",
+  "task-page",
+  "steps",
+  "cli",
+];
 export const SOURCE_BASE =
   "https://github.com/smarzban/herdr-tsk/blob/main/site/src/content/docs/docs";
 

--- a/site/src/pages/docs/[...slug].md.ts
+++ b/site/src/pages/docs/[...slug].md.ts
@@ -1,0 +1,41 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getCollection } from "astro:content";
+
+import {
+  formatTwin,
+  newestCommitIso,
+  slugFromDocsId,
+  sourceFileName,
+  stripFrontmatter,
+} from "../../lib/agent-docs.mjs";
+
+export async function getStaticPaths() {
+  const docs = await getCollection("docs");
+  return docs.map((entry) => ({
+    params: { slug: slugFromDocsId(entry.id) },
+    props: { entry },
+  }));
+}
+
+export async function GET({
+  props,
+}: {
+  props: { entry: { id: string; filePath?: string; data: { title: string } } };
+}) {
+  const { entry } = props;
+  if (!entry.filePath) {
+    throw new Error(`docs entry ${entry.id} has no filePath`);
+  }
+  const source = await readFile(join(process.cwd(), entry.filePath), "utf8");
+  const twin = formatTwin({
+    title: entry.data.title,
+    slug: slugFromDocsId(entry.id),
+    fileName: sourceFileName(entry.filePath),
+    updatedIso: newestCommitIso(entry.filePath),
+    body: stripFrontmatter(source),
+  });
+  return new Response(twin, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -32,7 +32,7 @@ const softwareApplication = {
     <title>tsk · a task board for you and your agents</title>
     <meta
       name="description"
-      content="tsk is a terminal task board for you and your agents. Plan in one place, move work through ready, started, blocked, review, done. You and your agents can create, edit, and complete tasks. Ships as a herdr plugin, runs standalone."
+      content="tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI."
     />
     <link rel="canonical" href={`${SITE}/`} />
     <meta property="og:type" content="website" />

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,6 +3,7 @@ import Wordmark from '../components/Wordmark.astro';
 import SharedHead from '../components/SharedHead.astro';
 import '../styles/landing.css';
 
+import { serializeJsonLd } from '../lib/agent-docs.mjs';
 import { VERSION } from '../version.mjs';
 const SITE = 'https://gettsk.sh';
 const REPO = 'https://github.com/smarzban/herdr-tsk';
@@ -100,7 +101,7 @@ const softwareApplication = {
       media="(prefers-color-scheme: light)"
     />
     <SharedHead />
-    <script type="application/ld+json" set:html={JSON.stringify(softwareApplication)} />
+    <script type="application/ld+json" set:html={serializeJsonLd(softwareApplication)} />
   </head>
   <body class="landing">
     <a class="skip" href="#main">skip to content</a>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -6,6 +6,21 @@ import '../styles/landing.css';
 import { VERSION } from '../version.mjs';
 const SITE = 'https://gettsk.sh';
 const REPO = 'https://github.com/smarzban/herdr-tsk';
+const softwareApplication = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'tsk',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'macOS, Linux',
+  license: 'https://opensource.org/licenses/MIT',
+  codeRepository: REPO,
+  softwareVersion: VERSION,
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
+};
 ---
 
 <!DOCTYPE html>
@@ -85,6 +100,7 @@ const REPO = 'https://github.com/smarzban/herdr-tsk';
       media="(prefers-color-scheme: light)"
     />
     <SharedHead />
+    <script type="application/ld+json" set:html={JSON.stringify(softwareApplication)} />
   </head>
   <body class="landing">
     <a class="skip" href="#main">skip to content</a>

--- a/site/src/pages/llms-full.txt.ts
+++ b/site/src/pages/llms-full.txt.ts
@@ -1,0 +1,35 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getCollection } from "astro:content";
+
+import {
+  formatTwin,
+  newestCommitIso,
+  SIDEBAR_SLUGS,
+  slugFromDocsId,
+  sourceFileName,
+  stripFrontmatter,
+} from "../lib/agent-docs.mjs";
+
+export async function GET() {
+  const docs = await getCollection("docs");
+  const bySlug = new Map(docs.map((entry) => [slugFromDocsId(entry.id), entry]));
+  const parts = [];
+  for (const slug of SIDEBAR_SLUGS) {
+    const entry = bySlug.get(slug);
+    if (!entry?.filePath) continue;
+    const source = await readFile(join(process.cwd(), entry.filePath), "utf8");
+    parts.push(
+      formatTwin({
+        title: entry.data.title,
+        slug,
+        fileName: sourceFileName(entry.filePath),
+        updatedIso: newestCommitIso(entry.filePath),
+        body: stripFrontmatter(source),
+      }).trimEnd(),
+    );
+  }
+  return new Response(`${parts.join("\n\n")}\n`, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -164,3 +164,21 @@ test("robots_txt_allows_star_and_listed_crawlers_and_names_the_sitemap", async (
   }
   assert.match(robots, /Sitemap: https:\/\/gettsk\.sh\/sitemap-index\.xml/);
 });
+
+test("every_docs_entry_has_description_and_an_answer_first_paragraph", async () => {
+  const files = await docsFiles();
+  assert.ok(files.length >= 8, "docs collection should have the current pages");
+  for (const fileName of files) {
+    const source = await read(join(docsDir, fileName));
+    const description = source.match(/^description:\s*(.+)$/m)?.[1]?.replace(/^"|"$/g, "").trim();
+    assert.ok(description, `${fileName} needs a description`);
+    const body = stripFrontmatter(source);
+    const first = body.split(/\r?\n/).map((line) => line.trim()).find((line) => line.length > 0) || "";
+    assert.ok(first, `${fileName} needs a first paragraph`);
+    assert.equal(
+      /^#|^-|^`|^:::|^</.test(first),
+      false,
+      `${fileName} should open on a paragraph, not ${first}`,
+    );
+  }
+});

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -122,3 +122,24 @@ test("docs_html_has_rel_alternate_to_the_twin_once_and_landing_has_none", async 
   const landing = await read(join(distDir, "index.html"));
   assert.doesNotMatch(landing, /rel="alternate" type="text\/markdown"/);
 });
+
+test("vercel_json_rewrites_docs_html_to_markdown_twin_when_accept_contains_text_markdown", async () => {
+  const config = JSON.parse(await read(join(siteRoot, "vercel.json")));
+  const rewrite = (config.rewrites || []).find((entry) =>
+    String(entry.source).includes("/docs/:path"),
+  );
+  assert.ok(rewrite, "expected a docs rewrite");
+  assert.match(String(rewrite.source), /\/docs\/:path\*/);
+  assert.match(String(rewrite.destination), /\.md$/);
+  const accept = (rewrite.has || []).find(
+    (item) => item.type === "header" && String(item.key).toLowerCase() === "accept",
+  );
+  assert.ok(accept, "expected an Accept header matcher");
+  assert.match(String(accept.value), /text\/markdown/);
+  const vary = (config.headers || []).find(
+    (entry) =>
+      /\/docs\/\(\.\*\)$/.test(String(entry.source)) &&
+      (entry.headers || []).some((header) => header.key === "Vary" && header.value === "Accept"),
+  );
+  assert.ok(vary, "expected Vary: Accept on /docs/(.*)");
+});

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -171,6 +171,30 @@ test("vercel_json_rewrites_docs_html_to_markdown_twin_when_accept_contains_text_
   assert.ok(vary, "expected Vary: Accept on /docs/(.*)");
 });
 
+test("vercel_json_docs_rewrite_does_not_capture_a_trailing_slash", async () => {
+  const config = JSON.parse(await read(join(siteRoot, "vercel.json")));
+  const rewrites = (config.rewrites || []).filter((entry) =>
+    String(entry.source).includes("/docs/:path"),
+  );
+  assert.ok(rewrites.length > 0, "expected a docs path rewrite");
+  let matchesTrailingSlash = false;
+  for (const rewrite of rewrites) {
+    const source = String(rewrite.source);
+    const inner = source.match(/:path\((.*)\)(?:\/\?|\/)?$/)?.[1];
+    assert.ok(inner, `${source} needs a custom :path regex`);
+    const innerRe = new RegExp(`^(?:${inner})$`);
+    assert.match("cli", innerRe);
+    assert.doesNotMatch("cli/", innerRe);
+    assert.doesNotMatch("cli.md", innerRe);
+    assert.match(String(rewrite.destination), /^\/docs\/:path\.md$/);
+    if (/\/\?$|\/$/.test(source)) matchesTrailingSlash = true;
+  }
+  assert.ok(
+    matchesTrailingSlash,
+    "expected a rewrite that matches /docs/<slug>/",
+  );
+});
+
 test("robots_txt_allows_star_and_listed_crawlers_and_names_the_sitemap", async () => {
   const robots = await read(join(siteRoot, "public/robots.txt"));
   assert.match(robots, /^User-agent: \*\nAllow: \//m);

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -231,3 +231,64 @@ test("llms_full_txt_contains_every_docs_title_in_sidebar_order", async () => {
     cursor = index + heading.length;
   }
 });
+
+function jsonLdBlocks(html) {
+  return [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)].map(
+    (match) => JSON.parse(match[1]),
+  );
+}
+
+test("landing_jsonld_is_software_application_with_required_fields", async () => {
+  ensureDist();
+  const html = await read(join(distDir, "index.html"));
+  const blobs = jsonLdBlocks(html);
+  const app = blobs.find((blob) => blob["@type"] === "SoftwareApplication");
+  assert.ok(app, "missing SoftwareApplication json-ld");
+  assert.equal(app.name, "tsk");
+  assert.equal(app.applicationCategory, "DeveloperApplication");
+  assert.match(String(app.operatingSystem), /macOS/);
+  assert.match(String(app.operatingSystem), /Linux/);
+  assert.match(String(app.license), /MIT/i);
+  assert.equal(app.codeRepository, "https://github.com/smarzban/herdr-tsk");
+  const version = (await read(join(siteRoot, "src/version.mjs"))).match(/VERSION = '([^']+)'/)?.[1];
+  assert.equal(app.softwareVersion, version);
+  assert.equal(String(app.offers?.price), "0");
+});
+
+test("docs_jsonld_is_tech_article_with_headline_description_date_and_is_part_of", async () => {
+  ensureDist();
+  const files = await docsFiles();
+  for (const fileName of files) {
+    const slug = fileName.replace(/\.(md|mdx)$/, "");
+    const htmlPath =
+      slug === "index"
+        ? join(distDir, "docs", "index.html")
+        : join(distDir, "docs", slug, "index.html");
+    const source = await read(join(docsDir, fileName));
+    const title = source.match(/^title:\s*(.+)$/m)?.[1]?.replace(/^"|"$/g, "");
+    const description = source.match(/^description:\s*(.+)$/m)?.[1]?.replace(/^"|"$/g, "");
+    const html = await read(htmlPath);
+    const article = jsonLdBlocks(html).find((blob) => blob["@type"] === "TechArticle");
+    assert.ok(article, `${slug} missing TechArticle json-ld`);
+    assert.equal(article.headline, title);
+    assert.equal(article.description, description);
+    assert.match(String(article.dateModified), /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(article.isPartOf?.url, "https://gettsk.sh/");
+  }
+});
+
+test("definition_sentence_appears_verbatim_in_index_astro_llms_txt_docs_index_and_readme", async () => {
+  const files = [
+    join(siteRoot, "src/pages/index.astro"),
+    join(siteRoot, "public/llms.txt"),
+    join(docsDir, "index.mdx"),
+    join(repoRoot, "README.md"),
+  ];
+  for (const filePath of files) {
+    const text = await read(filePath);
+    assert.ok(
+      text.includes(DEFINITION_SENTENCE),
+      `${filePath} is missing the definition sentence`,
+    );
+  }
+});

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -182,3 +182,52 @@ test("every_docs_entry_has_description_and_an_answer_first_paragraph", async () 
     );
   }
 });
+
+const DEFINITION_SENTENCE =
+  "tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.";
+
+const SIDEBAR_TITLES = [
+  "Overview",
+  "Install",
+  "Board",
+  "Keys",
+  "Capture",
+  "Task page",
+  "Steps",
+  "CLI",
+];
+
+test("llms_txt_is_under_60_lines_starts_with_definition_sentence_and_has_no_key_chords", async () => {
+  const text = await read(join(siteRoot, "public/llms.txt"));
+  const lines = text.replace(/\s+$/, "").split("\n");
+  assert.ok(lines.length < 60, `llms.txt is ${lines.length} lines`);
+  assert.equal(lines[0], "# tsk");
+  assert.match(text, new RegExp(`^> ${DEFINITION_SENTENCE}$`, "m"));
+  assert.doesNotMatch(text, /ctrl\+/i);
+  assert.doesNotMatch(text, /prefix\+/);
+  assert.doesNotMatch(text, /\bj\/k\b/);
+});
+
+test("every_llms_txt_gettsk_sh_link_except_agents_md_resolves_in_dist", async () => {
+  ensureDist();
+  const text = await read(join(siteRoot, "public/llms.txt"));
+  const links = [...text.matchAll(/https:\/\/gettsk\.sh(\/[^\s)]+)/g)].map((match) => match[1]);
+  assert.ok(links.length > 0, "expected gettsk.sh links");
+  for (const path of links) {
+    if (path === "/docs/agents.md") continue;
+    const filePath = join(distDir, path.replace(/^\//, ""));
+    assert.equal(existsSync(filePath), true, `missing ${filePath} for ${path}`);
+  }
+});
+
+test("llms_full_txt_contains_every_docs_title_in_sidebar_order", async () => {
+  ensureDist();
+  const text = await read(join(distDir, "llms-full.txt"));
+  let cursor = 0;
+  for (const title of SIDEBAR_TITLES) {
+    const heading = `# ${title}`;
+    const index = text.indexOf(heading, cursor);
+    assert.ok(index >= 0, `missing title ${title}`);
+    cursor = index + heading.length;
+  }
+});

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  formatTwin,
+  htmlUrlForSlug,
+  slugFromDocsId,
+  sourceFileName,
+  stripFrontmatter,
+  twinUrlForSlug,
+} from "../src/lib/agent-docs.mjs";
+
+const siteRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const repoRoot = dirname(siteRoot);
+const docsDir = join(siteRoot, "src/content/docs/docs");
+const distDir = join(siteRoot, "dist");
+
+const read = (path) => readFile(path, "utf8");
+
+function ensureDist() {
+  if (existsSync(join(distDir, "index.html"))) return;
+  const result = spawnSync("npm", ["run", "build"], {
+    cwd: siteRoot,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+async function docsFiles() {
+  const names = await readdir(docsDir);
+  return names.filter((name) => name.endsWith(".md") || name.endsWith(".mdx"));
+}
+
+test("markdown_twin_formatter_prefixes_title_html_source_and_updated", () => {
+  const rendered = formatTwin({
+    title: "CLI",
+    slug: "cli",
+    fileName: "cli.md",
+    updatedIso: "2026-09-09T00:00:00.000Z",
+    body: "The same store backs the board.\n",
+  });
+  assert.equal(
+    rendered,
+    [
+      "# CLI",
+      "",
+      "- html: https://gettsk.sh/docs/cli/",
+      "- source: https://github.com/smarzban/herdr-tsk/blob/main/site/src/content/docs/docs/cli.md",
+      "- updated: 2026-09-09T00:00:00.000Z",
+      "",
+      "The same store backs the board.",
+      "",
+    ].join("\n"),
+  );
+  assert.equal(htmlUrlForSlug("index"), "https://gettsk.sh/docs/");
+  assert.equal(twinUrlForSlug("index"), "https://gettsk.sh/docs/index.md");
+  assert.equal(slugFromDocsId("docs/cli"), "cli");
+  assert.equal(slugFromDocsId("docs/index"), "index");
+  assert.equal(sourceFileName("src/content/docs/docs/index.mdx"), "index.mdx");
+});
+
+test("dist_has_a_markdown_twin_for_every_docs_entry_with_matching_body", async () => {
+  ensureDist();
+  const files = await docsFiles();
+  assert.ok(files.length >= 8, "docs collection should have the current pages");
+  for (const fileName of files) {
+    const slug = fileName.replace(/\.(md|mdx)$/, "");
+    const twinPath = join(distDir, "docs", `${slug}.md`);
+    assert.equal(existsSync(twinPath), true, `missing twin ${twinPath}`);
+    const twin = await read(twinPath);
+    const source = await read(join(docsDir, fileName));
+    const body = stripFrontmatter(source).replace(/\s+$/, "");
+    const afterHeader = twin.replace(/^# .*\n\n(?:- .*\n){3}\n/, "").replace(/\s+$/, "");
+    assert.equal(afterHeader, body, `${fileName} twin body mismatch`);
+    const title = source.match(/^title:\s*(.+)$/m)?.[1]?.replace(/^"|"$/g, "");
+    assert.match(twin, new RegExp(`^# ${title}\\n`));
+    assert.match(twin, /- html: https:\/\/gettsk\.sh\/docs\//);
+    assert.match(
+      twin,
+      new RegExp(
+        `- source: https://github.com/smarzban/herdr-tsk/blob/main/site/src/content/docs/docs/${fileName}`,
+      ),
+    );
+    assert.match(twin, /- updated: \d{4}-\d{2}-\d{2}T/);
+  }
+});
+
+test("sitemap_xml_contains_no_md_urls", async () => {
+  ensureDist();
+  const names = await readdir(distDir);
+  const sitemaps = names.filter((name) => name.startsWith("sitemap") && name.endsWith(".xml"));
+  assert.ok(sitemaps.length > 0, "expected a built sitemap");
+  for (const name of sitemaps) {
+    const xml = await read(join(distDir, name));
+    assert.doesNotMatch(xml, /\.md</);
+    assert.doesNotMatch(xml, /\.md</);
+    assert.doesNotMatch(xml, /docs\/[^<]+\.md/);
+  }
+});
+
+test("docs_html_has_rel_alternate_to_the_twin_once_and_landing_has_none", async () => {
+  ensureDist();
+  const files = await docsFiles();
+  for (const fileName of files) {
+    const slug = fileName.replace(/\.(md|mdx)$/, "");
+    const htmlPath =
+      slug === "index"
+        ? join(distDir, "docs", "index.html")
+        : join(distDir, "docs", slug, "index.html");
+    const html = await read(htmlPath);
+    const href = twinUrlForSlug(slug);
+    const tag = `<link rel="alternate" type="text/markdown" href="${href}">`;
+    const matches = html.split(tag).length - 1;
+    assert.equal(matches, 1, `${slug} should contain the alternate link once`);
+  }
+  const landing = await read(join(distDir, "index.html"));
+  assert.doesNotMatch(landing, /rel="alternate" type="text\/markdown"/);
+});

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -143,3 +143,24 @@ test("vercel_json_rewrites_docs_html_to_markdown_twin_when_accept_contains_text_
   );
   assert.ok(vary, "expected Vary: Accept on /docs/(.*)");
 });
+
+test("robots_txt_allows_star_and_listed_crawlers_and_names_the_sitemap", async () => {
+  const robots = await read(join(siteRoot, "public/robots.txt"));
+  assert.match(robots, /^User-agent: \*\nAllow: \//m);
+  for (const agent of [
+    "GPTBot",
+    "ClaudeBot",
+    "Claude-SearchBot",
+    "PerplexityBot",
+    "Google-Extended",
+    "Applebot-Extended",
+    "Bingbot",
+  ]) {
+    assert.match(
+      robots,
+      new RegExp(`User-agent: ${agent}\nAllow: /`),
+      `missing allow for ${agent}`,
+    );
+  }
+  assert.match(robots, /Sitemap: https:\/\/gettsk\.sh\/sitemap-index\.xml/);
+});

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
-import { dirname, extname, join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import test from "node:test";
 
 import {
   formatTwin,
   htmlUrlForSlug,
+  newestCommitIso,
+  serializeJsonLd,
   slugFromDocsId,
   sourceFileName,
   stripFrontmatter,
@@ -63,6 +66,27 @@ test("markdown_twin_formatter_prefixes_title_html_source_and_updated", () => {
   assert.equal(slugFromDocsId("docs/cli"), "cli");
   assert.equal(slugFromDocsId("docs/index"), "index");
   assert.equal(sourceFileName("src/content/docs/docs/index.mdx"), "index.mdx");
+});
+
+test("serializeJsonLd_escapes_script_breakout_and_round_trips", () => {
+  const raw = serializeJsonLd({ headline: "</script><script>alert(1)</script>" });
+  assert.doesNotMatch(raw, /<\/script>/i);
+  assert.match(raw, /\\u003c/);
+  assert.equal(JSON.parse(raw).headline, "</script><script>alert(1)</script>");
+});
+
+test("newestCommitIso_falls_back_to_mtime_when_git_history_is_missing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tsk-twin-"));
+  const filePath = join(dir, "orphan.md");
+  writeFileSync(filePath, "hi\n");
+  try {
+    const iso = newestCommitIso(filePath);
+    assert.match(iso, /^\d{4}-\d{2}-\d{2}T/);
+    const mtimeIso = statSync(filePath).mtime.toISOString();
+    assert.equal(iso, mtimeIso);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("dist_has_a_markdown_twin_for_every_docs_entry_with_matching_body", async () => {
@@ -129,8 +153,11 @@ test("vercel_json_rewrites_docs_html_to_markdown_twin_when_accept_contains_text_
     String(entry.source).includes("/docs/:path"),
   );
   assert.ok(rewrite, "expected a docs rewrite");
-  assert.match(String(rewrite.source), /\/docs\/:path\*/);
+  assert.match(String(rewrite.source), /\/docs\/:path/);
+  assert.match(String(rewrite.source), /\\\.md/);
   assert.match(String(rewrite.destination), /\.md$/);
+  assert.doesNotMatch(String(rewrite.destination), /\.md\.md/);
+  assert.doesNotMatch(String(rewrite.source), /:path\*$/);
   const accept = (rewrite.has || []).find(
     (item) => item.type === "header" && String(item.key).toLowerCase() === "accept",
   );

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -164,7 +164,7 @@ test("docs paint keys as keycaps and leave flags as code", async () => {
 
 test("docs open on the two-party board and let agents set status", async () => {
   const overview = await read("../src/content/docs/docs/index.mdx");
-  assert.match(overview, /a task board for you and your agents/);
+  assert.match(overview, /a terminal task board for you and your agents/);
   assert.match(overview, /tsk status/);
   assert.doesNotMatch(overview, /Done is a human verb/);
   const cli = await read("../src/content/docs/docs/cli.md");

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -13,6 +13,50 @@
           "value": "text/markdown; charset=utf-8"
         }
       ]
+    },
+    {
+      "source": "/docs/(.*)",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/docs",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": "(.*)text/markdown(.*)"
+        }
+      ],
+      "destination": "/docs/index.md"
+    },
+    {
+      "source": "/docs/",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": "(.*)text/markdown(.*)"
+        }
+      ],
+      "destination": "/docs/index.md"
+    },
+    {
+      "source": "/docs/:path*",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": "(.*)text/markdown(.*)"
+        }
+      ],
+      "destination": "/docs/:path.md"
     }
   ]
 }

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -48,7 +48,7 @@
       "destination": "/docs/index.md"
     },
     {
-      "source": "/docs/:path*",
+      "source": "/docs/:path((?!.*\\.md$).*)",
       "has": [
         {
           "type": "header",

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -48,7 +48,7 @@
       "destination": "/docs/index.md"
     },
     {
-      "source": "/docs/:path((?!.*\\.md$).*)",
+      "source": "/docs/:path((?!.*\\.md$)[^/]+)/?",
       "has": [
         {
           "type": "header",

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -3,5 +3,16 @@
   "outputDirectory": "dist",
   "framework": "astro",
   "installCommand": "npm ci",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
+  "headers": [
+    {
+      "source": "/docs/(.*).md",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

gettsk.sh currently has no deliberate agent or crawler surface: no `.md` twins, no `robots.txt`, no structured data, and `llms.txt` is TUI chrome. This PR is **site plumbing only** (T-1..T-7). It publishes a Markdown twin for every docs page, rewrites `Accept: text/markdown` to that twin, ships `robots.txt` and a short `llms.txt` plus `llms-full.txt`, emits JSON-LD, and pins the definition sentence on the in-repo surfaces.

CLI (`tsk guide`, `tsk setup <agent>`), `/docs/agents/`, the docs control row, and the landing agents band wait for PR 2 (`agent-site/guide`).

## Acceptance criteria (this PR)

In scope: AC-5, AC-6, AC-8, AC-9, AC-10, AC-11, AC-14, AC-15, AC-16 (in-repo minus agents page), AC-17.

Out of scope (PR 2): AC-1, AC-2, AC-3, AC-4, AC-7, AC-12, AC-13, AC-18, AC-16 agents page.

## Coverage

| AC | Task |
| --- | --- |
| AC-5 | T-1 |
| AC-6 | T-2 |
| AC-8, AC-9, AC-16 (llms.txt) | T-5 |
| AC-10 | T-1, T-3 |
| AC-11 | T-3 (robots.txt; live UA curl after preview) |
| AC-14, AC-17 | T-6 (blobs tested; hosted validators after preview) |
| AC-15 | T-4 |
| AC-16 (landing, docs index, README) | T-7 |

## Verification

`sdlc-check 0.20.1 docs/specs/agent-site/agent-site.md --require ledger --require verification-report`: exit 0, 0 findings.

Fresh suite at pr-review: `cargo fmt --check` 0, `cargo clippy --all-targets -- -D warnings` 0, `cargo test` 0, `cargo build --release` 0, `cd site && npm test` 33 pass / 0 fail, `npm run build` 0, `npm run test:parity` 26 passed / 0 failed.

| Criterion | Type | Proof |
| --- | --- | --- |
| AC-1 | reviewer-checked | Out of scope for PR 1. Claimed by T-8 on agent-site/guide. |
| AC-2 | reviewer-checked | Out of scope for PR 1. Claimed by T-9 on agent-site/guide. |
| AC-3 | reviewer-checked | Out of scope for PR 1. Claimed by T-8 and T-9 on agent-site/guide. |
| AC-4 | reviewer-checked | Out of scope for PR 1. Claimed by T-9 on agent-site/guide. |
| AC-5 | test-backed | dist_has_a_markdown_twin_for_every_docs_entry_with_matching_body |
| AC-6 | test-backed | vercel_json_rewrites_docs_html_to_markdown_twin_when_accept_contains_text_markdown |
| AC-7 | reviewer-checked | Out of scope for PR 1. Claimed by T-10 on agent-site/guide. |
| AC-8 | test-backed | llms_txt_is_under_60_lines_starts_with_definition_sentence_and_has_no_key_chords, every_llms_txt_gettsk_sh_link_except_agents_md_resolves_in_dist |
| AC-9 | test-backed | llms_full_txt_contains_every_docs_title_in_sidebar_order |
| AC-10 | test-backed | sitemap_xml_contains_no_md_urls, robots_txt_allows_star_and_listed_crawlers_and_names_the_sitemap |
| AC-11 | reviewer-checked | Pending hosted preview. robots.txt allows the named crawlers; live curl -A is recorded after the preview URL exists. |
| AC-12 | reviewer-checked | Out of scope for PR 1. Claimed by T-12 on agent-site/guide. |
| AC-13 | reviewer-checked | Out of scope for PR 1. Claimed by T-11 on agent-site/guide. |
| AC-14 | test-backed | landing_jsonld_is_software_application_with_required_fields, docs_jsonld_is_tech_article_with_headline_description_date_and_is_part_of |
| AC-15 | test-backed | every_docs_entry_has_description_and_an_answer_first_paragraph |
| AC-16 | test-backed | definition_sentence_appears_verbatim_in_index_astro_llms_txt_docs_index_and_readme |
| AC-17 | reviewer-checked | Pending hosted Lighthouse SEO on / and /docs/. In-scope blobs are tested under AC-14. |
| AC-18 | reviewer-checked | Out of scope for PR 1. Claimed by T-8 T-10 T-12 on agent-site/guide. |

### Hosted checks still owed after preview

- AC-6 preview curl for Accept rewrite (fallback already shipped: `.md` URLs plus `rel=alternate`)
- AC-11 crawler User-Agent curls
- AC-14 schema.org validator and Google Rich Results (do not fabricate ratings if that is the only miss)
- AC-17 Lighthouse SEO on `/` and `/docs/`
- AC-16 GitHub repo description (owner-only)

### Known compromises

- `/docs/agents.md` may 404 until PR 2. The llms.txt test allows that one link.
- Spec tree (`docs/specs/`) is globally gitignored in this clone; the proof map is published here instead of a committed verification report.

## Provenance

Entered at a settled brief in `docs/specs/agent-site/agent-site.md` (materialized AC/Design/Tech Stack/Plan 2026-09-09). Gate verdict: ready to build. No untraced links.

## Spec

Local: `docs/specs/agent-site/agent-site.md` (gitignored). Shipping split: `docs/specs/agent-site/plan.md`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cd site && npm test && npm run build`
- [x] `cd site && npm run test:parity`
- [ ] Preview: `curl -H 'Accept: text/markdown' https://<preview>/docs/cli/` → twin, `Vary: Accept`
- [ ] Preview: `curl -A GPTBot` (and the other AC-10 crawlers) on `/docs/cli/` → 200 HTML
- [ ] schema.org + Rich Results + Lighthouse SEO
- Live herdr smoke was not required: this PR does not change the board.
