### PR TITLE
ci: restore public pull request validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     paths-ignore:
       - "site/**"
       - ".github/workflows/site.yml"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "site/**"
+      - ".github/workflows/site.yml"
 
 # Validation never needs more than reading the repo. Fork PRs run under this
 # token too (read-only, no secrets), and checkout leaves no credentials behind

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -7,6 +7,12 @@ on:
       - "site/**"
       - "skills/**"
       - ".github/workflows/site.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "skills/**"
+      - ".github/workflows/site.yml"
 
 permissions:
   contents: read
@@ -17,6 +23,7 @@ concurrency:
 
 jobs:
   build:
+    name: site build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -10,7 +10,6 @@ on:
       - "site/**"
       - "skills/**"
       - ".github/workflows/vercel.yml"
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -23,8 +22,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Manual runs are allowed only from main, matching the automatic trigger.
-    if: github.ref == 'refs/heads/main'
+    # Keep repository secrets out of every pull-request event.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,10 +190,17 @@ For scriptable board work, use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, 
   fail, restore the fix. Use content that actually crosses the boundary under test.
 - Temp state dirs need a per-binary atomic counter, not just `SystemTime::now()`.
 - Green bar: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release`
+  Warm, it takes about three minutes (`cargo test` alone runs 1000+ tests in under 30 s). If
+  it takes 20 minutes, a second cargo process is holding the `target/` lock: cargo waits
+  silently on it for every one of the 40+ test binaries. Never run two cargo commands in this
+  checkout at once, including a background release build or another agent's run. Run the bar
+  once at the end, as a single chain, not after every edit.
 - CI installs Rust **1.96.0** with `rustfmt` + `clippy` on ubuntu and macos. The
-  frame-time bench is Linux-only. While the repository is private, workflows run
-  automatically only on pushes to `main` to conserve Actions usage; PR checks are
-  not required. Site-only pushes skip the Rust matrix (`paths-ignore: site/**`).
+  frame-time bench is Linux-only. In this public repository, Rust CI and Site validation
+  run on pushes to `main` and pull requests targeting `main`, with the same path filters
+  for both events. Site-only changes skip the Rust matrix (`paths-ignore: site/**`).
+  Validation uses read-only permissions and no repository secrets, including on fork PRs.
+  Vercel production deployment runs only on pushes to `main`.
   Site CI is `npm ci && npm test && npm run build` in `site/`.
 - `site/vercel.json` is validated by Vercel's own route parser in `npm test`
   (`@vercel/routing-utils`, the same check `vercel deploy` runs before upload). Its

--- a/tests/packaging/test_workflow.py
+++ b/tests/packaging/test_workflow.py
@@ -16,6 +16,30 @@ WORKFLOW = ROOT / ".github/workflows/release.yml"
 
 
 class WorkflowTests(unittest.TestCase):
+    def test_public_pr_validation_is_read_only_and_secret_free(self):
+        for name in ["ci", "site"]:
+            with self.subTest(workflow=name):
+                source = (ROOT / f".github/workflows/{name}.yml").read_text()
+                triggers = source.split("on:\n", 1)[1].split("\npermissions:", 1)[0]
+                events = dict(re.findall(r"^  (\w+):\n((?:    .*\n|\n)*)", triggers, re.M))
+                self.assertEqual(set(events), {"push", "pull_request"})
+                self.assertEqual(events["push"].strip(), events["pull_request"].strip())
+                self.assertIn("branches: [main]", events["pull_request"])
+                self.assertIn("paths-ignore:" if name == "ci" else "paths:", events["pull_request"])
+                self.assertIn("permissions:\n  contents: read", source)
+                self.assertEqual(source.count("permissions:"), 1)
+                self.assertNotRegex(source, r"secrets\s*[.\[]")
+                self.assertIn("persist-credentials: false", source)
+
+    def test_vercel_secret_is_only_available_to_main_push_deployment(self):
+        source = (ROOT / ".github/workflows/vercel.yml").read_text()
+        triggers = source.split("on:\n", 1)[1].split("\npermissions:", 1)[0]
+        self.assertEqual(re.findall(r"^  ([a-z_]+):", triggers, re.M), ["push"])
+        self.assertIn("branches: [main]", triggers)
+        self.assertIn("if: github.event_name == 'push' && github.ref == 'refs/heads/main'", source)
+        self.assertIn("permissions:\n  contents: read", source)
+        self.assertEqual(source.count("permissions:"), 1)
+
     def test_packaging_checks_cover_rust_and_installer_changes_not_site_builds(self):
         site = (ROOT / ".github/workflows/site.yml").read_text()
         ci = (ROOT / ".github/workflows/ci.yml").read_text()


### PR DESCRIPTION
Public pull requests targeting main now run Rust CI and Site validation, using the same path filters as pushes. The check names are `Verify (ubuntu-latest)`, `Verify (macos-latest)`, and `site build`.

Validation retains `contents: read`, credential-free checkout, and no repository-secret references. Vercel production deployment accepts only pushes to main, with an explicit event/ref guard; the former manual trigger is removed. The owner-dispatched release workflow is unchanged, including its draft-creation job's necessary write permission.

AGENTS.md now describes public PR validation and includes the complete pre-existing cargo timing/concurrency addition (the only uncommitted block present when work started).

Validation:
- Workflow regression checks failed before the changes and pass afterward.
- All workflow YAML files parse successfully; `git diff --check` passes.
- Site install, 42 tests, and production build pass. npm still reports two high-severity dependency findings; dependency remediation is outside T19.

Confirmed repository settings: public visibility; Actions defaults read-only with PR-review approval disabled; secret scanning, push protection, and private vulnerability reporting enabled.

Owner follow-up after merge: configure strict required checks and exercise a tokenless fork PR. Path filters are intentionally preserved: requiring a whole workflow that is skipped by a path filter can leave the required check pending. First-public-PR usage review also remains pending.

Final local validation: Rust format, Clippy with warnings denied, full tests, and release build passed; all 37 packaging tests passed with the release binary. Live Herdr smoke was not run (`HERDR_ENV` is unset; no UI behavior changed).
