### PR TITLE
feat: tsk guide, agent setup, and agent site surfaces

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "site/**"
+      - "skills/**"
       - ".github/workflows/site.yml"
 
 permissions:

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,13 +1,14 @@
 name: Vercel
 
 # Deploys are driven here, not by Vercel's Git integration, so only
-# changes under site/ ever reach Vercel.
+# changes under site/ or skills/ ever reach Vercel.
 
 on:
   push:
     branches: [main]
     paths:
       - "site/**"
+      - "skills/**"
       - ".github/workflows/vercel.yml"
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+`tsk setup grok` installs the CLI skill into `~/.grok/skills/`. Empty `--skill-dir` is usage. A symlink at the skill folder or `SKILL.md` is refused.
+
 The installer configures PATH for Bash and Zsh, then tells you to reopen the terminal or run an export command.
 
 ## 0.6.0

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -22,6 +22,9 @@ pnpm-debug.log*
 # leftover decode/lock scratch (never ship)
 tmp/
 
+# generated from ../../skills/tsk-cli/SKILL.md
+src/content/docs/docs/agents.md
+
 # regenerated from src/assets/icon-*.svg
 public/apple-touch-icon.png
 public/apple-touch-icon-dark.png

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
       },
       components: {
         Head: './src/components/DocsHead.astro',
+        PageTitle: './src/components/DocsPageTitle.astro',
         SiteTitle: './src/components/DocsTitle.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',
         SocialIcons: './src/components/DocsLinks.astro',
@@ -111,6 +112,10 @@ export default defineConfig({
         {
           tag: 'script',
           attrs: { src: '/theme.js' },
+        },
+        {
+          tag: 'script',
+          attrs: { src: '/docs-copy.js' },
         },
         {
           tag: 'link',

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -90,6 +90,7 @@ export default defineConfig({
           label: 'Start here',
           items: [
             { label: 'Overview', slug: 'docs' },
+            { label: 'tsk for agents', slug: 'docs/agents' },
             { label: 'Install', slug: 'docs/install' },
             { label: 'Board', slug: 'docs/board' },
             { label: 'Keys', slug: 'docs/keys' },

--- a/site/package.json
+++ b/site/package.json
@@ -4,9 +4,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "node scripts/generate-apple-touch.mjs && astro dev",
+    "dev": "node scripts/generate-apple-touch.mjs && node scripts/sync-agents-page.mjs && astro dev",
     "start": "astro dev",
-    "build": "node scripts/generate-apple-touch.mjs && astro build",
+    "prebuild": "node scripts/generate-apple-touch.mjs && node scripts/sync-agents-page.mjs",
+    "build": "astro build",
+    "pretest": "node scripts/sync-agents-page.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "generate-apple-touch": "node scripts/generate-apple-touch.mjs",

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "node scripts/generate-apple-touch.mjs && node scripts/sync-agents-page.mjs && astro dev",
-    "start": "astro dev",
+    "start": "npm run dev",
     "prebuild": "node scripts/generate-apple-touch.mjs && node scripts/sync-agents-page.mjs",
     "build": "astro build",
     "pretest": "node scripts/sync-agents-page.mjs",

--- a/site/parity/agent-surface.spec.mjs
+++ b/site/parity/agent-surface.spec.mjs
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test.use({
+  permissions: ["clipboard-read", "clipboard-write"],
+});
+
+test("docs_cli_shows_markdown_link_and_copy_for_agent_writes_read_url", async ({
+  page,
+  context,
+}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.goto("http://127.0.0.1:4180/docs/cli/");
+  const row = page.locator(".docs-agent-row");
+  await expect(row).toContainText("markdown");
+  await expect(row).toContainText("copy for agent");
+  await expect(row.locator("a", { hasText: "markdown" })).toHaveAttribute(
+    "href",
+    "/docs/cli.md",
+  );
+  await row.getByRole("button", { name: "copy for agent" }).click();
+  const copied = await page.evaluate(() => navigator.clipboard.readText());
+  expect(copied).toBe("Read https://gettsk.sh/docs/cli.md and follow it.");
+  const colors = await row.evaluate((el) => {
+    const probe = document.createElement("span");
+    probe.style.color = "var(--sl-color-gray-3)";
+    document.body.appendChild(probe);
+    const expected = getComputedStyle(probe).color;
+    probe.remove();
+    return { actual: getComputedStyle(el).color, expected };
+  });
+  expect(colors.actual).toBe(colors.expected);
+  expect(colors.actual).not.toMatch(/#/);
+});

--- a/site/parity/agent-surface.spec.mjs
+++ b/site/parity/agent-surface.spec.mjs
@@ -31,3 +31,47 @@ test("docs_cli_shows_markdown_link_and_copy_for_agent_writes_read_url", async ({
   expect(colors.actual).toBe(colors.expected);
   expect(colors.actual).not.toMatch(/#/);
 });
+
+const BOOTSTRAP = [
+  "Use tsk for my task board. Run `tsk guide` and follow it;",
+  "if tsk is not installed, read https://gettsk.sh/docs/agents/",
+  "and ask me before installing.",
+].join("\n");
+
+test("landing_agents_band_after_cli_copies_bootstrap_and_stays_on_palette", async ({
+  page,
+  context,
+}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.goto("http://127.0.0.1:4180/");
+  const ids = await page.evaluate(() =>
+    [...document.querySelectorAll("section[id]")].map((section) => section.id),
+  );
+  expect(ids.indexOf("cli")).toBeGreaterThanOrEqual(0);
+  expect(ids.indexOf("agents")).toBeGreaterThan(ids.indexOf("cli"));
+  expect(ids.indexOf("install")).toBeGreaterThan(ids.indexOf("agents"));
+  const band = page.locator("#agents");
+  await expect(band.getByRole("heading", { name: "Hand it to your agent." })).toBeVisible();
+  await expect(band.locator(".index")).toContainText("06");
+  const paletteCheck = await page.evaluate(() => {
+    const used = new Set();
+    document.querySelectorAll("body *").forEach((el) => {
+      if (el.closest("#agents")) return;
+      const style = getComputedStyle(el);
+      used.add(style.color);
+      used.add(style.backgroundColor);
+    });
+    const outsiders = [];
+    document.querySelectorAll("#agents, #agents *").forEach((el) => {
+      const style = getComputedStyle(el);
+      for (const value of [style.color, style.backgroundColor]) {
+        if (!used.has(value)) outsiders.push(value);
+      }
+    });
+    return outsiders;
+  });
+  expect(paletteCheck).toEqual([]);
+  await band.locator("[data-copy]").click();
+  const copied = await page.evaluate(() => navigator.clipboard.readText());
+  expect(copied).toBe(BOOTSTRAP);
+});

--- a/site/parity/navigation.spec.mjs
+++ b/site/parity/navigation.spec.mjs
@@ -8,9 +8,13 @@ test("project navigation, counted views and selection match the app", async ({
     "background-color",
     "rgba(0, 0, 0, 0)",
   );
-  await expect(page.locator(".tsk-tab-group.is-on")).toHaveCSS(
+  await expect(page.locator(".tsk-tab-group.is-on .tsk-tab")).toHaveCSS(
     "text-decoration-line",
     "underline",
+  );
+  await expect(page.locator(".tsk-tab-group.is-on")).toHaveCSS(
+    "text-decoration-line",
+    "none",
   );
   for (const inactive of await page
     .locator(".tsk-tab-group:not(.is-on)")

--- a/site/public/board-demo.js
+++ b/site/public/board-demo.js
@@ -1274,7 +1274,7 @@ import { parseCapture } from "./capture.js";
     const tabs = TABS.map(([tab, label]) => {
       const on = state.tab === tab;
       const text = tab === "project" ? state.selectedProject : label;
-      return `<span class="tsk-tab-group ${on ? "is-on" : ""}"><button type="button" class="tsk-tab ${on ? "is-on" : ""}" data-tab="${tab}">${esc(text)}</button>${tab === "project" ? `<button class="tsk-tab-arrow" data-chip="1" aria-label="choose project"> ▾</button>` : ""}</span>`;
+      return `<span class="tsk-tab-group ${on ? "is-on" : ""}"><button type="button" class="tsk-tab ${on ? "is-on" : ""}" data-tab="${tab}">${esc(text)}</button>${tab === "project" ? `<button class="tsk-tab-arrow" data-chip="1" aria-label="choose project">▾</button>` : ""}</span>`;
     }).join(`<span class="dim"> · </span>`);
     const filter = state.focusProject
       ? state.threadFilter === null

--- a/site/public/docs-copy.js
+++ b/site/public/docs-copy.js
@@ -1,0 +1,10 @@
+document.addEventListener("click", async (event) => {
+  const btn = event.target.closest("[data-agent-copy]");
+  if (!btn) return;
+  const text = btn.getAttribute("data-copy-text") || "";
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (_) {
+    /* clipboard may be denied; the control still names the twin */
+  }
+});

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -7,6 +7,7 @@ Details: https://gettsk.sh/docs/install.md
 
 ## For agents
 
+- `tsk guide` prints the workflow; `tsk setup <agent>` installs the skill
 - Guide: https://gettsk.sh/docs/agents.md
 - CLI: https://gettsk.sh/docs/cli.md
 - Full docs: https://gettsk.sh/llms-full.txt

--- a/site/scripts/sync-agents-page.mjs
+++ b/site/scripts/sync-agents-page.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Generate the gitignored /docs/agents/ source from skills/tsk-cli/SKILL.md.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DEFINITION_SENTENCE, stripFrontmatter } from "../src/lib/agent-docs.mjs";
+
+const siteRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const repoRoot = dirname(siteRoot);
+const destDir = join(siteRoot, "src/content/docs/docs");
+const dest = join(destDir, "agents.md");
+const skill = readFileSync(join(repoRoot, "skills/tsk-cli/SKILL.md"), "utf8");
+const body = stripFrontmatter(skill).replace(/^\uFEFF/, "").replace(/\s+$/, "");
+
+mkdirSync(destDir, { recursive: true });
+writeFileSync(
+  dest,
+  [
+    "---",
+    "title: tsk for agents",
+    "description: The agent workflow printed by tsk guide, including what to do if tsk is not installed.",
+    "---",
+    "",
+    DEFINITION_SENTENCE,
+    "",
+    body,
+    "",
+  ].join("\n"),
+);

--- a/site/scripts/sync-agents-page.mjs
+++ b/site/scripts/sync-agents-page.mjs
@@ -12,7 +12,10 @@ const repoRoot = dirname(siteRoot);
 const destDir = join(siteRoot, "src/content/docs/docs");
 const dest = join(destDir, "agents.md");
 const skill = readFileSync(join(repoRoot, "skills/tsk-cli/SKILL.md"), "utf8");
-const body = stripFrontmatter(skill).replace(/^\uFEFF/, "").replace(/\s+$/, "");
+const body = stripFrontmatter(skill)
+  .replace(/^\uFEFF/, "")
+  .replace(/^# [^\n]+\n+/, "")
+  .replace(/\s+$/, "");
 
 mkdirSync(destDir, { recursive: true });
 writeFileSync(

--- a/site/src/components/DocsHead.astro
+++ b/site/src/components/DocsHead.astro
@@ -2,23 +2,19 @@
 import Head from '@astrojs/starlight/components/Head.astro';
 import SharedHead from './SharedHead.astro';
 import {
-  newestCommitIso,
   serializeJsonLd,
   SITE,
   slugFromDocsId,
+  twinSource,
   twinUrlForSlug,
 } from '../lib/agent-docs.mjs';
 
-const { entry, lastUpdated } = Astro.locals.starlightRoute;
+const { entry } = Astro.locals.starlightRoute;
 const isDocsPage = entry.id !== '404' && !entry.id.endsWith('/404');
-const href = isDocsPage ? twinUrlForSlug(slugFromDocsId(entry.id)) : '';
-const dateModified = isDocsPage
-  ? lastUpdated instanceof Date
-    ? lastUpdated.toISOString()
-    : entry.filePath
-      ? newestCommitIso(entry.filePath)
-      : undefined
-  : undefined;
+const slug = isDocsPage ? slugFromDocsId(entry.id) : '';
+const href = isDocsPage ? twinUrlForSlug(slug) : '';
+const dateModified =
+  isDocsPage && entry.filePath ? twinSource(slug, entry.filePath).updatedIso : undefined;
 const techArticle =
   isDocsPage && dateModified
     ? {

--- a/site/src/components/DocsPageTitle.astro
+++ b/site/src/components/DocsPageTitle.astro
@@ -1,0 +1,24 @@
+---
+import { slugFromDocsId, SITE } from '../lib/agent-docs.mjs';
+
+const { entry } = Astro.locals.starlightRoute;
+const isDocsPage = entry.id !== '404' && !entry.id.endsWith('/404');
+const slug = isDocsPage ? slugFromDocsId(entry.id) : '';
+const twinHref = slug ? `/docs/${slug}.md` : '';
+const copyText = slug ? `Read ${SITE}/docs/${slug}.md and follow it.` : '';
+---
+
+<div class="docs-title-block">
+  <h1 id="_top">{entry.data.title}</h1>
+  {
+    isDocsPage && (
+      <p class="docs-agent-row">
+        <a href={twinHref}>markdown</a>
+        <span aria-hidden="true"> · </span>
+        <button type="button" data-agent-copy data-copy-text={copyText}>
+          copy for agent
+        </button>
+      </p>
+    )
+  }
+</div>

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -27,6 +27,7 @@ The CLI is how an agent reaches the board. The rules that matter:
 
 The repo ships the same rules as an agent skill in
 [`skills/tsk-cli/SKILL.md`](https://github.com/smarzban/herdr-tsk/blob/main/skills/tsk-cli/SKILL.md).
+`tsk guide` prints that skill with the YAML frontmatter removed.
 
 ## Commands
 
@@ -35,10 +36,21 @@ The repo ships the same rules as an agent skill in
 | `tsk` | opens the board |
 | `tsk capture` | opens quick capture: the expanded quick-add page (also `TSK_MODE=capture`) |
 | `tsk add` · `tsk list` · `tsk steps` · `tsk status` · `tsk edit` · `tsk trash` · `tsk archive` · `tsk unarchive` · `tsk project` | headless; below |
+| `tsk guide` | print the agent workflow skill (frontmatter stripped), exit 0 |
 | `tsk --help` | usage, exit 0 |
 | `tsk --find-board-pane` | herdr helper: reads `pane list` JSON on stdin, prints the id of the pane labelled `tsk`; exit 1 when none |
 
 Every headless command takes `--state-dir <dir>` to work against another store.
+
+## guide
+
+Print the embedded agent skill, YAML frontmatter stripped. Stderr is empty.
+
+```
+tsk guide
+```
+
+Exit 0. The same body is the source for `/docs/agents/` and `tsk setup <agent>`.
 
 Human-readable stdout and stderr escape C0/C1 controls in stored titles, step
 text, and project names as `\u{00xx}`. JSON keeps the underlying values.

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -249,7 +249,7 @@ Edit refusals (exit 1): `unknown-task`, `soft-deleted-task`, `empty-title`,
 ```
 tsk setup
 tsk setup herdr
-tsk setup claude | pi | cursor | codex
+tsk setup claude | pi | cursor | grok | codex
 tsk setup --skill-dir <path> [--force] [--json]
 ```
 
@@ -266,13 +266,15 @@ that tool's user-level skills directory as `tsk-cli/SKILL.md`:
 - `claude` → `~/.claude/skills/`
 - `pi` → `~/.pi/agent/skills/`
 - `cursor` → `~/.cursor/skills/`
+- `grok` → `~/.grok/skills/`
 - `codex` → `~/.agents/skills/`
 - `--skill-dir <path>` → `<path>/tsk-cli/SKILL.md`
 
 A second run without `--force` exits 1 with `skill-exists` and leaves the file.
 `--force` overwrites. `--json` emits `outcome` (`written`, `exists`, or `listed`),
 `target`, and `path`. Two targets, or `herdr` plus `--skill-dir`, is usage (exit 2).
-A symlink at the skills root is refused.
+An empty `--skill-dir` is usage. A symlink at the skills root, the `tsk-cli`
+directory, or `SKILL.md` is refused.
 
 Exit codes: 0 success/help/list, 1 setup or confirmation failure or `skill-exists`,
 2 invalid arguments. Herdr setup does not edit task data. See

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -244,14 +244,37 @@ Status refusals (exit 1): `unknown-task`, `soft-deleted-task`.
 Edit refusals (exit 1): `unknown-task`, `soft-deleted-task`, `empty-title`,
 `invalid-title`.
 
-## Register the installed binary with Herdr
+## setup
 
-`tsk setup herdr` registers the embedded plugin assets and adds prefix+t (board)
-and prefix+a (quick capture). It uses the same installed binary, with no source
-checkout or second build. Herdr 0.9+ must be on PATH. Conflicting shortcuts require
-interactive confirmation; declining preserves them. A noninteractive conflict aborts
-without writes. `tsk setup herdr --help` is read-only.
+```
+tsk setup
+tsk setup herdr
+tsk setup claude | pi | cursor | codex
+tsk setup --skill-dir <path> [--force] [--json]
+```
 
-Exit codes: 0 success/help, 1 setup or confirmation failure, 2 invalid arguments.
-The command does not edit task data. See [installation](/docs/install/#herdr-setup-with-an-installed-binary)
+Bare `tsk setup` lists targets and writes nothing. `tsk setup herdr` registers
+the embedded plugin assets and adds prefix+t (board) and prefix+a (quick capture).
+It uses the same installed binary, with no source checkout or second build. Herdr
+0.9+ must be on PATH. Conflicting shortcuts require interactive confirmation;
+declining preserves them. A noninteractive conflict aborts without writes.
+`tsk setup herdr --help` is read-only.
+
+Agent targets write the embedded `skills/tsk-cli/SKILL.md` (frontmatter kept) into
+that tool's user-level skills directory as `tsk-cli/SKILL.md`:
+
+- `claude` → `~/.claude/skills/`
+- `pi` → `~/.pi/agent/skills/`
+- `cursor` → `~/.cursor/skills/`
+- `codex` → `~/.agents/skills/`
+- `--skill-dir <path>` → `<path>/tsk-cli/SKILL.md`
+
+A second run without `--force` exits 1 with `skill-exists` and leaves the file.
+`--force` overwrites. `--json` emits `outcome` (`written`, `exists`, or `listed`),
+`target`, and `path`. Two targets, or `herdr` plus `--skill-dir`, is usage (exit 2).
+A symlink at the skills root is refused.
+
+Exit codes: 0 success/help/list, 1 setup or confirmation failure or `skill-exists`,
+2 invalid arguments. Herdr setup does not edit task data. See
+[installation](/docs/install/#herdr-setup-with-an-installed-binary)
 for config paths, backups, reload, upgrades and removing integration.

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -30,6 +30,11 @@ tsk setup herdr
 herdr server reload-config
 ```
 
+To give an agent the CLI skill instead, run `tsk setup claude` (or `pi`,
+`cursor`, `codex`) after tsk is on PATH. That writes `tsk-cli/SKILL.md` into
+the tool's user-level skills directory. `tsk setup --skill-dir <path>` is the
+same write against any directory. See [CLI setup](/docs/cli/#setup).
+
 ## Open the board
 
 Run `tsk`, or press **prefix+t** in Herdr.

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -31,9 +31,9 @@ herdr server reload-config
 ```
 
 To give an agent the CLI skill instead, run `tsk setup claude` (or `pi`,
-`cursor`, `codex`) after tsk is on PATH. That writes `tsk-cli/SKILL.md` into
-the tool's user-level skills directory. `tsk setup --skill-dir <path>` is the
-same write against any directory. See [CLI setup](/docs/cli/#setup).
+`cursor`, `grok`, `codex`) after tsk is on PATH. That writes `tsk-cli/SKILL.md`
+into the tool's user-level skills directory. `tsk setup --skill-dir <path>` is
+the same write against any directory. See [CLI setup](/docs/cli/#setup).
 
 ## Open the board
 

--- a/site/src/lib/agent-docs.mjs
+++ b/site/src/lib/agent-docs.mjs
@@ -19,8 +19,11 @@ export const SIDEBAR_SLUGS = [
   "steps",
   "cli",
 ];
-export const SOURCE_BASE =
-  "https://github.com/smarzban/herdr-tsk/blob/main/site/src/content/docs/docs";
+export const SOURCE_REPO_BASE = "https://github.com/smarzban/herdr-tsk/blob/main";
+export const AGENTS_SKILL_REPO_PATH = "skills/tsk-cli/SKILL.md";
+export function agentsSkillFsPath() {
+  return resolve(process.cwd(), "../skills/tsk-cli/SKILL.md");
+}
 
 export function slugFromDocsId(id) {
   const value = String(id);
@@ -67,13 +70,27 @@ export function serializeJsonLd(value) {
   return JSON.stringify(value).replace(/</g, "\\u003c");
 }
 
-export function formatTwin({ title, slug, fileName, updatedIso, body }) {
+export function twinSource(slug, filePath) {
+  if (slug === "agents") {
+    return {
+      sourcePath: AGENTS_SKILL_REPO_PATH,
+      updatedIso: newestCommitIso(agentsSkillFsPath()),
+    };
+  }
+  return {
+    sourcePath: `site/src/content/docs/docs/${sourceFileName(filePath)}`,
+    updatedIso: newestCommitIso(filePath),
+  };
+}
+
+export function formatTwin({ title, slug, sourcePath, fileName, updatedIso, body }) {
   const trimmed = String(body).replace(/^\uFEFF/, "").replace(/\s+$/, "");
+  const path = sourcePath || `site/src/content/docs/docs/${fileName}`;
   return [
     `# ${title}`,
     "",
     `- html: ${htmlUrlForSlug(slug)}`,
-    `- source: ${SOURCE_BASE}/${fileName}`,
+    `- source: ${SOURCE_REPO_BASE}/${path}`,
     `- updated: ${updatedIso}`,
     "",
     trimmed,

--- a/site/src/lib/agent-docs.mjs
+++ b/site/src/lib/agent-docs.mjs
@@ -10,6 +10,7 @@ export const DEFINITION_SENTENCE =
   "tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.";
 export const SIDEBAR_SLUGS = [
   "index",
+  "agents",
   "install",
   "board",
   "keys",

--- a/site/src/pages/docs/[...slug].md.ts
+++ b/site/src/pages/docs/[...slug].md.ts
@@ -4,10 +4,9 @@ import { getCollection } from "astro:content";
 
 import {
   formatTwin,
-  newestCommitIso,
   slugFromDocsId,
-  sourceFileName,
   stripFrontmatter,
+  twinSource,
 } from "../../lib/agent-docs.mjs";
 
 export async function getStaticPaths() {
@@ -28,11 +27,13 @@ export async function GET({
     throw new Error(`docs entry ${entry.id} has no filePath`);
   }
   const source = await readFile(join(process.cwd(), entry.filePath), "utf8");
+  const slug = slugFromDocsId(entry.id);
+  const { sourcePath, updatedIso } = twinSource(slug, entry.filePath);
   const twin = formatTwin({
     title: entry.data.title,
-    slug: slugFromDocsId(entry.id),
-    fileName: sourceFileName(entry.filePath),
-    updatedIso: newestCommitIso(entry.filePath),
+    slug,
+    sourcePath,
+    updatedIso,
     body: stripFrontmatter(source),
   });
   return new Response(twin, {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -115,6 +115,7 @@ const softwareApplication = {
           <a href="#board">board</a>
           <a href="#keys">keys</a>
           <a href="#cli">cli</a>
+          <a href="#agents">agents</a>
           <a href="#install">install</a>
           <a href="/docs/">docs</a>
           <a href={REPO} rel="noopener noreferrer">github</a>
@@ -573,11 +574,40 @@ const softwareApplication = {
         </div>
       </section>
 
-      <!-- ──────────────────────────── install ─────────────────────────── -->
-      <section class="band band-alt" id="install" aria-labelledby="install-heading">
+      <!-- ──────────────────────────── agents ─────────────────────────── -->
+      <section class="band band-alt" id="agents" aria-labelledby="agents-heading">
         <div class="band-inner" data-reveal>
           <header class="band-head">
-            <span class="index">06 <span class="index-label">install</span></span>
+            <span class="index">06 <span class="index-label">agents</span></span>
+            <h2 id="agents-heading">Hand it to your agent.</h2>
+            <p class="band-lede">
+              Everything an agent needs is one command or one URL.
+            </p>
+          </header>
+
+          <div class="cli-grid">
+            <div class="shell-wrap">
+              <pre class="shell" data-copy-source>Use tsk for my task board. Run `tsk guide` and follow it;
+if tsk is not installed, read https://gettsk.sh/docs/agents/
+and ask me before installing.</pre>
+              <button type="button" class="copy" data-copy aria-label="Copy bootstrap prompt">copy</button>
+            </div>
+            <div class="cli-side">
+              <dl class="spec" aria-label="Agent surfaces">
+                <div><dt>skill</dt><dd>tsk setup claude</dd></div>
+                <div><dt>markdown</dt><dd>any /docs/ URL + .md</dd></div>
+                <div><dt>index</dt><dd>gettsk.sh/llms.txt</dd></div>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ──────────────────────────── install ─────────────────────────── -->
+      <section class="band" id="install" aria-labelledby="install-heading">
+        <div class="band-inner" data-reveal>
+          <header class="band-head">
+            <span class="index">07 <span class="index-label">install</span></span>
             <h2 id="install-heading">Install it. Open the board.</h2>
             <p class="band-lede">
               One binary, standalone or in Herdr. State lives in <code>~/.tsk</code> whether you run it
@@ -629,10 +659,10 @@ const softwareApplication = {
           </div>
         </div>
       </section>
-      <section class="band" id="coming-soon" aria-labelledby="coming-soon-heading">
+      <section class="band band-alt" id="coming-soon" aria-labelledby="coming-soon-heading">
         <div class="band-inner" data-reveal>
           <header class="band-head">
-            <span class="index">07 <span class="index-label">next phase</span></span>
+            <span class="index">08 <span class="index-label">next phase</span></span>
             <p class="coming-announcement">Coming soon</p>
             <h2 id="coming-soon-heading">From task to implementation.</h2>
             <p class="band-lede">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -594,7 +594,7 @@ and ask me before installing.</pre>
             </div>
             <div class="cli-side">
               <dl class="spec" aria-label="Agent surfaces">
-                <div><dt>skill</dt><dd>tsk setup claude</dd></div>
+                <div><dt>skill</dt><dd>tsk setup grok</dd></div>
                 <div><dt>markdown</dt><dd>any /docs/ URL + .md</dd></div>
                 <div><dt>index</dt><dd>gettsk.sh/llms.txt</dd></div>
               </dl>

--- a/site/src/pages/llms-full.txt.ts
+++ b/site/src/pages/llms-full.txt.ts
@@ -4,11 +4,10 @@ import { getCollection } from "astro:content";
 
 import {
   formatTwin,
-  newestCommitIso,
   SIDEBAR_SLUGS,
   slugFromDocsId,
-  sourceFileName,
   stripFrontmatter,
+  twinSource,
 } from "../lib/agent-docs.mjs";
 
 export async function GET() {
@@ -19,12 +18,13 @@ export async function GET() {
     const entry = bySlug.get(slug);
     if (!entry?.filePath) continue;
     const source = await readFile(join(process.cwd(), entry.filePath), "utf8");
+    const { sourcePath, updatedIso } = twinSource(slug, entry.filePath);
     parts.push(
       formatTwin({
         title: entry.data.title,
         slug,
-        fileName: sourceFileName(entry.filePath),
-        updatedIso: newestCommitIso(entry.filePath),
+        sourcePath,
+        updatedIso,
         body: stripFrontmatter(source),
       }).trimEnd(),
     );

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -2576,7 +2576,13 @@ html[data-theme="light"] .pane {
 .tsk-tab-group .tsk-tab { padding: 0; }
 .tsk-tab-arrow, .tsk-view-control { appearance: none; border: 0; padding: 0; background: none; font: inherit; color: inherit; cursor: pointer; }
 .tsk-tab-group { color: var(--dim); }
-.tsk-tab-group.is-on { color: var(--ink); text-decoration: underline; text-underline-offset: .2em; }
+.tsk-tab-group.is-on { color: var(--ink); }
+.tsk-tab-group.is-on .tsk-tab,
+.tsk-tab-group.is-on .tsk-tab-arrow {
+  text-decoration: underline;
+  text-underline-offset: .2em;
+}
+.tsk-tab-arrow { padding-left: 1ch; }
 .tsk-view-control { margin-left: auto; }
 .board .tsk-row.is-sel { background: transparent; color: var(--ink); }
 .tsk-project-row, .tsk-project-legend { display: grid; grid-template-columns: minmax(0,1fr) 10ch 11ch 7ch; align-items: baseline; padding: 0 2ch 0 1ch; gap: 0; text-align: right; font: inherit; line-height: inherit; }
@@ -2601,7 +2607,7 @@ html[data-theme="light"] .pane {
 .board .tsk-rail-row .tsk-row-main { display: block; white-space: pre; }
 .tsk-rail-continuation { display: block; white-space: pre; }
 
-/* The group owns one underline, including the project dropdown arrow. */
+/* Underline the tab word and the chevron, not the padding around them. */
 .demo-invitation { margin-bottom: 1.5rem; }
 .demo-invitation h2 { margin: 0 0 .5rem; font-size: 1.4rem; }
 .demo-invitation p { margin: 0; color: var(--ink); max-width: 65ch; }

--- a/site/src/styles/starlight.css
+++ b/site/src/styles/starlight.css
@@ -241,3 +241,36 @@ footer .meta {
     animation: none !important;
   }
 }
+
+/* Docs control row: dim, mono, right-aligned twin + copy. */
+.docs-title-block {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1.25rem;
+}
+
+.docs-agent-row {
+  margin: 0 0 0 auto;
+  font-family: var(--sl-font);
+  font-size: 0.82rem;
+  color: var(--sl-color-gray-3);
+  text-align: right;
+}
+
+.docs-agent-row a,
+.docs-agent-row button {
+  color: inherit;
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.docs-agent-row a:hover,
+.docs-agent-row button:hover {
+  text-decoration: underline;
+}

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -44,7 +44,7 @@ test("markdown_twin_formatter_prefixes_title_html_source_and_updated", () => {
   const rendered = formatTwin({
     title: "CLI",
     slug: "cli",
-    fileName: "cli.md",
+    sourcePath: "site/src/content/docs/docs/cli.md",
     updatedIso: "2026-09-09T00:00:00.000Z",
     body: "The same store backs the board.\n",
   });
@@ -105,12 +105,11 @@ test("dist_has_a_markdown_twin_for_every_docs_entry_with_matching_body", async (
     const title = source.match(/^title:\s*(.+)$/m)?.[1]?.replace(/^"|"$/g, "");
     assert.match(twin, new RegExp(`^# ${title}\\n`));
     assert.match(twin, /- html: https:\/\/gettsk\.sh\/docs\//);
-    assert.match(
-      twin,
-      new RegExp(
-        `- source: https://github.com/smarzban/herdr-tsk/blob/main/site/src/content/docs/docs/${fileName}`,
-      ),
-    );
+    const sourceLine =
+      slug === "agents"
+        ? "- source: https://github.com/smarzban/herdr-tsk/blob/main/skills/tsk-cli/SKILL.md"
+        : `- source: https://github.com/smarzban/herdr-tsk/blob/main/site/src/content/docs/docs/${fileName}`;
+    assert.match(twin, new RegExp(sourceLine.replaceAll(".", "\\.")));
     assert.match(twin, /- updated: \d{4}-\d{2}-\d{2}T/);
   }
 });
@@ -360,9 +359,12 @@ test("agents_page_notice_plus_skill_body_matches_source", async () => {
   syncAgentsPage();
   const generated = await read(join(docsDir, "agents.md"));
   const skill = await read(join(repoRoot, "skills/tsk-cli/SKILL.md"));
-  const skillBody = stripFrontmatter(skill).replace(/\s+$/, "");
+  const skillBody = stripFrontmatter(skill)
+    .replace(/^# [^\n]+\n+/, "")
+    .replace(/\s+$/, "");
   const body = stripFrontmatter(generated).replace(/\s+$/, "");
   assert.match(generated, /^title:\s*tsk for agents/m);
+  assert.doesNotMatch(body, /^# /m);
   assert.equal(body, `${NOTICE}\n\n${skillBody}`);
 });
 
@@ -381,6 +383,29 @@ test("definition_sentence_appears_in_agents_page", async () => {
   syncAgentsPage();
   const generated = await read(join(docsDir, "agents.md"));
   assert.ok(generated.includes(DEFINITION_SENTENCE));
+});
+
+test("agents_markdown_twin_points_source_and_updated_at_the_skill", async () => {
+  ensureDist();
+  const twin = await read(join(distDir, "docs/agents.md"));
+  assert.match(
+    twin,
+    /- source: https:\/\/github.com\/smarzban\/herdr-tsk\/blob\/main\/skills\/tsk-cli\/SKILL.md/,
+  );
+  const expected = newestCommitIso(join(repoRoot, "skills/tsk-cli/SKILL.md"));
+  assert.match(twin, new RegExp(`- updated: ${expected.replaceAll(".", "\\.")}`));
+});
+
+test("npm_start_and_deploy_paths_watch_the_skill", async () => {
+  const pkg = JSON.parse(await read(join(siteRoot, "package.json")));
+  assert.match(String(pkg.scripts.dev), /sync-agents-page/);
+  assert.equal(pkg.scripts.start, "npm run dev");
+  const siteYml = await read(join(repoRoot, ".github/workflows/site.yml"));
+  const vercelYml = await read(join(repoRoot, ".github/workflows/vercel.yml"));
+  assert.match(siteYml, /skills\/\*\*/);
+  assert.match(vercelYml, /skills\/\*\*/);
+  const vercelJson = JSON.parse(await read(join(siteRoot, "vercel.json")));
+  assert.match(String(vercelJson.ignoreCommand), /\.\.\/skills/);
 });
 
 test("vercel_docs_rewrite_matches_nested_slug_and_skips_md", async () => {

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -239,6 +239,7 @@ const DEFINITION_SENTENCE =
 
 const SIDEBAR_TITLES = [
   "Overview",
+  "tsk for agents",
   "Install",
   "Board",
   "Keys",
@@ -265,7 +266,6 @@ test("every_llms_txt_gettsk_sh_link_except_agents_md_resolves_in_dist", async ()
   const links = [...text.matchAll(/https:\/\/gettsk\.sh(\/[^\s)]+)/g)].map((match) => match[1]);
   assert.ok(links.length > 0, "expected gettsk.sh links");
   for (const path of links) {
-    if (path === "/docs/agents.md") continue;
     const filePath = join(distDir, path.replace(/^\//, ""));
     assert.equal(existsSync(filePath), true, `missing ${filePath} for ${path}`);
   }
@@ -342,4 +342,68 @@ test("definition_sentence_appears_verbatim_in_index_astro_llms_txt_docs_index_an
       `${filePath} is missing the definition sentence`,
     );
   }
+});
+
+const NOTICE =
+  "tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.";
+
+function syncAgentsPage() {
+  const result = spawnSync("node", ["scripts/sync-agents-page.mjs"], {
+    cwd: siteRoot,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout || "sync-agents-page failed");
+}
+
+test("agents_page_notice_plus_skill_body_matches_source", async () => {
+  syncAgentsPage();
+  const generated = await read(join(docsDir, "agents.md"));
+  const skill = await read(join(repoRoot, "skills/tsk-cli/SKILL.md"));
+  const skillBody = stripFrontmatter(skill).replace(/\s+$/, "");
+  const body = stripFrontmatter(generated).replace(/\s+$/, "");
+  assert.match(generated, /^title:\s*tsk for agents/m);
+  assert.equal(body, `${NOTICE}\n\n${skillBody}`);
+});
+
+test("dist_docs_agents_md_exists", async () => {
+  ensureDist();
+  assert.equal(existsSync(join(distDir, "docs/agents.md")), true);
+  assert.equal(existsSync(join(distDir, "docs/agents/index.html")), true);
+});
+
+test("llms_txt_agents_md_link_resolves", async () => {
+  ensureDist();
+  assert.equal(existsSync(join(distDir, "docs/agents.md")), true);
+});
+
+test("definition_sentence_appears_in_agents_page", async () => {
+  syncAgentsPage();
+  const generated = await read(join(docsDir, "agents.md"));
+  assert.ok(generated.includes(DEFINITION_SENTENCE));
+});
+
+test("vercel_docs_rewrite_matches_nested_slug_and_skips_md", async () => {
+  const config = JSON.parse(await read(join(siteRoot, "vercel.json")));
+  const rewrites = (config.rewrites || []).filter((entry) =>
+    String(entry.source).includes("/docs/:path"),
+  );
+  assert.ok(rewrites.length > 0, "expected a docs path rewrite");
+  let matchesNested = false;
+  let skipsMd = true;
+  for (const rewrite of rewrites) {
+    const source = String(rewrite.source);
+    const inner = source.match(/:path\((.*)\)(?:\/\?|\/)?$/)?.[1];
+    assert.ok(inner, `${source} needs a custom :path regex`);
+    const innerRe = new RegExp(`^(?:${inner})$`);
+    assert.match("cli", innerRe);
+    assert.match("a/b", innerRe, `${source} should match nested slugs`);
+    assert.doesNotMatch("cli.md", innerRe);
+    assert.doesNotMatch("a/b.md", innerRe);
+    assert.match(String(rewrite.destination), /^\/docs\/:path\.md$/);
+    matchesNested = true;
+    if (innerRe.test("cli.md") || innerRe.test("a/b.md")) skipsMd = false;
+  }
+  assert.ok(matchesNested, "expected a rewrite that matches /docs/a/b/");
+  assert.ok(skipsMd, "/docs/a/b.md and /docs/cli.md must not match");
 });

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -55,7 +55,7 @@ test("the Astro site and sitemap build on the canonical URL", async () => {
 
 test("Vercel ignores unchanged files relative to the site root", async () => {
   const config = JSON.parse(await read("../vercel.json"));
-  assert.equal(config.ignoreCommand, "git diff --quiet HEAD^ HEAD -- .");
+  assert.equal(config.ignoreCommand, "git diff --quiet HEAD^ HEAD -- . ../skills");
 });
 
 test("demo capture keeps an absolute project path verbatim", () => {

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -48,7 +48,7 @@
       "destination": "/docs/index.md"
     },
     {
-      "source": "/docs/:path((?!.*\\.md$)[^/]+)/?",
+      "source": "/docs/:path((?!.*\\.md$)[^/]+(?:/[^/]+)*)/?",
       "has": [
         {
           "type": "header",

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -3,7 +3,7 @@
   "outputDirectory": "dist",
   "framework": "astro",
   "installCommand": "npm ci",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ../skills",
   "headers": [
     {
       "source": "/docs/(.*).md",

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -10,6 +10,12 @@ board store, `tsk status` to set human status, `tsk edit` to change title or
 notes, and `tsk steps` to add, toggle, rename, or remove steps. Human output
 escapes terminal controls in titles, step text, and project names; JSON does not.
 
+## If tsk is not installed
+
+Run `command -v tsk`. If it is missing, give the user
+https://gettsk.sh/docs/install.md and stop. Never run `install.sh`, `brew`, or
+`cargo build` unless they asked.
+
 ## Adding
 
 ```sh

--- a/src/cli/guide.rs
+++ b/src/cli/guide.rs
@@ -1,0 +1,30 @@
+//! Print the embedded agent skill.
+
+use super::CliOutput;
+
+/// Full `skills/tsk-cli/SKILL.md`, including YAML frontmatter.
+pub const SKILL_MD: &str = include_str!("../../skills/tsk-cli/SKILL.md");
+
+/// Skill body after the closing `---` fence and one following blank line.
+pub fn body() -> &'static str {
+    strip_frontmatter(SKILL_MD)
+}
+
+pub fn strip_frontmatter(source: &str) -> &str {
+    let Some(rest) = source.strip_prefix("---\n") else {
+        return source;
+    };
+    let Some(close) = rest.find("\n---\n") else {
+        return source;
+    };
+    let after = &rest[close + "\n---\n".len()..];
+    after.strip_prefix('\n').unwrap_or(after)
+}
+
+pub fn run() -> CliOutput {
+    CliOutput {
+        stdout: body().to_string(),
+        stderr: String::new(),
+        code: 0,
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -269,10 +269,11 @@ fn parse_plan(source: &str) -> Result<Vec<Value>, String> {
 }
 
 fn run_setup<R: Read>(args: Vec<String>, stdin: &mut R, stdin_is_tty: bool) -> CliOutput {
-    let tail: Vec<_> = args.iter().skip(2).map(String::as_str).collect();
-    match tail.as_slice() {
-        ["--help"] | ["herdr", "--help"] => presenter::setup_help(),
-        ["herdr"] => {
+    match crate::setup_agent::parse(&args) {
+        Err(error) => presenter::setup_error(&error.to_string(), 2),
+        Ok(crate::setup_agent::Command::Help) => presenter::setup_help(),
+        Ok(crate::setup_agent::Command::List { json }) => presenter::setup_agent_listed(json),
+        Ok(crate::setup_agent::Command::Herdr) => {
             let mut reader = std::io::BufReader::new(stdin);
             let mut stderr = std::io::stderr();
             let interactive = stdin_is_tty && stderr.is_terminal();
@@ -281,6 +282,17 @@ fn run_setup<R: Read>(args: Vec<String>, stdin: &mut R, stdin_is_tty: bool) -> C
                 Err(error) => presenter::setup_error(&error.to_string(), 1),
             }
         }
-        _ => presenter::setup_error("usage: tsk setup herdr", 2),
+        Ok(crate::setup_agent::Command::Skill {
+            target,
+            force,
+            json,
+        }) => match crate::setup_agent::install(&target, force) {
+            Ok(path) => presenter::setup_agent_written(&target, &path, json),
+            Err(crate::setup_agent::Error::Exists(path)) => {
+                presenter::setup_agent_exists(&target, &path, json)
+            }
+            Err(crate::setup_agent::Error::Usage(reason)) => presenter::setup_error(&reason, 2),
+            Err(error) => presenter::setup_error(&error.to_string(), 1),
+        },
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 pub mod add;
 pub mod archive;
 pub mod edit;
+pub mod guide;
 pub mod list;
 pub mod parser;
 pub mod presenter;
@@ -37,6 +38,7 @@ where
         .collect::<Vec<_>>();
     match args.get(1).map(String::as_str) {
         Some("setup") => run_setup(args, &mut stdin, stdin_is_tty),
+        Some("guide") => guide::run(),
         Some("add") => run_add(args, &mut stdin, stdin_is_tty),
         Some("steps") => run_steps(args),
         Some("list") => run_list(args),

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -784,15 +784,14 @@ pub fn rejected(error: AddError) -> CliOutput {
 
 pub fn setup_help() -> CliOutput {
     CliOutput {
-        stdout: concat!(
-            "usage: tsk setup herdr | claude | pi | cursor | codex | --skill-dir <path> [--force] [--json]\n",
-            "Register the installed binary and bundled plugin assets.\n",
-            "Adds prefix+t for board and prefix+a for capture; asks before replacing conflicts.\n",
-            "Uses HERDR_CONFIG_PATH, or XDG_CONFIG_HOME/herdr/config.toml, or ~/.config/herdr/config.toml.\n",
-            "Agent targets write skills/tsk-cli/SKILL.md into that tool's user-level skills directory.\n",
-            "--force overwrites an existing skill. Without it, an existing file exits 1 with skill-exists.\n",
-        )
-        .into(),
+        stdout: format!(
+            "{}\nRegister the installed binary and bundled plugin assets.\n\
+             Adds prefix+t for board and prefix+a for capture; asks before replacing conflicts.\n\
+             Uses HERDR_CONFIG_PATH, or XDG_CONFIG_HOME/herdr/config.toml, or ~/.config/herdr/config.toml.\n\
+             Agent targets write skills/tsk-cli/SKILL.md into that tool's user-level skills directory.\n\
+             --force overwrites an existing skill. Without it, an existing file exits 1 with skill-exists.\n",
+            crate::setup_agent::USAGE
+        ),
         stderr: String::new(),
         code: 0,
     }

--- a/src/cli/presenter.rs
+++ b/src/cli/presenter.rs
@@ -783,7 +783,80 @@ pub fn rejected(error: AddError) -> CliOutput {
 }
 
 pub fn setup_help() -> CliOutput {
-    CliOutput {stdout:"usage: tsk setup herdr\nRegister the installed binary and bundled plugin assets.\nAdds prefix+t for board and prefix+a for capture; asks before replacing conflicts.\nUses HERDR_CONFIG_PATH, or XDG_CONFIG_HOME/herdr/config.toml, or ~/.config/herdr/config.toml.\n".into(),stderr:String::new(),code:0}
+    CliOutput {
+        stdout: concat!(
+            "usage: tsk setup herdr | claude | pi | cursor | codex | --skill-dir <path> [--force] [--json]\n",
+            "Register the installed binary and bundled plugin assets.\n",
+            "Adds prefix+t for board and prefix+a for capture; asks before replacing conflicts.\n",
+            "Uses HERDR_CONFIG_PATH, or XDG_CONFIG_HOME/herdr/config.toml, or ~/.config/herdr/config.toml.\n",
+            "Agent targets write skills/tsk-cli/SKILL.md into that tool's user-level skills directory.\n",
+            "--force overwrites an existing skill. Without it, an existing file exits 1 with skill-exists.\n",
+        )
+        .into(),
+        stderr: String::new(),
+        code: 0,
+    }
+}
+
+pub fn setup_agent_listed(json: bool) -> CliOutput {
+    if json {
+        return setup_agent_json("listed", None, None, 0);
+    }
+    CliOutput {
+        stdout: crate::setup_agent::list_text(),
+        stderr: String::new(),
+        code: 0,
+    }
+}
+
+pub fn setup_agent_written(
+    target: &crate::setup_agent::Target,
+    path: &std::path::Path,
+    json: bool,
+) -> CliOutput {
+    if json {
+        return setup_agent_json("written", Some(target.name()), Some(path), 0);
+    }
+    CliOutput {
+        stdout: format!("{}\n", path.display()),
+        stderr: String::new(),
+        code: 0,
+    }
+}
+
+pub fn setup_agent_exists(
+    target: &crate::setup_agent::Target,
+    path: &std::path::Path,
+    json: bool,
+) -> CliOutput {
+    if json {
+        return setup_agent_json("exists", Some(target.name()), Some(path), 1);
+    }
+    CliOutput {
+        stdout: String::new(),
+        stderr: "tsk setup: skill-exists\n".into(),
+        code: 1,
+    }
+}
+
+fn setup_agent_json(
+    outcome: &str,
+    target: Option<&str>,
+    path: Option<&std::path::Path>,
+    code: u8,
+) -> CliOutput {
+    CliOutput {
+        stdout: format!(
+            "{}\n",
+            serde_json::json!({
+                "outcome": outcome,
+                "target": target,
+                "path": path.map(|value| value.display().to_string()),
+            })
+        ),
+        stderr: String::new(),
+        code,
+    }
 }
 pub fn setup_error(reason: &str, code: u8) -> CliOutput {
     CliOutput {

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -15,6 +15,7 @@ pub enum Surface {
     Unarchive,
     Project,
     Setup,
+    Guide,
     FindBoardPane,
     ResolveContext,
     GlobalHelp,
@@ -64,6 +65,7 @@ pub fn route<S: AsRef<str>>(
             "unarchive" => Surface::Unarchive,
             "project" => Surface::Project,
             "setup" => Surface::Setup,
+            "guide" => Surface::Guide,
             _ => Surface::Usage,
         };
     }
@@ -172,5 +174,10 @@ mod tests {
     #[test]
     fn no_args_selects_board() {
         assert_eq!(route(["tsk"], None), Surface::Board);
+    }
+
+    #[test]
+    fn guide_selects_guide_surface() {
+        assert_eq!(route(["tsk", "guide"], None), Surface::Guide);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod reopen;
 pub mod save_recovery;
 pub mod scope;
 pub mod setup;
+pub mod setup_agent;
 pub mod store;
 pub(crate) mod text;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> ExitCode {
         Surface::ResolveContext => resolve_context_main(),
         Surface::GlobalHelp => {
             println!(
-                "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | setup herdr | guide | --find-board-pane | --help\n\nCommands:\n  guide          print the agent workflow skill\n  setup herdr    register plugin and shortcuts for this installed binary\n  add    create one task or apply a JSON plan\n  steps  add, toggle, rename, or remove one step on a task\n  list   inspect tasks\n  status set a task's human status\n  edit   update a task's title or notes\n  trash  restore a trashed task\n  archive    keep a task off the working views\n  unarchive  put an archived task back\n  project    archive or unarchive a project\n\nRun `tsk add --help`, `tsk steps --help`, `tsk list --help`, `tsk status --help`, `tsk edit --help`, `tsk trash --help`, `tsk archive --help`, `tsk unarchive --help`, or `tsk project --help` for command details.\n\nAgents: run `tsk guide`, or read https://gettsk.sh/docs/agents.md"
+                "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | setup | guide | --find-board-pane | --help\n\nCommands:\n  guide          print the agent workflow skill\n  setup          register herdr, or install the agent skill\n  add    create one task or apply a JSON plan\n  steps  add, toggle, rename, or remove one step on a task\n  list   inspect tasks\n  status set a task's human status\n  edit   update a task's title or notes\n  trash  restore a trashed task\n  archive    keep a task off the working views\n  unarchive  put an archived task back\n  project    archive or unarchive a project\n\nRun `tsk add --help`, `tsk steps --help`, `tsk list --help`, `tsk status --help`, `tsk edit --help`, `tsk trash --help`, `tsk archive --help`, `tsk unarchive --help`, or `tsk project --help` for command details.\n\nAgents: run `tsk guide`, or read https://gettsk.sh/docs/agents.md"
             );
             ExitCode::SUCCESS
         }
@@ -40,7 +40,7 @@ fn main() -> ExitCode {
 
 fn usage_exit() -> ExitCode {
     eprintln!(
-        "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | setup herdr | guide | --find-board-pane | --help"
+        "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | setup | guide | --find-board-pane | --help"
     );
     ExitCode::from(2)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> ExitCode {
         Surface::ResolveContext => resolve_context_main(),
         Surface::GlobalHelp => {
             println!(
-                "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | setup herdr | --find-board-pane | --help\n\nCommands:\n  setup herdr    register plugin and shortcuts for this installed binary\n  add    create one task or apply a JSON plan\n  steps  add, toggle, rename, or remove one step on a task\n  list   inspect tasks\n  status set a task's human status\n  edit   update a task's title or notes\n  trash  restore a trashed task\n  archive    keep a task off the working views\n  unarchive  put an archived task back\n  project    archive or unarchive a project\n\nRun `tsk add --help`, `tsk steps --help`, `tsk list --help`, `tsk status --help`, `tsk edit --help`, `tsk trash --help`, `tsk archive --help`, `tsk unarchive --help`, or `tsk project --help` for command details."
+                "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | setup herdr | guide | --find-board-pane | --help\n\nCommands:\n  guide          print the agent workflow skill\n  setup herdr    register plugin and shortcuts for this installed binary\n  add    create one task or apply a JSON plan\n  steps  add, toggle, rename, or remove one step on a task\n  list   inspect tasks\n  status set a task's human status\n  edit   update a task's title or notes\n  trash  restore a trashed task\n  archive    keep a task off the working views\n  unarchive  put an archived task back\n  project    archive or unarchive a project\n\nRun `tsk add --help`, `tsk steps --help`, `tsk list --help`, `tsk status --help`, `tsk edit --help`, `tsk trash --help`, `tsk archive --help`, `tsk unarchive --help`, or `tsk project --help` for command details.\n\nAgents: run `tsk guide`, or read https://gettsk.sh/docs/agents.md"
             );
             ExitCode::SUCCESS
         }
@@ -26,7 +26,8 @@ fn main() -> ExitCode {
         | Surface::Archive
         | Surface::Unarchive
         | Surface::Project
-        | Surface::Setup => headless_main(args),
+        | Surface::Setup
+        | Surface::Guide => headless_main(args),
         Surface::Board | Surface::Capture => match tsk_tui::run(args) {
             Ok(()) => ExitCode::SUCCESS,
             Err(err) => {
@@ -39,7 +40,7 @@ fn main() -> ExitCode {
 
 fn usage_exit() -> ExitCode {
     eprintln!(
-        "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | setup herdr | --find-board-pane | --help"
+        "usage: tsk [capture] | add | steps | list | status | edit | trash | archive | unarchive | project | setup herdr | guide | --find-board-pane | --help"
     );
     ExitCode::from(2)
 }

--- a/src/setup_agent.rs
+++ b/src/setup_agent.rs
@@ -1,0 +1,231 @@
+//! Install the embedded agent skill into a host skills directory.
+
+use std::env;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::cli::guide::SKILL_MD;
+
+const SKILL_FOLDER: &str = "tsk-cli";
+const SKILL_FILE: &str = "SKILL.md";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Target {
+    Claude,
+    Pi,
+    Cursor,
+    Codex,
+    SkillDir(PathBuf),
+}
+
+impl Target {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Claude => "claude",
+            Self::Pi => "pi",
+            Self::Cursor => "cursor",
+            Self::Codex => "codex",
+            Self::SkillDir(_) => "skill-dir",
+        }
+    }
+
+    pub fn skills_root(&self) -> Result<PathBuf, Error> {
+        match self {
+            Self::SkillDir(path) => Ok(path.clone()),
+            Self::Claude => Ok(home_dir()?.join(".claude/skills")),
+            Self::Pi => Ok(home_dir()?.join(".pi/agent/skills")),
+            Self::Cursor => Ok(home_dir()?.join(".cursor/skills")),
+            Self::Codex => Ok(home_dir()?.join(".agents/skills")),
+        }
+    }
+
+    pub fn skill_path(&self) -> Result<PathBuf, Error> {
+        Ok(self.skills_root()?.join(SKILL_FOLDER).join(SKILL_FILE))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    Help,
+    List {
+        json: bool,
+    },
+    Herdr,
+    Skill {
+        target: Target,
+        force: bool,
+        json: bool,
+    },
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Usage(String),
+    Exists(PathBuf),
+    Symlink(PathBuf),
+    Home,
+    Io(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Usage(reason) => write!(f, "{reason}"),
+            Self::Exists(_) => write!(f, "skill-exists"),
+            Self::Symlink(path) => write!(f, "refusing symlink: {}", path.display()),
+            Self::Home => write!(f, "HOME is not set"),
+            Self::Io(detail) => write!(f, "{detail}"),
+        }
+    }
+}
+
+pub fn parse(args: &[String]) -> Result<Command, Error> {
+    let tail = args.get(2..).unwrap_or(&[]);
+    if tail.iter().any(|arg| arg == "--help") {
+        return Ok(Command::Help);
+    }
+
+    let mut herdr = false;
+    let mut force = false;
+    let mut json = false;
+    let mut agents: Vec<Target> = Vec::new();
+    let mut skill_dir: Option<PathBuf> = None;
+    let mut index = 0;
+    while index < tail.len() {
+        let arg = tail[index].as_str();
+        match arg {
+            "herdr" => {
+                if herdr {
+                    return Err(usage());
+                }
+                herdr = true;
+            }
+            "claude" => push_agent(&mut agents, Target::Claude)?,
+            "pi" => push_agent(&mut agents, Target::Pi)?,
+            "cursor" => push_agent(&mut agents, Target::Cursor)?,
+            "codex" => push_agent(&mut agents, Target::Codex)?,
+            "--force" => force = true,
+            "--json" => json = true,
+            "--skill-dir" => {
+                index += 1;
+                let Some(value) = tail.get(index) else {
+                    return Err(usage());
+                };
+                if value.starts_with('-') || skill_dir.is_some() {
+                    return Err(usage());
+                }
+                skill_dir = Some(PathBuf::from(value));
+            }
+            flag if flag.starts_with("--skill-dir=") => {
+                let value = &flag["--skill-dir=".len()..];
+                if value.is_empty() || skill_dir.is_some() {
+                    return Err(usage());
+                }
+                skill_dir = Some(PathBuf::from(value));
+            }
+            _ => return Err(usage()),
+        }
+        index += 1;
+    }
+
+    let named = agents.len() + usize::from(skill_dir.is_some());
+    if herdr {
+        if named > 0 || force || json {
+            return Err(usage());
+        }
+        return Ok(Command::Herdr);
+    }
+    if named > 1 {
+        return Err(usage());
+    }
+    if named == 0 {
+        if force {
+            return Err(usage());
+        }
+        return Ok(Command::List { json });
+    }
+    let target = if let Some(path) = skill_dir {
+        Target::SkillDir(path)
+    } else {
+        agents.pop().expect("one named agent")
+    };
+    Ok(Command::Skill {
+        target,
+        force,
+        json,
+    })
+}
+
+pub fn install(target: &Target, force: bool) -> Result<PathBuf, Error> {
+    let root = target.skills_root()?;
+    refuse_symlink(&root)?;
+    let dest = root.join(SKILL_FOLDER).join(SKILL_FILE);
+    if dest.exists() && !force {
+        return Err(Error::Exists(dest));
+    }
+    fs::create_dir_all(dest.parent().unwrap_or(root.as_path())).map_err(io_error)?;
+    refuse_symlink(&root)?;
+    fs::write(&dest, SKILL_MD).map_err(io_error)?;
+    Ok(dest)
+}
+
+pub fn list_text() -> String {
+    let home = env::var("HOME").ok().filter(|value| !value.is_empty());
+    let display = |suffix: &str| match &home {
+        Some(home) => format!("{home}/{suffix}/tsk-cli/SKILL.md"),
+        None => format!("$HOME/{suffix}/tsk-cli/SKILL.md"),
+    };
+    format!(
+        "usage: tsk setup herdr | claude | pi | cursor | codex | --skill-dir <path> [--force] [--json]\n\n\
+         herdr     register the plugin and shortcuts for this installed binary\n\
+         claude    {}\n\
+         pi        {}\n\
+         cursor    {}\n\
+         codex     {}\n\
+         --skill-dir <path>  write <path>/tsk-cli/SKILL.md\n",
+        display(".claude/skills"),
+        display(".pi/agent/skills"),
+        display(".cursor/skills"),
+        display(".agents/skills"),
+    )
+}
+
+fn push_agent(agents: &mut Vec<Target>, target: Target) -> Result<(), Error> {
+    if agents
+        .iter()
+        .any(|existing| existing.name() == target.name())
+    {
+        return Err(usage());
+    }
+    agents.push(target);
+    Ok(())
+}
+
+fn usage() -> Error {
+    Error::Usage(
+        "usage: tsk setup herdr | claude | pi | cursor | codex | --skill-dir <path> [--force] [--json]"
+            .into(),
+    )
+}
+
+fn home_dir() -> Result<PathBuf, Error> {
+    env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or(Error::Home)
+}
+
+fn refuse_symlink(path: &Path) -> Result<(), Error> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => Err(Error::Symlink(path.to_path_buf())),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_error(error)),
+    }
+}
+
+fn io_error(error: io::Error) -> Error {
+    Error::Io(format!("could not write skill: {error}"))
+}

--- a/src/setup_agent.rs
+++ b/src/setup_agent.rs
@@ -11,11 +11,14 @@ use crate::cli::guide::SKILL_MD;
 const SKILL_FOLDER: &str = "tsk-cli";
 const SKILL_FILE: &str = "SKILL.md";
 
+pub const USAGE: &str = "usage: tsk setup herdr | claude | pi | cursor | grok | codex | --skill-dir <path> [--force] [--json]";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Target {
     Claude,
     Pi,
     Cursor,
+    Grok,
     Codex,
     SkillDir(PathBuf),
 }
@@ -26,6 +29,7 @@ impl Target {
             Self::Claude => "claude",
             Self::Pi => "pi",
             Self::Cursor => "cursor",
+            Self::Grok => "grok",
             Self::Codex => "codex",
             Self::SkillDir(_) => "skill-dir",
         }
@@ -37,6 +41,7 @@ impl Target {
             Self::Claude => Ok(home_dir()?.join(".claude/skills")),
             Self::Pi => Ok(home_dir()?.join(".pi/agent/skills")),
             Self::Cursor => Ok(home_dir()?.join(".cursor/skills")),
+            Self::Grok => Ok(home_dir()?.join(".grok/skills")),
             Self::Codex => Ok(home_dir()?.join(".agents/skills")),
         }
     }
@@ -105,6 +110,7 @@ pub fn parse(args: &[String]) -> Result<Command, Error> {
             "claude" => push_agent(&mut agents, Target::Claude)?,
             "pi" => push_agent(&mut agents, Target::Pi)?,
             "cursor" => push_agent(&mut agents, Target::Cursor)?,
+            "grok" => push_agent(&mut agents, Target::Grok)?,
             "codex" => push_agent(&mut agents, Target::Codex)?,
             "--force" => force = true,
             "--json" => json = true,
@@ -113,7 +119,7 @@ pub fn parse(args: &[String]) -> Result<Command, Error> {
                 let Some(value) = tail.get(index) else {
                     return Err(usage());
                 };
-                if value.starts_with('-') || skill_dir.is_some() {
+                if value.is_empty() || value.starts_with('-') || skill_dir.is_some() {
                     return Err(usage());
                 }
                 skill_dir = Some(PathBuf::from(value));
@@ -160,13 +166,21 @@ pub fn parse(args: &[String]) -> Result<Command, Error> {
 
 pub fn install(target: &Target, force: bool) -> Result<PathBuf, Error> {
     let root = target.skills_root()?;
+    if root.as_os_str().is_empty() {
+        return Err(usage());
+    }
+    let folder = root.join(SKILL_FOLDER);
+    let dest = folder.join(SKILL_FILE);
     refuse_symlink(&root)?;
-    let dest = root.join(SKILL_FOLDER).join(SKILL_FILE);
-    if dest.exists() && !force {
+    refuse_symlink(&folder)?;
+    refuse_symlink(&dest)?;
+    if path_present(&dest)? && !force {
         return Err(Error::Exists(dest));
     }
-    fs::create_dir_all(dest.parent().unwrap_or(root.as_path())).map_err(io_error)?;
+    fs::create_dir_all(&folder).map_err(io_error)?;
     refuse_symlink(&root)?;
+    refuse_symlink(&folder)?;
+    refuse_symlink(&dest)?;
     fs::write(&dest, SKILL_MD).map_err(io_error)?;
     Ok(dest)
 }
@@ -178,16 +192,18 @@ pub fn list_text() -> String {
         None => format!("$HOME/{suffix}/tsk-cli/SKILL.md"),
     };
     format!(
-        "usage: tsk setup herdr | claude | pi | cursor | codex | --skill-dir <path> [--force] [--json]\n\n\
+        "{USAGE}\n\n\
          herdr     register the plugin and shortcuts for this installed binary\n\
          claude    {}\n\
          pi        {}\n\
          cursor    {}\n\
+         grok      {}\n\
          codex     {}\n\
          --skill-dir <path>  write <path>/tsk-cli/SKILL.md\n",
         display(".claude/skills"),
         display(".pi/agent/skills"),
         display(".cursor/skills"),
+        display(".grok/skills"),
         display(".agents/skills"),
     )
 }
@@ -204,10 +220,15 @@ fn push_agent(agents: &mut Vec<Target>, target: Target) -> Result<(), Error> {
 }
 
 fn usage() -> Error {
-    Error::Usage(
-        "usage: tsk setup herdr | claude | pi | cursor | codex | --skill-dir <path> [--force] [--json]"
-            .into(),
-    )
+    Error::Usage(USAGE.into())
+}
+
+fn path_present(path: &Path) -> Result<bool, Error> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(io_error(error)),
+    }
 }
 
 fn home_dir() -> Result<PathBuf, Error> {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -4391,6 +4391,28 @@ fn selector_chip_wraps(model: &QueueFrameModel<'_>, width: u16) -> bool {
     tabs_width.saturating_add(chip_width) > width as usize
 }
 
+/// Active tab labels keep a cell of padding for hit targets; underline only the word.
+fn push_selector_tab_spans(spans: &mut Vec<Span<'static>>, text: &str, active: bool) {
+    if !active {
+        spans.push(Span::styled(text.to_string(), style_dim()));
+        return;
+    }
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        spans.push(Span::styled(text.to_string(), style_heading()));
+        return;
+    }
+    let start = text.find(trimmed).expect("trim is a substring");
+    let end = start + trimmed.len();
+    if start > 0 {
+        spans.push(Span::styled(text[..start].to_string(), style_plain()));
+    }
+    spans.push(Span::styled(trimmed.to_string(), style_heading()));
+    if end < text.len() {
+        spans.push(Span::styled(text[end..].to_string(), style_plain()));
+    }
+}
+
 /// Paint the selector row's persistent tabs. Tabs never disappear, so `1`/`2`/`3`
 /// keep their keyboard mappings even though the digit labels are not shown.
 fn paint_selector_row(
@@ -4419,10 +4441,7 @@ fn paint_selector_row(
             left_width as u16,
             w.max(1) as u16,
         ));
-        spans.push(Span::styled(
-            shown,
-            if active { style_heading() } else { style_dim() },
-        ));
+        push_selector_tab_spans(&mut spans, &shown, active);
         left_width += w;
     }
 
@@ -4732,6 +4751,71 @@ mod tests {
                 x.saturating_add(width) <= 40,
                 "{target:?} overflows selector"
             );
+        }
+    }
+
+    fn selector_model(active: NavTab) -> QueueFrameModel<'static> {
+        static VIEW: std::sync::OnceLock<QueueView> = std::sync::OnceLock::new();
+        let view = VIEW.get_or_init(|| QueueView {
+            sections: vec![],
+            counts: crate::ui::queue::StatusCounts::default(),
+            projects: vec![],
+        });
+        QueueFrameModel {
+            tasks: &[],
+            view,
+            selection_id: None,
+            nav: NavPaint {
+                active,
+                slot2_label: "tsk".to_string(),
+                slot2_project: true,
+                chip: None,
+            },
+            surface: BoardSurface::Desk,
+            thread_labels: false,
+            show_project_meta: false,
+            projects: &[],
+            projects_index: false,
+            projects_cursor: 0,
+            projects_query: "",
+            summary: None,
+            context: " desk".to_string(),
+            status_message: None,
+            status_undo_offset: None,
+            verb_items: &[],
+            now: SystemTime::UNIX_EPOCH,
+            overlay: QueueOverlay::None,
+            detail_open: None,
+            list_scroll: 0,
+            follow_list: false,
+            archived_collapsed: true,
+            archived_header_selected: false,
+            rows_dim: false,
+        }
+    }
+
+    #[test]
+    fn active_tab_underlines_the_word_not_its_padding() {
+        let (line, _) = paint_selector_row(&selector_model(NavTab::Desk), &tier::resolve(78, 24));
+        let text = plain(&line);
+        assert!(
+            text.contains(" desk "),
+            "padding around the word stays for hits: {text:?}"
+        );
+        let underlined: String = line
+            .spans
+            .iter()
+            .filter(|span| span.style.add_modifier.contains(Modifier::UNDERLINED))
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert_eq!(underlined, "desk");
+        for span in &line.spans {
+            if span.content.as_ref().chars().all(|ch| ch == ' ') {
+                assert!(
+                    !span.style.add_modifier.contains(Modifier::UNDERLINED),
+                    "padding must not be underlined: {span:?}"
+                );
+            }
         }
     }
 

--- a/tests/cli_guide.rs
+++ b/tests/cli_guide.rs
@@ -1,0 +1,26 @@
+use std::io::Cursor;
+
+use tsk_tui::cli::run_with;
+
+fn skill_minus_frontmatter() -> &'static str {
+    let source = include_str!("../skills/tsk-cli/SKILL.md");
+    let rest = source
+        .strip_prefix("---\n")
+        .expect("skill starts with YAML frontmatter");
+    let close = rest.find("\n---\n").expect("skill has a closing fence");
+    let after = &rest[close + "\n---\n".len()..];
+    after.strip_prefix('\n').unwrap_or(after)
+}
+
+#[test]
+fn guide_prints_skill_minus_frontmatter_and_exits_0() {
+    let output = run_with(["tsk", "guide"], Cursor::new(Vec::<u8>::new()), true);
+    assert_eq!(output.code, 0);
+    assert!(output.stderr.is_empty());
+    assert_eq!(output.stdout, skill_minus_frontmatter());
+    assert!(
+        !output.stdout.starts_with("---"),
+        "frontmatter must be stripped"
+    );
+    assert!(output.stdout.starts_with("# tsk CLI"));
+}

--- a/tests/cli_router_process.rs
+++ b/tests/cli_router_process.rs
@@ -71,6 +71,33 @@ fn top_level_help_names_subcommands_and_their_help() {
 }
 
 #[test]
+fn top_level_help_lists_guide_and_ends_with_agent_footer() {
+    let output = wait_with_output_before_deadline(
+        Command::new(binary())
+            .arg("--help")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn global help"),
+        "top-level help",
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(output.stderr.is_empty());
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 help");
+    assert!(
+        stdout.contains("guide"),
+        "top-level help must list the guide command"
+    );
+    let trimmed = stdout.trim_end();
+    assert!(
+        trimmed.ends_with("Agents: run `tsk guide`, or read https://gettsk.sh/docs/agents.md"),
+        "help must end with the agent footer, got {trimmed:?}"
+    );
+}
+
+#[test]
 fn executable_accepts_piped_json_plan_and_persists_it() {
     let dir = temp_state_dir("piped-plan");
     let mut child = Command::new(binary())

--- a/tests/cli_setup_agent.rs
+++ b/tests/cli_setup_agent.rs
@@ -1,0 +1,209 @@
+use std::fs;
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tsk_tui::cli::run_with;
+
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("tsk-agent-site-setup-{label}-{nanos}-{seq}"));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn cli(args: &[&str]) -> tsk_tui::cli::CliOutput {
+    run_with(args.iter().copied(), Cursor::new(Vec::<u8>::new()), true)
+}
+
+fn skill_source() -> &'static str {
+    include_str!("../skills/tsk-cli/SKILL.md")
+}
+
+#[test]
+fn skill_dir_writes_full_skill_prints_path_exits_0() {
+    let _lock = env_lock();
+    let root = temp_dir("write");
+    let skill_dir = root.join("skills");
+    let output = cli(&[
+        "tsk",
+        "setup",
+        "--skill-dir",
+        skill_dir.to_str().expect("utf-8"),
+    ]);
+    let written = skill_dir.join("tsk-cli/SKILL.md");
+    assert_eq!(output.code, 0);
+    assert!(output.stderr.is_empty());
+    assert!(
+        output.stdout.contains(written.to_str().expect("utf-8")),
+        "stdout should print the written path, got {:?}",
+        output.stdout
+    );
+    assert_eq!(
+        fs::read_to_string(&written).expect("read written skill"),
+        skill_source()
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn second_run_without_force_is_skill_exists_and_leaves_file() {
+    let _lock = env_lock();
+    let root = temp_dir("exists");
+    let skill_dir = root.join("skills");
+    let first = cli(&[
+        "tsk",
+        "setup",
+        "--skill-dir",
+        skill_dir.to_str().expect("utf-8"),
+    ]);
+    assert_eq!(first.code, 0);
+    let written = skill_dir.join("tsk-cli/SKILL.md");
+    fs::write(&written, "stale-marker\n").expect("stamp file");
+    let second = cli(&[
+        "tsk",
+        "setup",
+        "--skill-dir",
+        skill_dir.to_str().expect("utf-8"),
+    ]);
+    assert_eq!(second.code, 1);
+    assert!(
+        second.stderr.contains("skill-exists"),
+        "stderr should name skill-exists, got {:?}",
+        second.stderr
+    );
+    assert_eq!(
+        fs::read_to_string(&written).expect("unchanged"),
+        "stale-marker\n"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn force_overwrites() {
+    let _lock = env_lock();
+    let root = temp_dir("force");
+    let skill_dir = root.join("skills");
+    let written = skill_dir.join("tsk-cli/SKILL.md");
+    fs::create_dir_all(written.parent().expect("parent")).expect("mkdir");
+    fs::write(&written, "stale-marker\n").expect("stamp file");
+    let output = cli(&[
+        "tsk",
+        "setup",
+        "--skill-dir",
+        skill_dir.to_str().expect("utf-8"),
+        "--force",
+    ]);
+    assert_eq!(output.code, 0);
+    assert_eq!(
+        fs::read_to_string(&written).expect("overwritten"),
+        skill_source()
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn bare_setup_lists_targets_and_writes_nothing() {
+    let _lock = env_lock();
+    let root = temp_dir("list");
+    let home = root.join("home");
+    fs::create_dir_all(&home).expect("home");
+    let previous_home = std::env::var_os("HOME");
+    let previous_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    std::env::set_var("HOME", &home);
+    std::env::set_var("XDG_CONFIG_HOME", root.join("xdg"));
+    let output = cli(&["tsk", "setup"]);
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    match previous_xdg {
+        Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+        None => std::env::remove_var("XDG_CONFIG_HOME"),
+    }
+    assert_eq!(output.code, 0);
+    for token in ["herdr", "claude", "pi", "codex", "cursor", "--skill-dir"] {
+        assert!(
+            output.stdout.contains(token),
+            "bare setup should list {token}, got {:?}",
+            output.stdout
+        );
+    }
+    assert!(
+        !home.join(".claude").exists(),
+        "bare setup must not write agent skills"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn two_targets_or_herdr_plus_skill_dir_are_usage() {
+    let _lock = env_lock();
+    let root = temp_dir("usage");
+    let skill_dir = root.join("skills");
+    let two = cli(&["tsk", "setup", "claude", "pi"]);
+    assert_eq!(two.code, 2);
+    let mixed = cli(&[
+        "tsk",
+        "setup",
+        "herdr",
+        "--skill-dir",
+        skill_dir.to_str().expect("utf-8"),
+    ]);
+    assert_eq!(mixed.code, 2);
+    assert!(!skill_dir.exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn json_emits_written_exists_or_listed() {
+    let _lock = env_lock();
+    let root = temp_dir("json");
+    let skill_dir = root.join("skills");
+    let path = skill_dir.to_str().expect("utf-8");
+    let written = cli(&["tsk", "setup", "--skill-dir", path, "--json"]);
+    assert_eq!(written.code, 0);
+    let written_value: serde_json::Value =
+        serde_json::from_str(written.stdout.trim()).expect("written json");
+    assert_eq!(written_value["outcome"], "written");
+    assert!(written_value["path"].as_str().is_some());
+    assert!(written_value["target"].as_str().is_some());
+
+    let exists = cli(&["tsk", "setup", "--skill-dir", path, "--json"]);
+    assert_eq!(exists.code, 1);
+    let exists_value: serde_json::Value =
+        serde_json::from_str(exists.stdout.trim()).expect("exists json");
+    assert_eq!(exists_value["outcome"], "exists");
+
+    let listed = cli(&["tsk", "setup", "--json"]);
+    assert_eq!(listed.code, 0);
+    let listed_value: serde_json::Value =
+        serde_json::from_str(listed.stdout.trim()).expect("listed json");
+    assert_eq!(listed_value["outcome"], "listed");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn setup_herdr_still_matches_existing_tests() {
+    let help = cli(&["tsk", "setup", "herdr", "--help"]);
+    assert_eq!(help.code, 0);
+    assert!(help.stdout.contains("prefix+t"));
+    let bad = cli(&["tsk", "setup", "herdr", "--force"]);
+    assert_eq!(bad.code, 2);
+}

--- a/tests/cli_setup_agent.rs
+++ b/tests/cli_setup_agent.rs
@@ -138,13 +138,26 @@ fn bare_setup_lists_targets_and_writes_nothing() {
         None => std::env::remove_var("XDG_CONFIG_HOME"),
     }
     assert_eq!(output.code, 0);
-    for token in ["herdr", "claude", "pi", "codex", "cursor", "--skill-dir"] {
+    for token in [
+        "herdr",
+        "claude",
+        "pi",
+        "codex",
+        "cursor",
+        "grok",
+        "--skill-dir",
+    ] {
         assert!(
             output.stdout.contains(token),
             "bare setup should list {token}, got {:?}",
             output.stdout
         );
     }
+    assert!(
+        output.stdout.contains(".grok/skills"),
+        "bare setup should advertise the grok skills dir, got {:?}",
+        output.stdout
+    );
     assert!(
         !home.join(".claude").exists(),
         "bare setup must not write agent skills"
@@ -206,4 +219,107 @@ fn setup_herdr_still_matches_existing_tests() {
     assert!(help.stdout.contains("prefix+t"));
     let bad = cli(&["tsk", "setup", "herdr", "--force"]);
     assert_eq!(bad.code, 2);
+}
+
+#[test]
+fn empty_skill_dir_is_usage_and_writes_nothing() {
+    let _lock = env_lock();
+    let root = temp_dir("empty-dir");
+    let previous = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(&root).expect("chdir temp");
+    let space = cli(&["tsk", "setup", "--skill-dir", ""]);
+    let equals = cli(&["tsk", "setup", "--skill-dir="]);
+    std::env::set_current_dir(&previous).expect("restore cwd");
+    assert_eq!(space.code, 2, "{space:?}");
+    assert_eq!(equals.code, 2, "{equals:?}");
+    assert!(
+        !root.join("tsk-cli").exists(),
+        "empty --skill-dir must not write into cwd"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn named_agent_targets_write_under_home() {
+    let _lock = env_lock();
+    let root = temp_dir("named");
+    let home = root.join("home");
+    fs::create_dir_all(&home).expect("home");
+    let previous_home = std::env::var_os("HOME");
+    std::env::set_var("HOME", &home);
+    let cases = [
+        ("claude", ".claude/skills"),
+        ("pi", ".pi/agent/skills"),
+        ("cursor", ".cursor/skills"),
+        ("codex", ".agents/skills"),
+        ("grok", ".grok/skills"),
+    ];
+    for (name, suffix) in cases {
+        let dest = home.join(suffix).join("tsk-cli/SKILL.md");
+        let output = cli(&["tsk", "setup", name, "--force"]);
+        assert_eq!(output.code, 0, "{name}: {output:?}");
+        assert_eq!(
+            fs::read_to_string(&dest).expect("written skill"),
+            skill_source(),
+            "{name} path"
+        );
+    }
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn force_refuses_a_symlinked_skill_file_and_directory() {
+    let _lock = env_lock();
+    let root = temp_dir("symlink");
+    let skill_dir = root.join("skills");
+    let outside = root.join("outside");
+    fs::create_dir_all(&outside).expect("outside");
+    let planted = outside.join("SKILL.md");
+    fs::write(&planted, "do-not-clobber\n").expect("plant");
+
+    fs::create_dir_all(skill_dir.join("tsk-cli")).expect("skill folder");
+    std::os::unix::fs::symlink(&planted, skill_dir.join("tsk-cli/SKILL.md")).expect("link file");
+    let file = cli(&[
+        "tsk",
+        "setup",
+        "--skill-dir",
+        skill_dir.to_str().expect("utf-8"),
+        "--force",
+    ]);
+    assert_eq!(file.code, 1, "{file:?}");
+    assert!(
+        file.stderr.contains("refusing symlink"),
+        "stderr should refuse the file symlink, got {:?}",
+        file.stderr
+    );
+    assert_eq!(
+        fs::read_to_string(&planted).expect("untouched file"),
+        "do-not-clobber\n"
+    );
+
+    let _ = fs::remove_dir_all(skill_dir.join("tsk-cli"));
+    std::os::unix::fs::symlink(&outside, skill_dir.join("tsk-cli")).expect("link dir");
+    let dir = cli(&[
+        "tsk",
+        "setup",
+        "--skill-dir",
+        skill_dir.to_str().expect("utf-8"),
+        "--force",
+    ]);
+    assert_eq!(dir.code, 1, "{dir:?}");
+    assert!(
+        dir.stderr.contains("refusing symlink"),
+        "stderr should refuse the directory symlink, got {:?}",
+        dir.stderr
+    );
+    assert_eq!(
+        fs::read_to_string(&planted).expect("untouched dir target"),
+        "do-not-clobber\n"
+    );
+    let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary

Agent path for gettsk.sh and the binary: `tsk guide` prints the skill, `tsk setup <agent>` installs it, `/docs/agents/` is generated from the same file, docs pages get a markdown/copy row, and the landing gains a "Hand it to your agent." band after CLI.

This is PR 2 of the agent-site work (T-8..T-12). `tsk setup herdr` is unchanged.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release`
- [ ] Manual herdr open-board smoke (if host paths changed) — **not required**: this PR does not change the board. Live herdr smoke was not run.
- [x] `cd site && npm test && npm run build && npm run test:parity`

## Commits

- `cli: add tsk guide and the agent help footer`
- `cli: install the agent skill with tsk setup`
- `site: generate /docs/agents/ from the skill`
- `site: add markdown and copy-for-agent on docs pages`
- `site: add the Hand it to your agent landing band`

## Agent skill directories (AC-4)

Verified at implementation time, cited in the T-9 commit:

| Target | User-level dir | Source |
| --- | --- | --- |
| claude | `~/.claude/skills/<name>/SKILL.md` | https://code.claude.com/docs/en/skills |
| pi | `~/.pi/agent/skills/` | https://pi.dev/docs/latest/skills |
| cursor | `~/.cursor/skills/` | https://cursor.com/docs/skills |
| codex | `$HOME/.agents/skills` | https://developers.openai.com/codex/skills |

Vercel nested-slug rewrite: https://vercel.com/docs/rewrites (`:path` with a custom regex, same shape as `/:path((?!uk/).* )`). Destination stays `/docs/:path.md`.

## Acceptance criteria this PR claims

AC-1, AC-2, AC-3, AC-4, AC-7, AC-12, AC-13, AC-16 (agents page), AC-18. Plumbing ACs (twins, robots, llms, JSON-LD) shipped in #51.

## Verification (AC → proof)

| Criterion | Type | Proof |
| --- | --- | --- |
| AC-1 | test-backed | guide_prints_skill_minus_frontmatter_and_exits_0 |
| AC-2 | test-backed | skill_dir_writes_full_skill_prints_path_exits_0, second_run_without_force_is_skill_exists_and_leaves_file, force_overwrites, setup_herdr_still_matches_existing_tests |
| AC-3 | test-backed | top_level_help_lists_guide_and_ends_with_agent_footer, bare_setup_lists_targets_and_writes_nothing |
| AC-4 | reviewer-checked | T-9 commit cites a live URL per shipped target (table above). Pass. |
| AC-7 | test-backed | agents_page_notice_plus_skill_body_matches_source, dist_docs_agents_md_exists |
| AC-12 | test-backed | landing_agents_band_after_cli_copies_bootstrap_and_stays_on_palette |
| AC-13 | test-backed | docs_cli_shows_markdown_link_and_copy_for_agent_writes_read_url |
| AC-16 | test-backed | definition_sentence_appears_in_agents_page |
| AC-18 | reviewer-checked | Three trials 2026-09-09, all PASS. Transcripts local (not committed): `docs/specs/agent-site/trials/grok-4.6-with-path.md`, `docs/specs/agent-site/trials/grok-4.5-with-path.md`, `docs/specs/agent-site/trials/grok-4.6-without-path.md`. With PATH: add in repo scope, two steps, started, `--json`, no install, no hand store edit. Without PATH: live `/docs/agents/` 404s until this ships; agent read the local twin and asked before installing. |

`cli.md` was diffed against `src/cli/` (`## guide` and `## setup` match the binary). GitHub repo description remains owner-only.

## Notes

- Nested Accept rewrite in `site/vercel.json` now matches `/docs/a/b/` → `/docs/a/b.md` and still skips `.md` paths.
- Preview curls for AC-6 / crawler UAs / Lighthouse belong to PR 1 (#51) except the nested-slug fix here.
