### PR TITLE
site: drop Accept rewrites that Vercel rejects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,11 @@ For scriptable board work, use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, 
   automatically only on pushes to `main` to conserve Actions usage; PR checks are
   not required. Site-only pushes skip the Rust matrix (`paths-ignore: site/**`).
   Site CI is `npm ci && npm test && npm run build` in `site/`.
+- `site/vercel.json` is validated by Vercel's own route parser in `npm test`
+  (`@vercel/routing-utils`, the same check `vercel deploy` runs before upload). Its
+  `:param(...)` patterns reject regex lookaheads; a bad pattern fails every production
+  deploy silently from the site's point of view, so never edit that file without the test.
+  Markdown twins are reached by `.md` URLs and `rel=alternate`, not `Accept` negotiation.
 - Landing page and Starlight docs live in `site/` (Astro). They are not part of
   the `tsk` binary. Production: https://gettsk.sh. Point Vercel at
   this repo with Root Directory `site`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,4 +46,4 @@ Canonical terms for this repo. No implementation detail.
 - **guide**: the agent workflow doc, `skills/tsk-cli/SKILL.md`, printed by `tsk guide` and published at `/docs/agents/`.
 - **twin**: the Markdown representation of a docs page at `/docs/<slug>.md`.
 - **bootstrap prompt**: the three-line text a human pastes to an agent to start using tsk.
-- **definition sentence**: `tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.`
+- **definition sentence**: `tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tsk
 
-tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.
+tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.
 
-You and your agents put work on one board and move it through human status:
+You and your agents put work on one board and move it through:
 ready, started, blocked, review, done. Agents reach the board through the CLI.
 It ships as a [herdr](https://herdr.dev) plugin, and the `tsk` binary also runs
 standalone against `~/.tsk`.
@@ -31,7 +31,7 @@ brew install smarzban/tap/tsk
 The installer sets up PATH for Bash and Zsh. If prompted, reopen your terminal
 or run the printed `export` command before continuing.
 
-### Add to Herdr (optional)
+### Add to Herdr
 
 With Herdr 0.9+ installed:
 

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.63.0",
+        "@vercel/routing-utils": "6.5.0",
         "prettier": "^3.9.6"
       }
     },
@@ -2473,6 +2474,20 @@
         }
       }
     },
+    "node_modules/@vercel/routing-utils": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/routing-utils/-/routing-utils-6.5.0.tgz",
+      "integrity": "sha512-2PXgATJyJYEaIuDEhljZ+sfOfJEsBl6OEzD+jHhy6NAb0k2mHdbTjcK3zTBNnYq0nebrXpq5ZGiwOxBFoUwB3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "path-to-regexp": "6.1.0",
+        "path-to-regexp-updated": "npm:path-to-regexp@6.3.0"
+      },
+      "optionalDependencies": {
+        "ajv": "^6.12.3"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -2492,6 +2507,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/am-i-vibing": {
@@ -3379,6 +3412,22 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -4043,6 +4092,14 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
@@ -5691,6 +5748,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp-updated": {
+      "name": "path-to-regexp",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -5852,6 +5924,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/radix3": {
@@ -6877,6 +6960,17 @@
         "uploadthing": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-extras": {

--- a/site/package.json
+++ b/site/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.63.0",
+    "@vercel/routing-utils": "6.5.0",
     "prettier": "^3.9.6"
   }
 }

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,6 +1,6 @@
 # tsk
 
-> tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.
+> tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.
 
 Install with `curl -fsSL https://gettsk.sh/install.sh | sh` or `brew install smarzban/tap/tsk`.
 Details: https://gettsk.sh/docs/install.md

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: What tsk is, who moves the work, and where to read next.
 ---
 
-**tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.** You both put work on one board and move it through human status: ready, started, blocked, review, done.
+**tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.** You both put work on one board and move it through human status: ready, started, blocked, review, done.
 
 It ships as the herdr plugin `herdr-tsk`. The `tsk` binary also runs standalone
 against `~/.tsk`. The pane, the quick-capture popup, and the CLI edit the same store.

--- a/site/src/lib/agent-docs.mjs
+++ b/site/src/lib/agent-docs.mjs
@@ -7,7 +7,7 @@ import { basename, dirname, resolve } from "node:path";
 
 export const SITE = "https://gettsk.sh";
 export const DEFINITION_SENTENCE =
-  "tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.";
+  "tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.";
 export const SIDEBAR_SLUGS = [
   "index",
   "agents",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -33,7 +33,7 @@ const softwareApplication = {
     <title>tsk · a task board for you and your agents</title>
     <meta
       name="description"
-      content="tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI."
+      content="tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them."
     />
     <link rel="canonical" href={`${SITE}/`} />
     <meta property="og:type" content="website" />

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -234,7 +234,7 @@ test("every_docs_entry_has_description_and_an_answer_first_paragraph", async () 
 });
 
 const DEFINITION_SENTENCE =
-  "tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.";
+  "tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.";
 
 const SIDEBAR_TITLES = [
   "Overview",
@@ -344,7 +344,7 @@ test("definition_sentence_appears_verbatim_in_index_astro_llms_txt_docs_index_an
 });
 
 const NOTICE =
-  "tsk is a terminal task board for you and your agents: one board, five statuses, agents work through the CLI.";
+  "tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.";
 
 function syncAgentsPage() {
   const result = spawnSync("node", ["scripts/sync-agents-page.mjs"], {

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -146,52 +146,24 @@ test("docs_html_has_rel_alternate_to_the_twin_once_and_landing_has_none", async 
   assert.doesNotMatch(landing, /rel="alternate" type="text\/markdown"/);
 });
 
-test("vercel_json_rewrites_docs_html_to_markdown_twin_when_accept_contains_text_markdown", async () => {
+test("vercel_json_has_no_accept_rewrites_and_no_regex_lookaheads", async () => {
+  // Vercel's route parser rejects lookaheads inside :param patterns, and static
+  // files win over rewrites anyway. Markdown is reached by .md URLs and rel=alternate.
   const config = JSON.parse(await read(join(siteRoot, "vercel.json")));
-  const rewrite = (config.rewrites || []).find((entry) =>
-    String(entry.source).includes("/docs/:path"),
-  );
-  assert.ok(rewrite, "expected a docs rewrite");
-  assert.match(String(rewrite.source), /\/docs\/:path/);
-  assert.match(String(rewrite.source), /\\\.md/);
-  assert.match(String(rewrite.destination), /\.md$/);
-  assert.doesNotMatch(String(rewrite.destination), /\.md\.md/);
-  assert.doesNotMatch(String(rewrite.source), /:path\*$/);
-  const accept = (rewrite.has || []).find(
-    (item) => item.type === "header" && String(item.key).toLowerCase() === "accept",
-  );
-  assert.ok(accept, "expected an Accept header matcher");
-  assert.match(String(accept.value), /text\/markdown/);
-  const vary = (config.headers || []).find(
-    (entry) =>
-      /\/docs\/\(\.\*\)$/.test(String(entry.source)) &&
-      (entry.headers || []).some((header) => header.key === "Vary" && header.value === "Accept"),
-  );
-  assert.ok(vary, "expected Vary: Accept on /docs/(.*)");
+  assert.equal(config.rewrites, undefined, "no rewrites expected");
+  for (const entry of [...(config.headers || []), ...(config.redirects || [])]) {
+    assert.doesNotMatch(String(entry.source), /\(\?/, `${entry.source} uses a lookahead`);
+  }
+  const markdown = (config.headers || []).find((entry) => String(entry.source) === "/docs/(.*).md");
+  assert.ok(markdown, "expected the Content-Type header for .md twins");
 });
 
-test("vercel_json_docs_rewrite_does_not_capture_a_trailing_slash", async () => {
+test("vercel_json_passes_vercels_own_route_validator", async () => {
+  // Same check `vercel deploy` runs client-side before uploading.
+  const { getTransformedRoutes } = await import("@vercel/routing-utils");
   const config = JSON.parse(await read(join(siteRoot, "vercel.json")));
-  const rewrites = (config.rewrites || []).filter((entry) =>
-    String(entry.source).includes("/docs/:path"),
-  );
-  assert.ok(rewrites.length > 0, "expected a docs path rewrite");
-  let matchesTrailingSlash = false;
-  for (const rewrite of rewrites) {
-    const source = String(rewrite.source);
-    const inner = source.match(/:path\((.*)\)(?:\/\?|\/)?$/)?.[1];
-    assert.ok(inner, `${source} needs a custom :path regex`);
-    const innerRe = new RegExp(`^(?:${inner})$`);
-    assert.match("cli", innerRe);
-    assert.doesNotMatch("cli/", innerRe);
-    assert.doesNotMatch("cli.md", innerRe);
-    assert.match(String(rewrite.destination), /^\/docs\/:path\.md$/);
-    if (/\/\?$|\/$/.test(source)) matchesTrailingSlash = true;
-  }
-  assert.ok(
-    matchesTrailingSlash,
-    "expected a rewrite that matches /docs/<slug>/",
-  );
+  const result = getTransformedRoutes(config);
+  assert.equal(result.error, null, result.error?.message);
 });
 
 test("robots_txt_allows_star_and_listed_crawlers_and_names_the_sitemap", async () => {
@@ -408,27 +380,3 @@ test("npm_start_and_deploy_paths_watch_the_skill", async () => {
   assert.match(String(vercelJson.ignoreCommand), /\.\.\/skills/);
 });
 
-test("vercel_docs_rewrite_matches_nested_slug_and_skips_md", async () => {
-  const config = JSON.parse(await read(join(siteRoot, "vercel.json")));
-  const rewrites = (config.rewrites || []).filter((entry) =>
-    String(entry.source).includes("/docs/:path"),
-  );
-  assert.ok(rewrites.length > 0, "expected a docs path rewrite");
-  let matchesNested = false;
-  let skipsMd = true;
-  for (const rewrite of rewrites) {
-    const source = String(rewrite.source);
-    const inner = source.match(/:path\((.*)\)(?:\/\?|\/)?$/)?.[1];
-    assert.ok(inner, `${source} needs a custom :path regex`);
-    const innerRe = new RegExp(`^(?:${inner})$`);
-    assert.match("cli", innerRe);
-    assert.match("a/b", innerRe, `${source} should match nested slugs`);
-    assert.doesNotMatch("cli.md", innerRe);
-    assert.doesNotMatch("a/b.md", innerRe);
-    assert.match(String(rewrite.destination), /^\/docs\/:path\.md$/);
-    matchesNested = true;
-    if (innerRe.test("cli.md") || innerRe.test("a/b.md")) skipsMd = false;
-  }
-  assert.ok(matchesNested, "expected a rewrite that matches /docs/a/b/");
-  assert.ok(skipsMd, "/docs/a/b.md and /docs/cli.md must not match");
-});

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -13,50 +13,6 @@
           "value": "text/markdown; charset=utf-8"
         }
       ]
-    },
-    {
-      "source": "/docs/(.*)",
-      "headers": [
-        {
-          "key": "Vary",
-          "value": "Accept"
-        }
-      ]
-    }
-  ],
-  "rewrites": [
-    {
-      "source": "/docs",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": "(.*)text/markdown(.*)"
-        }
-      ],
-      "destination": "/docs/index.md"
-    },
-    {
-      "source": "/docs/",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": "(.*)text/markdown(.*)"
-        }
-      ],
-      "destination": "/docs/index.md"
-    },
-    {
-      "source": "/docs/:path((?!.*\\.md$)[^/]+(?:/[^/]+)*)/?",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": "(.*)text/markdown(.*)"
-        }
-      ],
-      "destination": "/docs/:path.md"
     }
   ]
 }


### PR DESCRIPTION
Production deploys have failed since #51: `vercel deploy` refuses the `/docs/:path((?!.*\.md$)...)` rewrite because `:param` patterns cannot contain lookaheads. Static files would also win over the rewrite.

- Remove the three `Accept: text/markdown` rewrites and the `Vary: Accept` header; keep the `.md` Content-Type header.
- `npm test` now runs `@vercel/routing-utils` `getTransformedRoutes` on `vercel.json` (same validator the CLI runs before upload); it reproduces the deploy error on the old file.
- AGENTS.md rule.

Markdown twins remain reachable via `.md` URLs and `rel=alternate`. Site tests 42/42, build clean.