### PR TITLE
reopen: acknowledge waits briefly for the lock

### DIFF
--- a/src/reopen.rs
+++ b/src/reopen.rs
@@ -17,6 +17,8 @@ use crate::fsperm;
 use crate::store::{StoreSignature, TaskStore};
 
 const REQUEST_FILE: &str = "reopen.json";
+/// How long `acknowledge` waits for a momentarily held lock before leaving the file.
+const ACK_LOCK_BUDGET: Duration = Duration::from_millis(100);
 const LOCK_FILE: &str = "reopen.json.lock";
 const MAX_REQUEST_BYTES: usize = 8 * 1024;
 const MAX_PROJECT_BYTES: usize = 4096;
@@ -159,21 +161,25 @@ impl RequestLock {
     /// Acquire the persistent lock inode with a bounded wait. Ownership is the OS
     /// advisory lock, not the inode, so a crash releases it without unlinking anything.
     fn acquire(state_dir: &Path) -> io::Result<Self> {
-        Self::acquire_bounded(state_dir, 100)
+        Self::acquire_bounded(state_dir, Duration::from_millis(500))
     }
 
-    /// Wait at most `tries` × 5 ms for the lock. Acknowledgement uses a short bound: a
-    /// forked child (test harnesses, host launchers) briefly holds a copy of another
-    /// thread's lock fd until its exec closes it, and one immediate `try_lock` then
-    /// leaves a handled request file behind.
-    fn acquire_bounded(state_dir: &Path, tries: u32) -> io::Result<Self> {
+    /// Wait at most `budget` (wall clock, so a slow machine cannot stretch it) for the
+    /// lock. Acknowledgement uses a short budget: a forked child (test harnesses, host
+    /// launchers) briefly holds a copy of another thread's lock fd until its exec closes
+    /// it, and one immediate `try_lock` then leaves a handled request file behind.
+    fn acquire_bounded(state_dir: &Path, budget: Duration) -> io::Result<Self> {
         let path = state_dir.join(LOCK_FILE);
         let file = crate::fsperm::open_lock_file(&path)?;
         crate::fsperm::tighten_file(&path);
-        for _ in 0..tries {
+        let deadline = std::time::Instant::now() + budget;
+        loop {
             match file.try_lock() {
                 Ok(()) => return Ok(Self { _file: file }),
                 Err(std::fs::TryLockError::WouldBlock) => {
+                    if std::time::Instant::now() >= deadline {
+                        break;
+                    }
                     std::thread::sleep(Duration::from_millis(5));
                 }
                 Err(std::fs::TryLockError::Error(error)) => return Err(error),
@@ -298,7 +304,7 @@ impl ReopenWatch {
 
         // Bounded (about 100 ms), not nonblocking: this runs once per applied request, not
         // on the idle tick, and giving up on a momentarily held lock leaves the file behind.
-        let Ok(_lock) = RequestLock::acquire_bounded(&self.state_dir, 20) else {
+        let Ok(_lock) = RequestLock::acquire_bounded(&self.state_dir, ACK_LOCK_BUDGET) else {
             return;
         };
         let path = self.request_path();
@@ -585,8 +591,8 @@ mod tests {
         let started = std::time::Instant::now();
         watch.acknowledge();
         assert!(
-            started.elapsed() < Duration::from_millis(200),
-            "acknowledgement waits at most its own short bound, never the writer's 500ms"
+            started.elapsed() < ACK_LOCK_BUDGET + Duration::from_millis(300),
+            "acknowledgement waits at most its own budget plus scheduling slack, never the writer's 500ms"
         );
         drop(lock);
         assert_eq!(watch.poll(), None, "handled request must not replay");

--- a/src/reopen.rs
+++ b/src/reopen.rs
@@ -159,10 +159,18 @@ impl RequestLock {
     /// Acquire the persistent lock inode with a bounded wait. Ownership is the OS
     /// advisory lock, not the inode, so a crash releases it without unlinking anything.
     fn acquire(state_dir: &Path) -> io::Result<Self> {
+        Self::acquire_bounded(state_dir, 100)
+    }
+
+    /// Wait at most `tries` × 5 ms for the lock. Acknowledgement uses a short bound: a
+    /// forked child (test harnesses, host launchers) briefly holds a copy of another
+    /// thread's lock fd until its exec closes it, and one immediate `try_lock` then
+    /// leaves a handled request file behind.
+    fn acquire_bounded(state_dir: &Path, tries: u32) -> io::Result<Self> {
         let path = state_dir.join(LOCK_FILE);
         let file = crate::fsperm::open_lock_file(&path)?;
         crate::fsperm::tighten_file(&path);
-        for _ in 0..100 {
+        for _ in 0..tries {
             match file.try_lock() {
                 Ok(()) => return Ok(Self { _file: file }),
                 Err(std::fs::TryLockError::WouldBlock) => {
@@ -288,7 +296,9 @@ impl ReopenWatch {
         self.last_seen = Some(signature);
         self.deferred_notice_sent = false;
 
-        let Ok(_lock) = RequestLock::try_acquire(&self.state_dir) else {
+        // Bounded (about 100 ms), not nonblocking: this runs once per applied request, not
+        // on the idle tick, and giving up on a momentarily held lock leaves the file behind.
+        let Ok(_lock) = RequestLock::acquire_bounded(&self.state_dir, 20) else {
             return;
         };
         let path = self.request_path();
@@ -525,6 +535,39 @@ mod tests {
     }
 
     #[test]
+    fn acknowledge_outlasts_a_briefly_held_lock_and_still_removes_the_file() {
+        // CI saw try_acquire report the lock busy with no live holder (a forked test child
+        // inherits another thread's lock fd until its exec closes it). Acknowledge is not on
+        // the idle tick, so it may wait a little rather than leave the file behind.
+        let dir = std::env::temp_dir().join(format!(
+            "tsk-reopen-ack-brief-lock-{}-{}",
+            std::process::id(),
+            REQUEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("state dir");
+        let store = TaskStore::new(&dir);
+        let mut watch = ReopenWatch::seeded(&store);
+        ReopenRequest::new(Some(PathBuf::from("/repo/a")))
+            .write(&dir)
+            .expect("request a");
+        assert!(watch.poll().is_some(), "request applied");
+        let holder_dir = dir.clone();
+        let holder = std::thread::spawn(move || {
+            let lock = RequestLock::acquire(&holder_dir).expect("brief holder");
+            std::thread::sleep(Duration::from_millis(30));
+            drop(lock);
+        });
+        std::thread::sleep(Duration::from_millis(5));
+        watch.acknowledge();
+        holder.join().expect("holder thread");
+        assert!(
+            !dir.join(REQUEST_FILE).exists(),
+            "acknowledge must remove the handled request once the brief holder is gone"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn acknowledge_is_nonblocking_and_consumes_a_request_when_cleanup_is_busy() {
         let dir = std::env::temp_dir().join(format!(
             "tsk-reopen-ack-nonblocking-{}-{}",
@@ -543,7 +586,7 @@ mod tests {
         watch.acknowledge();
         assert!(
             started.elapsed() < Duration::from_millis(200),
-            "acknowledgement must not wait for the writer's 500ms bounded acquisition"
+            "acknowledgement waits at most its own short bound, never the writer's 500ms"
         );
         drop(lock);
         assert_eq!(watch.poll(), None, "handled request must not replay");


### PR DESCRIPTION
Release run 34403484601 failed on aarch64 musl in `reopen_watch_reads_one_atomic_request_and_acknowledges_it_once`: `acknowledge` saw the lock busy and skipped removing the handled request.

Third `reopen` test to trip on a spuriously busy lock in CI (macOS, Ubuntu, now musl), each a different assertion, all explained by `try_acquire` returning `WouldBlock` with no live holder. The test binary forks `tsk` children, which inherit other threads' lock fds until exec closes them.

`acknowledge` runs once per applied request, not on the idle tick, so it now waits up to ~100 ms (`acquire_bounded`) instead of giving up immediately. Regression test holds the lock from another thread for 30 ms and asserts the file is still removed; fails without the fix.

After merge the `v0.7.0` tag moves to the new commit (nothing published yet) and `Prepare release` is re-dispatched.