### PR TITLE
cli: dim a newer-release notice on the board status row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,8 +235,12 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   keeps its internal name `TaskScope::Global`; do not "fix" either without a store
   migration.
 - State is `$HOME/.tsk/tsk.json`, walkthrough dismissal is
-  `$HOME/.tsk/walkthrough.json`, overridable with `TSK_STATE_DIR` / `TSK_CONFIG_DIR`.
+  `$HOME/.tsk/walkthrough.json`, the release-check cache is `$HOME/.tsk/update.json`,
+  overridable with `TSK_STATE_DIR` / `TSK_CONFIG_DIR`.
   Host-injected `HERDR_PLUGIN_*` dirs are ignored. Mutating verbs always use Ctrl.
+  On board launch, if `TSK_NO_UPDATE_CHECK` is unset and that cache is older than 24h,
+  a background `curl` of the GitHub latest-release tag updates it; a newer tag paints a
+  dim `v<tag> available` on the idle status row. Any check failure is silent.
 - Store format is versioned (`STORE_FORMAT_VERSION`, currently 2). Any schema change bumps it
   and adds a `vN → vN+1` step to `MIGRATIONS` in `src/store.rs`; `deny_unknown_fields` stays on
   `Task` and `DomainState` so an older binary refuses a newer file instead of dropping fields.
@@ -251,6 +255,10 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   `tsk project archive|unarchive <name>`, `tsk list --archived`; `tsk add` into an archived
   project refuses with error code `project-archived`. `tsk status` accepts ready, started
   (or start), blocked, review, or done. `tsk steps` also renames and removes.
+  `tsk guide` prints the embedded `skills/tsk-cli/SKILL.md` body (also published at
+  `/docs/agents/`, generated at site build). `tsk setup <claude|pi|cursor|codex|--skill-dir p>`
+  writes that skill into the agent's skills dir (`src/setup_agent.rs`); bare `tsk setup` lists
+  and writes nothing. `tsk --help` ends with a two-line agent footer.
 - `~/.tsk` must live on a local disk (flock plus rename-based replace); synced folders are
   unsupported, `TSK_STATE_DIR` is the escape hatch. State/config directory roots must be real
   directories, not symlinks; permission hardening refuses a symlink instead of chmodding its target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+The board checks GitHub for a newer release at most once a day and paints a dim
+`vX.Y.Z available` on the status row. Set `TSK_NO_UPDATE_CHECK` to disable it.
+
 `tsk setup grok` installs the CLI skill into `~/.grok/skills/`. Empty `--skill-dir` is usage. A symlink at the skill folder or `SKILL.md` is refused.
 
 The installer configures PATH for Bash and Zsh, then tells you to reopen the terminal or run an export command.

--- a/site/parity/navigation.spec.mjs
+++ b/site/parity/navigation.spec.mjs
@@ -27,6 +27,14 @@ test("project navigation, counted views and selection match the app", async ({
     expect(colors[0]).not.toBe(colors[1]);
   }
   await page.locator('[data-tab="project"]').click();
+  await expect(page.locator(".tsk-tab-group.is-on .tsk-tab")).toHaveCSS(
+    "text-decoration-line",
+    "underline",
+  );
+  await expect(page.locator(".tsk-tab-group.is-on .tsk-tab-arrow")).toHaveCSS(
+    "text-decoration-line",
+    "none",
+  );
   await expect(page.locator("[data-filter]")).toHaveText("all ▾");
   await page.locator("[data-filter]").click();
   await expect(

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -4,6 +4,7 @@
 
 Install with `curl -fsSL https://gettsk.sh/install.sh | sh` or `brew install smarzban/tap/tsk`.
 Details: https://gettsk.sh/docs/install.md
+The board checks GitHub releases at most daily and shows a dim `vX.Y.Z available` on the status row; set `TSK_NO_UPDATE_CHECK` to disable.
 
 ## For agents
 

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -124,6 +124,13 @@ Use `TSK_STATE_DIR` / `TSK_CONFIG_DIR` to override state/config directories. Kee
 on a local disk, not NFS or a synced folder, and use real directories, not symlinks.
 Herdr-injected plugin directories do not change where tsk stores tasks.
 
+On launch the board reads `update.json` in the state directory. If that check is
+older than 24 hours and `TSK_NO_UPDATE_CHECK` is unset, it `GET`s
+`https://api.github.com/repos/smarzban/herdr-tsk/releases/latest` and stores the
+`tag_name`. The request sends nothing else. A tag newer than this binary paints a
+dim `vX.Y.Z available` on the status row, behind any other status message or
+bottom input. Set `TSK_NO_UPDATE_CHECK` to skip the check and the notice.
+
 ## Next
 
 [Board](/docs/board/) · [Keys](/docs/keys/) · [Capture](/docs/capture/)

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -2577,8 +2577,7 @@ html[data-theme="light"] .pane {
 .tsk-tab-arrow, .tsk-view-control { appearance: none; border: 0; padding: 0; background: none; font: inherit; color: inherit; cursor: pointer; }
 .tsk-tab-group { color: var(--dim); }
 .tsk-tab-group.is-on { color: var(--ink); }
-.tsk-tab-group.is-on .tsk-tab,
-.tsk-tab-group.is-on .tsk-tab-arrow {
+.tsk-tab-group.is-on .tsk-tab {
   text-decoration: underline;
   text-underline-offset: .2em;
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -100,13 +100,18 @@ pub fn load_board_for_quick_capture() -> Result<(TaskStore, DomainState, BoardMo
 fn load_board_inner(
     offer_launch_card: bool,
 ) -> Result<(TaskStore, DomainState, BoardModel), Box<dyn Error>> {
-    let store = TaskStore::new(default_state_dir());
+    let state_dir = default_state_dir();
+    let store = TaskStore::new(state_dir.clone());
     let state = store.load()?;
     let snapshot = load_snapshot();
     let mut model = BoardModel::from_domain(&state, snapshot.this_repo.clone());
     if offer_launch_card {
         model.offer_launch_card(&state, &snapshot);
     }
+    model.set_update_notice(crate::update::startup(
+        &state_dir,
+        env!("CARGO_PKG_VERSION"),
+    ));
     Ok((store, state, model))
 }
 

--- a/src/fsperm.rs
+++ b/src/fsperm.rs
@@ -2,7 +2,8 @@
 //!
 //! State files hold the user's tasks; they are nobody else's business. On Unix
 //! the state/config directories are `0700` and the files `0600` (`tsk.json`,
-//! `trash.jsonl`, backups, the lock file, temp files, `walkthrough.json`), both
+//! `trash.jsonl`, backups, the lock file, temp files, `walkthrough.json`,
+//! `update.json`), both
 //! for fresh creation and tightened after the fact for paths an older version
 //! or a looser umask left readable. Tightening only ever strips bits: an
 //! existing stricter mode (a file an admin locked to `0400`, a read-only

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod setup_agent;
 pub mod store;
 pub(crate) mod text;
 pub mod ui;
+pub mod update;
 
 pub use board_pane::{find_board_pane_from_stdin, find_board_pane_id};
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -717,9 +717,11 @@ fn is_private_state_name(name: &str) -> bool {
         || name == BACKUP_FILE
         || name == LOCK_FILE
         || name == TRASH_FILE
+        || name == "update.json"
         || name.starts_with(&format!("{STATE_FILE}.v"))
         || name.starts_with(&format!(".{STATE_FILE}.tmp."))
         || name.starts_with(&format!(".{TRASH_FILE}.tmp."))
+        || name.starts_with(".update.json.tmp.")
 }
 
 /// RAII exclusive lock on the store lock file (released on drop via `File::unlock`).

--- a/src/ui/board/draw.rs
+++ b/src/ui/board/draw.rs
@@ -660,6 +660,15 @@ fn build_task_page_overlay<'a>(
 
 /// Idle status-row context for the active lens. Stored paths and thread names reach the
 /// renderer only through its `present_line` path before they are painted.
+fn status_idle(model: &BoardModel, surface: BoardSurface, has_message: bool) -> String {
+    if !has_message {
+        if let Some(notice) = model.update_notice() {
+            return format!(" {notice}");
+        }
+    }
+    footer_context(model, surface)
+}
+
 fn footer_context(model: &BoardModel, surface: BoardSurface) -> String {
     match surface {
         BoardSurface::Desk => " desk".to_string(),
@@ -1149,7 +1158,7 @@ fn draw_board_hits(frame: &mut Frame, model: &BoardModel) -> render::QueueHitMap
         projects_cursor: model.projects_cursor(),
         projects_query: model.projects_query(),
         summary: None,
-        context: footer_context(model, surface),
+        context: status_idle(model, surface, status_owned.is_some()),
         status_message: status_owned.as_deref(),
         status_undo_offset,
         verb_items: &verbs,
@@ -1318,7 +1327,7 @@ fn draw_wide_board(
         projects_cursor: model.projects_cursor(),
         projects_query: model.projects_query(),
         summary: None,
-        context: footer_context(model, surface),
+        context: status_idle(model, surface, status_owned.is_some()),
         status_message: status_owned.as_deref(),
         status_undo_offset,
         verb_items: &verbs,

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -716,6 +716,8 @@ pub struct BoardModel {
     pub(super) hold_task_edit_save: bool,
     /// Last board action feedback or empty-selection chrome message.
     pub(super) message: Option<String>,
+    /// Dim status-row notice when a cached release tag is newer than this binary.
+    pub(super) update_notice: Option<String>,
     /// Title of the task the last soft-delete removed, captured at delete time.
     ///
     /// Transient presentation only: it is never persisted, and it is the whole of the delete
@@ -814,6 +816,7 @@ impl BoardModel {
             task_edit_save: None,
             hold_task_edit_save: false,
             message: None,
+            update_notice: None,
             delete_notice: None,
             suspended_delete_notice: None,
             pending_delete: None,
@@ -2608,6 +2611,14 @@ impl BoardModel {
     /// Chrome status/message line feedback.
     pub fn message(&self) -> Option<&str> {
         self.message.as_deref()
+    }
+
+    pub fn update_notice(&self) -> Option<&str> {
+        self.update_notice.as_deref()
+    }
+
+    pub fn set_update_notice(&mut self, notice: Option<String>) {
+        self.update_notice = notice;
     }
 
     pub fn set_message(&mut self, msg: impl Into<String>) {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1304,9 +1304,11 @@ fn paint_footer(
                 _ => {}
             }
         } else {
-            let idle = if model.projects_index {
+            let idle = if model.projects_index && !model.context.trim_end().ends_with(" available")
+            {
                 // The index's status row names the selected project's full path; rows
-                // carry only the basename.
+                // carry only the basename. An update notice already in `context` keeps
+                // this idle slot, same as desk and project boards.
                 index_selected_path(model)
             } else {
                 model.context.clone()

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -4393,25 +4393,43 @@ fn selector_chip_wraps(model: &QueueFrameModel<'_>, width: u16) -> bool {
     tabs_width.saturating_add(chip_width) > width as usize
 }
 
-/// Active tab labels keep a cell of padding for hit targets; underline only the word.
+/// Active tab labels keep a cell of padding for hit targets; underline only the word,
+/// never the padding or the slot-2 chevron.
 fn push_selector_tab_spans(spans: &mut Vec<Span<'static>>, text: &str, active: bool) {
     if !active {
         spans.push(Span::styled(text.to_string(), style_dim()));
         return;
     }
-    let trimmed = text.trim();
+    let chevron_at = text
+        .char_indices()
+        .rev()
+        .find_map(|(i, ch)| (ch == '\u{25be}' || ch == '\u{25b8}').then_some(i));
+    let (label_part, chevron_part) = match chevron_at {
+        Some(i) => {
+            let label_end = text[..i]
+                .rfind(|ch: char| !ch.is_whitespace())
+                .map(|j| j + text[j..].chars().next().map(char::len_utf8).unwrap_or(0))
+                .unwrap_or(0);
+            (&text[..label_end], &text[label_end..])
+        }
+        None => (text, ""),
+    };
+    let trimmed = label_part.trim();
     if trimmed.is_empty() {
         spans.push(Span::styled(text.to_string(), style_heading()));
         return;
     }
-    let start = text.find(trimmed).expect("trim is a substring");
+    let start = label_part.find(trimmed).expect("trim is a substring");
     let end = start + trimmed.len();
     if start > 0 {
-        spans.push(Span::styled(text[..start].to_string(), style_plain()));
+        spans.push(Span::styled(label_part[..start].to_string(), style_plain()));
     }
     spans.push(Span::styled(trimmed.to_string(), style_heading()));
-    if end < text.len() {
-        spans.push(Span::styled(text[end..].to_string(), style_plain()));
+    if end < label_part.len() {
+        spans.push(Span::styled(label_part[end..].to_string(), style_plain()));
+    }
+    if !chevron_part.is_empty() {
+        spans.push(Span::styled(chevron_part.to_string(), style_bold()));
     }
 }
 
@@ -4816,6 +4834,40 @@ mod tests {
                 assert!(
                     !span.style.add_modifier.contains(Modifier::UNDERLINED),
                     "padding must not be underlined: {span:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn active_project_tab_underlines_the_name_not_the_chevron() {
+        let (line, _) = paint_selector_row(
+            &selector_model(NavTab::ProjectBoard),
+            &tier::resolve(78, 24),
+        );
+        let text = plain(&line);
+        assert!(
+            text.contains('▾'),
+            "project tab keeps its chevron: {text:?}"
+        );
+        let underlined: String = line
+            .spans
+            .iter()
+            .filter(|span| span.style.add_modifier.contains(Modifier::UNDERLINED))
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert_eq!(underlined, "tsk");
+        for span in &line.spans {
+            if span.content.contains('▾') || span.content.contains('▸') {
+                assert!(
+                    !span.style.add_modifier.contains(Modifier::UNDERLINED),
+                    "chevron must not be underlined: {span:?}"
+                );
+            }
+            if span.content.as_ref().chars().all(|ch| ch == ' ') {
+                assert!(
+                    !span.style.add_modifier.contains(Modifier::UNDERLINED),
+                    "space around the chevron must not be underlined: {span:?}"
                 );
             }
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,7 @@ const UPDATE_FILE: &str = "update.json";
 const UPDATE_TEMP_PREFIX: &str = ".update.json.tmp.";
 pub const STALE_AFTER_SECS: u64 = 24 * 60 * 60;
 const RELEASES_URL: &str = "https://api.github.com/repos/smarzban/herdr-tsk/releases/latest";
+static BACKGROUND_FETCH: AtomicBool = AtomicBool::new(true);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UpdateCache {
@@ -29,6 +31,25 @@ pub struct CheckPlan {
 
 pub fn opt_out() -> bool {
     std::env::var_os("TSK_NO_UPDATE_CHECK").is_some()
+}
+
+/// Integration tests link the library without `cfg(test)`, so `spawn_fetch` cannot
+/// use that cfg. Tests that load the board call this before `load_board*`.
+pub fn suppress_background_fetch() {
+    BACKGROUND_FETCH.store(false, Ordering::SeqCst);
+}
+
+pub fn mark_check_started(dir: &Path, now: u64) {
+    let latest = read_cache(dir)
+        .map(|cache| cache.latest)
+        .unwrap_or_default();
+    let _ = write_cache(
+        dir,
+        &UpdateCache {
+            last_check_unix: now,
+            latest,
+        },
+    );
 }
 
 pub fn unix_now() -> u64 {
@@ -145,13 +166,14 @@ pub fn startup(state_dir: &Path, current: &str) -> Option<String> {
     let now = unix_now();
     let planned = plan(state_dir, current, now);
     if planned.should_fetch {
+        mark_check_started(state_dir, now);
         spawn_fetch(state_dir.to_path_buf());
     }
     planned.notice
 }
 
 fn spawn_fetch(dir: PathBuf) {
-    if cfg!(test) {
+    if cfg!(test) || !BACKGROUND_FETCH.load(Ordering::SeqCst) {
         return;
     }
     std::thread::spawn(move || {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,224 @@
+//! Optional GitHub release check: a cached tag and a dim footer notice.
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::fsperm;
+
+const UPDATE_FILE: &str = "update.json";
+const UPDATE_TEMP_PREFIX: &str = ".update.json.tmp.";
+pub const STALE_AFTER_SECS: u64 = 24 * 60 * 60;
+const RELEASES_URL: &str = "https://api.github.com/repos/smarzban/herdr-tsk/releases/latest";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateCache {
+    pub last_check_unix: u64,
+    pub latest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckPlan {
+    pub notice: Option<String>,
+    pub should_fetch: bool,
+}
+
+pub fn opt_out() -> bool {
+    std::env::var_os("TSK_NO_UPDATE_CHECK").is_some()
+}
+
+pub fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+pub fn is_stale(last_check_unix: u64, now: u64) -> bool {
+    now.saturating_sub(last_check_unix) >= STALE_AFTER_SECS
+}
+
+pub fn parse_semver(value: &str) -> Option<(u64, u64, u64)> {
+    let trimmed = value.trim();
+    let rest = trimmed
+        .strip_prefix('v')
+        .or_else(|| trimmed.strip_prefix('V'))
+        .unwrap_or(trimmed);
+    let core = rest.split(['-', '+']).next().unwrap_or(rest);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+pub fn is_newer(latest: &str, current: &str) -> bool {
+    match (parse_semver(latest), parse_semver(current)) {
+        (Some(latest), Some(current)) => latest > current,
+        _ => false,
+    }
+}
+
+pub fn notice_for(latest: &str, current: &str) -> Option<String> {
+    if !is_newer(latest, current) {
+        return None;
+    }
+    let body = latest.trim();
+    let shown = if body.starts_with('v') || body.starts_with('V') {
+        body.to_string()
+    } else {
+        format!("v{body}")
+    };
+    Some(format!("{shown} available"))
+}
+
+pub fn read_cache(dir: &Path) -> Option<UpdateCache> {
+    let path = dir.join(UPDATE_FILE);
+    let data = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+pub fn write_cache(dir: &Path, cache: &UpdateCache) -> io::Result<()> {
+    fsperm::ensure_private_dir(dir)?;
+    let document = dir.join(UPDATE_FILE);
+    let tmp = unique_tmp_path(dir);
+    let data = serde_json::to_string(cache).map_err(io::Error::other)?;
+    let write_result = (|| -> io::Result<()> {
+        let mut temp_file = fsperm::create_private_file(&tmp)?;
+        temp_file.write_all(data.as_bytes())?;
+        temp_file.sync_all()?;
+        drop(temp_file);
+        fs::rename(&tmp, &document)?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    write_result
+}
+
+pub fn plan(dir: &Path, current: &str, now: u64) -> CheckPlan {
+    if opt_out() {
+        return CheckPlan {
+            notice: None,
+            should_fetch: false,
+        };
+    }
+    let cache = read_cache(dir);
+    let notice = cache
+        .as_ref()
+        .and_then(|cache| notice_for(&cache.latest, current));
+    let should_fetch = cache
+        .as_ref()
+        .map(|cache| is_stale(cache.last_check_unix, now))
+        .unwrap_or(true);
+    CheckPlan {
+        notice,
+        should_fetch,
+    }
+}
+
+pub fn apply_fetch(dir: &Path, now: u64, fetch: impl FnOnce() -> Option<String>) {
+    let Some(latest) = fetch() else {
+        return;
+    };
+    if latest.trim().is_empty() {
+        return;
+    }
+    let _ = write_cache(
+        dir,
+        &UpdateCache {
+            last_check_unix: now,
+            latest: latest.trim().to_string(),
+        },
+    );
+}
+
+pub fn startup(state_dir: &Path, current: &str) -> Option<String> {
+    let now = unix_now();
+    let planned = plan(state_dir, current, now);
+    if planned.should_fetch {
+        spawn_fetch(state_dir.to_path_buf());
+    }
+    planned.notice
+}
+
+fn spawn_fetch(dir: PathBuf) {
+    if cfg!(test) {
+        return;
+    }
+    std::thread::spawn(move || {
+        apply_fetch(&dir, unix_now(), fetch_latest);
+    });
+}
+
+fn fetch_latest() -> Option<String> {
+    let output = Command::new("curl")
+        .args(["-fsSL", "--max-time", "15", RELEASES_URL])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let tag = value.get("tag_name")?.as_str()?.trim();
+    if tag.is_empty() {
+        return None;
+    }
+    Some(tag.to_string())
+}
+
+fn unique_tmp_path(dir: &Path) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    dir.join(format!("{UPDATE_TEMP_PREFIX}{pid}.{nanos}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semver_compare_orders_core_versions_and_v_prefix() {
+        assert!(is_newer("v0.6.1", "0.6.0"));
+        assert!(is_newer("0.7.0", "0.6.9"));
+        assert!(is_newer("1.0.0", "0.9.9"));
+        assert!(!is_newer("0.6.0", "0.6.0"));
+        assert!(!is_newer("v0.6.0", "0.6.0"));
+        assert!(!is_newer("0.5.9", "0.6.0"));
+        assert!(!is_newer("not-a-version", "0.6.0"));
+        assert!(!is_newer("0.6.0", "nope"));
+        assert_eq!(
+            notice_for("v0.7.0", "0.6.0").as_deref(),
+            Some("v0.7.0 available")
+        );
+        assert_eq!(
+            notice_for("0.7.0", "0.6.0").as_deref(),
+            Some("v0.7.0 available")
+        );
+        assert_eq!(notice_for("0.6.0", "0.6.0"), None);
+    }
+
+    #[test]
+    fn cache_is_stale_after_24h_and_future_timestamp_is_fresh() {
+        let now = 1_700_000_000;
+        assert!(!is_stale(now, now));
+        assert!(!is_stale(now - STALE_AFTER_SECS + 1, now));
+        assert!(is_stale(now - STALE_AFTER_SECS, now));
+        assert!(is_stale(now - STALE_AFTER_SECS - 1, now));
+        assert!(
+            !is_stale(now + 60, now),
+            "a future last_check stays eligible"
+        );
+    }
+}

--- a/tests/queue_board_loop.rs
+++ b/tests/queue_board_loop.rs
@@ -17,6 +17,7 @@ use tsk_tui::app::{
 use tsk_tui::domain::{DomainState, ProvenanceOrigin, TaskScope};
 use tsk_tui::ui::scheduler::{next_wait, DEFAULT_BASE_TICK};
 use tsk_tui::ui::{apply_intent, draw_board, BoardIntent, BoardModel, IntentOutcome};
+use tsk_tui::update::suppress_background_fetch;
 
 /// A directory this test owns alone, removed on drop even if the test panics.
 struct TempDirGuard(PathBuf);
@@ -203,6 +204,7 @@ fn autoscroll_shortens_the_board_frame_wait() {
 /// leaves this as the one open-path exercise: load, then draw).
 #[test]
 fn load_board_and_draw_path_smoke_at_80x24() {
+    suppress_background_fetch();
     let dir = temp_state_dir("smoke");
     let _dir_guard = TempDirGuard(dir.clone());
     let _env_guard = EnvVarGuard::set("TSK_STATE_DIR", &dir);

--- a/tests/quick_capture_process.rs
+++ b/tests/quick_capture_process.rs
@@ -102,6 +102,7 @@ fn capture_entrypoint_skips_launch_card_preserves_reopen_and_exits_on_escape() {
         .arg("capture")
         .current_dir(&repo)
         .env("TSK_STATE_DIR", store.path())
+        .env("TSK_NO_UPDATE_CHECK", "1")
         .env("TSK_CONFIG_DIR", root.join("config"))
         .env_remove("TSK_MODE")
         .env("TERM", "xterm-256color")

--- a/tests/update_notice.rs
+++ b/tests/update_notice.rs
@@ -1,0 +1,212 @@
+//! Update-notice cache, opt-out, fetch failure, and footer paint.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ratatui::backend::TestBackend;
+use ratatui::style::Modifier;
+use ratatui::Terminal;
+use tsk_tui::app::load_board_model;
+use tsk_tui::domain::DomainState;
+use tsk_tui::ui::{apply_intent, draw_board, BoardIntent, BoardModel};
+use tsk_tui::update::{
+    apply_fetch, is_stale, notice_for, plan, read_cache, unix_now, write_cache, CheckPlan,
+    UpdateCache, STALE_AFTER_SECS,
+};
+
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("tsk-update-{label}-{nanos}-{seq}"));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn seed_cache(dir: &Path, last_check_unix: u64, latest: &str) {
+    write_cache(
+        dir,
+        &UpdateCache {
+            last_check_unix,
+            latest: latest.to_string(),
+        },
+    )
+    .expect("write cache");
+}
+
+#[test]
+fn twenty_four_hour_freshness_and_future_timestamp_are_eligible() {
+    let _lock = env_lock();
+    std::env::remove_var("TSK_NO_UPDATE_CHECK");
+    let dir = temp_dir("fresh");
+    let now = 1_700_000_000u64;
+    seed_cache(&dir, now - 60, "v9.0.0");
+    let fresh = plan(&dir, "0.6.0", now);
+    assert_eq!(
+        fresh,
+        CheckPlan {
+            notice: Some("v9.0.0 available".into()),
+            should_fetch: false,
+        }
+    );
+    seed_cache(&dir, now - STALE_AFTER_SECS, "v9.0.0");
+    let stale = plan(&dir, "0.6.0", now);
+    assert!(stale.should_fetch);
+    assert_eq!(stale.notice.as_deref(), Some("v9.0.0 available"));
+    seed_cache(&dir, now + 3_600, "v9.0.0");
+    let future = plan(&dir, "0.6.0", now);
+    assert!(!future.should_fetch, "future last_check stays eligible");
+    assert!(!is_stale(now + 3_600, now));
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn opt_out_env_disables_notice_and_fetch() {
+    let _lock = env_lock();
+    let dir = temp_dir("opt-out");
+    seed_cache(&dir, 1, "v9.0.0");
+    std::env::set_var("TSK_NO_UPDATE_CHECK", "1");
+    let planned = plan(&dir, "0.6.0", 1_700_000_000);
+    std::env::remove_var("TSK_NO_UPDATE_CHECK");
+    assert_eq!(
+        planned,
+        CheckPlan {
+            notice: None,
+            should_fetch: false,
+        }
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn curl_failure_leaves_cache_and_footer_untouched() {
+    let _lock = env_lock();
+    std::env::remove_var("TSK_NO_UPDATE_CHECK");
+    let dir = temp_dir("fail");
+    let original = UpdateCache {
+        last_check_unix: 42,
+        latest: "v0.1.0".into(),
+    };
+    write_cache(&dir, &original).expect("seed");
+    let before = fs::read_to_string(dir.join("update.json")).expect("read");
+    apply_fetch(&dir, 99, || None);
+    let after = fs::read_to_string(dir.join("update.json")).expect("reread");
+    assert_eq!(after, before);
+    assert_eq!(read_cache(&dir), Some(original));
+    assert_eq!(notice_for("v0.1.0", "0.6.0"), None);
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn footer_paints_dim_notice_from_a_seeded_cache_and_hides_for_a_message() {
+    let mut model = BoardModel::from_domain(&DomainState::new(), None);
+    let notice = notice_for("v9.9.9", "0.6.0").expect("newer");
+    model.set_update_notice(Some(notice.clone()));
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer();
+    let mut found = None;
+    for y in 0..24 {
+        let row: String = (0..80)
+            .map(|x| buffer[(x, y)].symbol().to_string())
+            .collect();
+        if let Some(x) = row.find(&notice) {
+            found = Some((x as u16, y));
+            break;
+        }
+    }
+    let (x, y) = found.expect("status row should paint the update notice");
+    assert!(
+        buffer[(x, y)].style().add_modifier.contains(Modifier::DIM),
+        "notice must be dim"
+    );
+    assert!(
+        !buffer[(x, y)].style().add_modifier.contains(Modifier::BOLD),
+        "notice must not use the message style"
+    );
+
+    model.set_message("copied");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("draw message");
+    let buffer = terminal.backend().buffer();
+    let mut still = false;
+    for y in 0..24 {
+        let row: String = (0..80)
+            .map(|x| buffer[(x, y)].symbol().to_string())
+            .collect();
+        if row.contains(&notice) {
+            still = true;
+        }
+    }
+    assert!(!still, "any other status message hides the update notice");
+
+    let mut domain = DomainState::new();
+    model.set_update_notice(Some(notice.clone()));
+    model.clear_message();
+    apply_intent(&mut domain, &mut model, BoardIntent::OpenCapture, None).expect("open quick-add");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("draw quick-add");
+    let buffer = terminal.backend().buffer();
+    let mut on_input = false;
+    for y in 0..24 {
+        let row: String = (0..80)
+            .map(|x| buffer[(x, y)].symbol().to_string())
+            .collect();
+        if row.contains(&notice) {
+            on_input = true;
+        }
+    }
+    assert!(!on_input, "a bottom input hides the update notice");
+}
+
+#[test]
+fn load_board_uses_seeded_update_json_in_state_dir() {
+    let _lock = env_lock();
+    std::env::remove_var("TSK_NO_UPDATE_CHECK");
+    let dir = temp_dir("load");
+    seed_cache(&dir, unix_now(), "v9.9.9");
+    let previous = std::env::var_os("TSK_STATE_DIR");
+    std::env::set_var("TSK_STATE_DIR", &dir);
+    let model = load_board_model().expect("load board");
+    match previous {
+        Some(value) => std::env::set_var("TSK_STATE_DIR", value),
+        None => std::env::remove_var("TSK_STATE_DIR"),
+    }
+    assert_eq!(model.update_notice(), Some("v9.9.9 available"));
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn semver_notice_matches_public_compare() {
+    assert_eq!(
+        notice_for("v0.6.1", env!("CARGO_PKG_VERSION")).is_some(),
+        tsk_tui::update::is_newer("v0.6.1", env!("CARGO_PKG_VERSION"))
+    );
+}

--- a/tests/update_notice.rs
+++ b/tests/update_notice.rs
@@ -11,10 +11,11 @@ use ratatui::style::Modifier;
 use ratatui::Terminal;
 use tsk_tui::app::load_board_model;
 use tsk_tui::domain::DomainState;
+use tsk_tui::ui::queue::NavTab;
 use tsk_tui::ui::{apply_intent, draw_board, BoardIntent, BoardModel};
 use tsk_tui::update::{
-    apply_fetch, is_stale, notice_for, plan, read_cache, unix_now, write_cache, CheckPlan,
-    UpdateCache, STALE_AFTER_SECS,
+    apply_fetch, is_stale, mark_check_started, notice_for, plan, read_cache,
+    suppress_background_fetch, unix_now, write_cache, CheckPlan, UpdateCache, STALE_AFTER_SECS,
 };
 
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -90,6 +91,26 @@ fn opt_out_env_disables_notice_and_fetch() {
             should_fetch: false,
         }
     );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn starting_a_check_stamps_last_check_and_keeps_the_cached_tag() {
+    let _lock = env_lock();
+    std::env::remove_var("TSK_NO_UPDATE_CHECK");
+    let dir = temp_dir("stamp");
+    seed_cache(&dir, 1, "v9.0.0");
+    mark_check_started(&dir, 99);
+    assert_eq!(
+        read_cache(&dir),
+        Some(UpdateCache {
+            last_check_unix: 99,
+            latest: "v9.0.0".into(),
+        })
+    );
+    let planned = plan(&dir, "0.6.0", 99);
+    assert!(!planned.should_fetch);
+    assert_eq!(planned.notice.as_deref(), Some("v9.0.0 available"));
     let _ = fs::remove_dir_all(dir);
 }
 
@@ -184,11 +205,42 @@ fn footer_paints_dim_notice_from_a_seeded_cache_and_hides_for_a_message() {
         }
     }
     assert!(!on_input, "a bottom input hides the update notice");
+
+    apply_intent(&mut domain, &mut model, BoardIntent::CancelQuickAdd, None)
+        .expect("close quick-add");
+    model.set_update_notice(Some(notice.clone()));
+    apply_intent(
+        &mut domain,
+        &mut model,
+        BoardIntent::SelectNavTab(NavTab::Projects),
+        None,
+    )
+    .expect("open projects");
+    terminal
+        .draw(|frame| {
+            let _ = draw_board(frame, &model);
+        })
+        .expect("draw projects");
+    let buffer = terminal.backend().buffer();
+    let mut on_projects = false;
+    for y in 0..24 {
+        let row: String = (0..80)
+            .map(|x| buffer[(x, y)].symbol().to_string())
+            .collect();
+        if row.contains(&notice) {
+            on_projects = true;
+        }
+    }
+    assert!(
+        on_projects,
+        "Projects Overview idle status shows the update notice"
+    );
 }
 
 #[test]
 fn load_board_uses_seeded_update_json_in_state_dir() {
     let _lock = env_lock();
+    suppress_background_fetch();
     std::env::remove_var("TSK_NO_UPDATE_CHECK");
     let dir = temp_dir("load");
     seed_cache(&dir, unix_now(), "v9.9.9");


### PR DESCRIPTION
## Summary

On board launch, if `TSK_NO_UPDATE_CHECK` is unset and `<state dir>/update.json` is older than 24h, spawn a thread that `curl`s the GitHub latest-release tag and writes `{last_check_unix, latest}` atomically. Failures are silent. A tag newer than `CARGO_PKG_VERSION` paints a dim `v<tag> available` on the idle status row, behind any other message or bottom input.

No channel detection, upgrade command, dismiss, or telemetry.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release`
- [x] `cd site && npm test && npm run build`
- [ ] Live herdr smoke — **not run** (`HERDR_ENV` unset). Load-path smoke: `load_board_uses_seeded_update_json_in_state_dir` with isolated `TSK_STATE_DIR`.

## Proof

- `update::tests::semver_compare_orders_core_versions_and_v_prefix`
- `update::tests::cache_is_stale_after_24h_and_future_timestamp_is_fresh`
- `opt_out_env_disables_notice_and_fetch`
- `curl_failure_leaves_cache_and_footer_untouched`
- `footer_paints_dim_notice_from_a_seeded_cache_and_hides_for_a_message`
- `load_board_uses_seeded_update_json_in_state_dir`