### PR TITLE
docs: clarify README onboarding and everyday use

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,9 @@ TSK_STATE_DIR=/tmp/tsk-dev-state TSK_CONFIG_DIR=/tmp/tsk-dev-config cargo run
 
 Do not point development builds at a board containing data you care about.
 
+For local website setup, builds, and deployment configuration, see the
+[site README](site/README.md).
+
 ## Making a change
 
 Keep changes focused and add regression coverage for behavior changes. A regression test must fail without its fix and pass with it. User-visible behavior changes must update the relevant page under `site/src/content/docs/docs/`, plus the README, landing page, demo, or `site/public/llms.txt` when they describe the changed behavior.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ or run the printed `export` command before continuing.
 
 ### Add to Herdr
 
+[Install Herdr](https://herdr.dev/docs/install/) if you haven't already, then:
+
 ```sh
 tsk setup herdr
 herdr server reload-config

--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # tsk
 
-tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.
+A terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.
 
-You and your agents put work on one board and move it through:
-ready, started, blocked, review, done. Agents reach the board through the CLI.
-It ships as a [herdr](https://herdr.dev) plugin, and the `tsk` binary also runs
-standalone against `~/.tsk`.
+Keep the next task, the work in progress, and the things waiting on you in view.
+Press `+` to capture a thought, add notes and steps when it needs a plan, and give
+your agent the task number when you're ready to work on it.
 
-![The tsk board in a Herdr pane beside a working agent: NEEDS YOU, IN MOTION and ON DECK sections, with a task peeked open](docs/images/board-in-herdr.png)
+### the flow
 
-![At 110 columns or wider the board and the task page sit side by side: notes, steps 2 of 4 ticked, thread and status](docs/images/wide-task-page.png)
+![The tsk board beside an agent working on the selected Redis-to-Postgres migration task](docs/images/board-in-herdr.png)
 
-- Queue board with desk, a selected project, a projects index, and cross-project thread views
-- Quick-add on the board, plus a herdr quick-capture popup
-- Task page for notes, thread, scope, and steps
-- Headless `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`
+In Herdr, **prefix+t** opens your board and **prefix+a** opens quick capture.
+Click a task's `T` number to copy it, then paste it into your agent conversation.
 
-Park, resume, attention, linking, and dispatch are not part of this tree.
+### Room to think
+
+![A wide tsk board with the selected task's notes and steps open alongside it](docs/images/wide-task-page.png)
+
+In a wide pane, `→` opens task details beside the board; `←` brings you back.
+Press `Enter` for a full-screen task and `Esc` to return. For a standalone board,
+run `tsk` in your terminal.
 
 ## Quickstart
 
@@ -37,12 +40,23 @@ or run the printed `export` command before continuing.
 
 ### Add to Herdr
 
-With Herdr 0.9+ installed:
-
 ```sh
 tsk setup herdr
 herdr server reload-config
 ```
+
+### Give your agent the skill
+
+Install the tsk skill so your agent knows how to read the board, add tasks, and
+update their status and steps:
+
+```sh
+tsk setup pi
+```
+
+Replace `pi` with `claude`, `cursor`, `grok`, or `codex` for your agent. This
+installs the skill in its user-level skills directory.
+[Other skill directories and setup options](https://gettsk.sh/docs/cli/#setup).
 
 ### Open the board
 
@@ -54,58 +68,42 @@ Run `tsk`, or press **prefix+t** in Herdr.
 tsk add -t "your task title"
 ```
 
-Or press **prefix+a** in Herdr.
+Or press **prefix+a** in Herdr, or ask your agent to add a task to the board.
+
+For example: “Add a task to the board to fix the login timeout, with steps to reproduce
+the bug.”
 
 [Installation details and upgrades](https://gettsk.sh/docs/install/).
 
 ## Usage
 
-How to use the board and CLI lives on the site, not in this file:
+Mouse or keyboard, your choice. Click tabs to switch views, double-click a task
+to open it, and scroll through your board. The actions along the bottom are
+clickable too, including adding a task and changing its status.
 
-- [Overview](https://gettsk.sh/docs/)
-- [Board](https://gettsk.sh/docs/board/)
-- [Keys](https://gettsk.sh/docs/keys/)
-- [Capture](https://gettsk.sh/docs/capture/)
-- [Task page](https://gettsk.sh/docs/task-page/)
-- [Steps](https://gettsk.sh/docs/steps/)
-- [CLI](https://gettsk.sh/docs/cli/)
+Prefer the keyboard? A few keys for everyday use:
 
-The store is `~/.tsk/tsk.json`; walkthrough dismissal is kept beside it in
-`walkthrough.json`. Deleted tasks live in `trash.jsonl` beside the store; the
-previous document is kept as `tsk.json.1`, and a format migration backs up the
-pre-migration document as `tsk.json.v<N>`. Override with `TSK_STATE_DIR` /
-`TSK_CONFIG_DIR`. herdr's injected plugin dirs are ignored, so
-the pane and the CLI edit the same board. Archived tasks and projects stay on
-the board but out of every working view (`ctrl+f`, `tsk archive`,
-`tsk project archive`, `tsk list --archived`).
+| Key | Action |
+| --- | --- |
+| `↑` / `↓` or `j` / `k` | Move between tasks |
+| `→` / `←` | Peek at a task and close the peek in narrow panes; move between board and task views in wide panes |
+| `+` | Add a task |
+| `Enter` | Open the selected task |
+| `ctrl+s` | Start a ready task or reopen a done task |
+| `ctrl+r` | Move an open task to review, or back to ready |
+| `ctrl+d` | Mark the selected task done |
+| `p` | Switch projects |
+| `d` | Show or hide completed tasks |
+| `?` | Show all shortcuts |
 
-Keep `~/.tsk` on a local disk. The writer lock is `flock`-style and every save
-is a rename-based atomic replace; NFS, Dropbox, iCloud Drive, and similar
-synced folders can break both. Point `TSK_STATE_DIR` at a local disk instead.
-State and config directory roots must be real directories, not symlinks.
-Windows is not tested in CI.
-
-Mutating keys need Ctrl. Bare letters do nothing. Legacy modifier settings are ignored.
+[Full keymap](https://gettsk.sh/docs/keys/) ·
+[Board guide](https://gettsk.sh/docs/board/) ·
+[CLI reference](https://gettsk.sh/docs/cli/)
 
 ## Docs
 
-The user guide lives at https://gettsk.sh/docs/ and is built from `site/`.
-
-```bash
-cd site
-npm install
-npm run dev
-```
-
-`npm run build` writes `site/dist/`. Vercel Root Directory is `site`.
-
-## Verify
-
-```bash
-cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test && cargo build --release
-```
-
-Site-only: `cd site && npm ci && npm test && npm run build`.
+See the [user guide](https://gettsk.sh/docs/) for installation, task management,
+agent setup, and the full CLI reference.
 
 ## Contributing and security
 


### PR DESCRIPTION
The README mixed onboarding with storage internals and website development instructions. It now leads with the shared board workflow, adds useful screenshot captions and agent skill setup, and gives readers mouse guidance and a concise keyboard reference.

Detailed documentation stays linked from the README; the contributor guide now points to the existing website setup instructions.

Validation: checked documented controls and setup targets against source, verified local links and image references, and ran `git diff --check`.
