### PR TITLE
docs: simplify onboarding and user guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ installs the skill in its user-level skills directory.
 
 Run `tsk`, or press **prefix+t** in Herdr.
 
+**No project setup needed.** Open tsk in your project directory and add your first
+task—the project appears on your board automatically.
+
 ### Add a task
 
 ```sh

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -91,14 +91,25 @@ export default defineConfig({
           label: 'Start here',
           items: [
             { label: 'Overview', slug: 'docs' },
-            { label: 'tsk for agents', slug: 'docs/agents' },
             { label: 'Install', slug: 'docs/install' },
+          ],
+        },
+        {
+          label: 'Use tsk',
+          items: [
             { label: 'Board', slug: 'docs/board' },
             { label: 'Keys', slug: 'docs/keys' },
             { label: 'Capture', slug: 'docs/capture' },
             { label: 'Task page', slug: 'docs/task-page' },
             { label: 'Steps', slug: 'docs/steps' },
+          ],
+        },
+        {
+          label: 'Reference',
+          items: [
+            { label: 'tsk for agents', slug: 'docs/agents' },
             { label: 'CLI', slug: 'docs/cli' },
+            { label: 'Storage', slug: 'docs/storage' },
           ],
         },
       ],

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -11,6 +11,8 @@ The board checks GitHub releases at most daily and shows a dim `vX.Y.Z available
 - `tsk guide` prints the workflow; `tsk setup <agent>` installs the skill
 - Guide: https://gettsk.sh/docs/agents.md
 - CLI: https://gettsk.sh/docs/cli.md
+
+Storage, backups, and release-check settings: https://gettsk.sh/docs/storage.md
 - Full docs: https://gettsk.sh/llms-full.txt
 
 ## Docs

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -1,252 +1,166 @@
 ---
 title: Board
-description: Tabs, sections, status, peek, and the done drawer.
+description: Find tasks, switch projects, and keep work moving.
 ---
 
-The board keeps three navigation destinations visible: **desk** · **selected project** ·
-**projects**. Use `1` / `2` / `3` from normal board mode. `p` opens the project picker
-from the keyboard.
+Click to navigate, or use the keyboard. The footer shows actions for the current selection; those actions are clickable.
 
-## Tabs
+## Navigate
 
-The active tab is bright and underlined; inactive tabs are dim.
+| View | Key | Contents |
+| --- | --- | --- |
+| **desk** | `1` | Blocked/review and started tasks across all live projects; ready tasks from your desk |
+| **selected project** | `2` | Tasks in the selected project |
+| **projects** | `3` | Project overview |
 
-- **desk**: your overview. NEEDS YOU is blocked or review work across all live
-  projects and your desk. IN MOTION is every started task, from any project. ON DECK is desk work
-  that is ready: general to-dos, future projects, anything that belongs to no
-  repository, with project attribution on other work.
-- **selected project**: the project board for slot 2. Its local thread filter (shown as
-  `all` or `#name`) can narrow every status section.
-- **projects**: one selectable overview row per live project, with NEEDS YOU,
-  IN MOTION, and READY counts anchored to the right edge so the name column takes the
-  remaining width; one blank row separates the legend from the first project. A zero
-  paints as a dim `·`; a live NEEDS YOU count paints bold. Rows show the project's
-  basename only, with a dim `here` after the project you launched from. The status row
-  names the selected row's full path, which is how same-named projects are told apart;
-  while the `/` search is open that path moves to the row above the query.
-  At 100 columns or wider a dim THREADS column lists that project's open threads, most
-  recently touched first, ending in `+n` when they do not all fit. Enter opens the
-  selected project in slot 2; a click selects a row and a fast second click on it opens it.
-  Press `/` or click the footer's `/ search projects` affordance, type a project name
-  (paste works too), then press Enter to open the match. Esc clears the query and
-  returns to navigation. The `Overview` selector (`v`) can replace the index with a
-  flat cross-project thread board, with project attribution (including `desk`).
+Launching inside a Git repository opens that project. Outside a repository, tsk uses the current directory as the project. Reopening from another directory updates the existing board's project context.
 
-At startup, a pane inside a repository opens that project, including when it is
-empty. Outside a repository it opens Desk. Reopening tsk from another project
-updates the existing board to that invocation project, or Desk outside a repository.
+The middle tab remembers your selected project. If none is selected, `2` opens the project picker.
 
-The three navigation slots stay visible everywhere as **desk** · **selected project** ·
-**projects**. Their keyboard shortcuts remain `1`, `2`, and `3`. The selected-project
-slot keeps its identity while Desk or Projects is active; if it is empty, `2` opens the
-project picker. The active destination's chip shows only its selected value, such as
-`all ▾`, `#release ▾`, or `Overview ▾`, and opens its picker. A selector that wraps below
-the tabs has one blank line above it. Both project and cross-project thread views go
-straight to the status sections, without a separate task-count summary.
-Collapse state is session-only.
+## Projects
 
-Thread selectors (`t` within a project, `v` on Projects) accept typing and paste.
-All letters, including `j` and `k`, are search text; use arrows or Tab to move between
-options. An unmatched query stays visible with `no matching options` so you can edit
-it or press Esc to close.
+Press `p` to choose a project, or open **projects** for an overview.
 
-The projects search opens in the shared footer slot: closed it reads `/ search projects`,
-while focused it shows the query and caret there. Letters, digits, Backspace, and
-bracketed paste edit the query, while Enter opens the selected match and Esc clears and
-closes it. No search row appears above the project table.
+- Click a project to select it; double-click or press `Enter` to open it.
+- Press `/` to search. Type or paste, then press `Enter` to open the result.
+- Press `Esc` to clear and close search.
+- Check the footer for the selected project's full path.
 
-Selected task rows use `▸` without a filled highlight. The status glyph follows
-(`●` for Started), then a dim store-global identifier such as `T30`. Click the identifier to copy it (`copy sent: T30`). Collapsed task rows
-show no project or thread label. Opening peek shows the project on global rows,
-or `#thread` on project rows, on a dim `└─ label` line below the peek notes.
-That line is read-only peek content, and long labels wrap without truncation.
-Titles use the full width and wrap two cells before the right edge.
-Task-page informational dates remain in the footer. A scoped
-group with nothing open offers `p` to rescope or `+` to add a task.
+Counts show work needing attention, in progress, and ready. A dim `·` means zero. `here` marks the launch project. At 100 columns or wider, the overview also lists threads.
 
-## Sections
+## Threads
 
-One urgency-ordered list. Sections are computed, not navigated. Desk NEEDS YOU contains
-blocked and review tasks from all live projects and the desk; project boards contain
-only that project's tasks.
+A thread groups related tasks within a project, such as `release` or `login-fix`.
 
-- **NEEDS YOU**: blocked and review, on desk (desk/global tasks) and on a project
-  board (that project). Omitted when empty. Sits above IN MOTION.
-- **IN MOTION**: work you have started
-- **ON DECK** when you are on a project board: that project's ready tasks, with
-  thread labels in their peek
-- **z** opens the done drawer
+| Where | Action |
+| --- | --- |
+| Project board | Press `t` or click the filter to choose a thread |
+| Projects overview | Press `v` or click **Overview** to view a thread across projects |
 
-An archived task keeps its human status and leaves every working lens (desk,
-projects, project focus, and default `tsk list` views). The done
-drawer lists archived tasks in its scope under an `▾ archived · n` group below
-DONE: closed on every launch, one click or `Enter` on the header toggles it on its
-own, and expanded rows paint dim with their status glyph and `T<n>`. The header
-paints the word bold when it holds the selection, never a reverse block. It is the
-done drawer's only collapsible group: while the drawer is open, `g` folds and
-unfolds it; with the drawer closed `g` leaves it alone. `d` opens and closes the
-drawer itself. `ctrl+f` on a row
-files it, and `ctrl+f` or `ctrl+u` on an archived
-selection brings it back; neither writes an undo entry.
+Type to filter the choices. Use arrows or `Tab` to select, `Enter` to choose, and `Esc` to close. `j` and `k` are search text in these selectors.
 
-Thread headers on a scoped deck show `#name` and an open count. They take a list
-row of space. They are not selectable and clicks do not land on them.
+Assign threads when [capturing](/docs/capture/#title-tokens) or [editing a task](/docs/task-page/#scope-and-thread).
 
-Unthreaded tasks list after thread groups in the same deck.
+## Status
 
-## Human status
+| Section | Status |
+| --- | --- |
+| **NEEDS YOU** | `blocked`, `review` |
+| **IN MOTION** | `started` |
+| **ON DECK** | `ready` |
+| Done drawer | `done` |
 
-`ready` · `started` · `blocked` · `review` · `done`
+On your desk, **ON DECK** contains only desk tasks. On a project board, it contains that project's ready tasks. Use the thread filter to narrow them.
 
-Human status is the source of truth. Completing every step does not complete the
-task. Agents do not auto-complete work.
+Select a task, then click a footer action or use:
 
-`ctrl+s` starts a ready task, or reopens a done one. On a started, blocked, or
-review task it does nothing, and the verb bar drops the entry. `ctrl+d` marks done.
-`ctrl+o` sets ready again from any status; the palette's `reopen` entry appears only
-for a done task. `ctrl+b` toggles blocked ↔ ready; `ctrl+r` toggles review ↔ ready. A
-done task answers `completed tasks cannot be blocked` (or `… go to review`). With
-nothing selected, every verb answers `select a task first`.
+| Key | Action |
+| --- | --- |
+| `ctrl+s` | Start a ready task; return a done task to ready |
+| `ctrl+d` | Mark done |
+| `ctrl+o` | Set ready |
+| `ctrl+b` | Set blocked; press again to return to ready |
+| `ctrl+r` | Set review; press again to return to ready |
 
-The verb row shows only the seats that matter for the selected row: `enter open`, the
-status verbs its status makes meaningful (`ctrl+s start` on ready, `ctrl+d done` and
-`ctrl+b block` or `unblock` while open, `ctrl+o reopen` when done), `+ add`, `? help`.
-Archive, delete, undo, the drawer and the palette are reached by their keys, `?`, or `:`.
+`ctrl+s` leaves started, blocked, and review tasks unchanged. Done tasks must be reopened before blocking or sending to review.
 
-## Delete and undo
+Agents can set any status with [the CLI](/docs/cli/#status). Task status does not change automatically when steps are checked or an agent stops.
 
-`ctrl+x` (or `ctrl+Delete`) asks once (`press ctrl+x again to delete`), then soft-deletes the selected task. It leaves every lens
-and the status row reads `Deleted "title" · ctrl+u undo` until your next action. While
-that notice is visible, the board prompt begins `ctrl+u undo`. Nothing on the board
-hard-deletes; `tsk list --deleted` still shows it.
+## Mouse
 
-`ctrl+u` undoes the most recent delete or done, then the one before it. If the task
-changed on disk since then, undo refuses with `changed since the undoable action`
-and the delete notice comes back so you can try again.
+| Action | Result |
+| --- | --- |
+| Click a tab or selector | Change view or open its choices |
+| Click a task | Peek in narrow panes; select in wide panes |
+| Click the same task again in a narrow pane | Close its peek |
+| Double-click a task | Open it full screen |
+| Click its `T` number | Copy the task number |
+| Click a footer action | Run that action |
+| Wheel or drag a scrollbar | Scroll |
+| Drag across text | Select and copy on release |
+
+Open peeks show notes and the task's project or thread. Below 110 columns, `→` opens a peek and `←` closes it. Peeks show up to five wrapped note lines; the [task page](/docs/task-page/) shows the rest.
 
 ## Wide stage slider
 
-At 110 usable columns or wider the board is a four-stage slider. Focus and geometry
-are the same thing:
+At **110 usable columns** or wider, use `→` and `←` to move through a four-stage slider:
 
-| Stage | Left | Right | Focus |
-| --- | --- | --- | --- |
-| 0 | board, full width | none | board |
-| A | board, 40% | task page | board |
-| G | dim rail, 32 columns | task page | task |
-| F | none | task page, full width | task |
-
-One dim `│` rule separates the columns. There is no box and no colour: the task
-header rule (`T12 title ──── started · tsk`) is dim in A and bold in G and F, and its
-right slot reads `editing <field>` or `unsaved` when that applies. One footer spans
-the frame: the rule, the status row with a dim stage crumb on the right, and the verb
-bar for whichever side owns focus. The session opens in stage 0; the stage is never
-saved.
-
-`→` and `←` slide the stage. `Enter` opens F and remembers where it came from; `Esc`
-returns there. Changing the selection in A retargets the pane, with no peek. Click a
-board row to select it in place; click a rail row to select it and move focus back to
-the board; double-click to open F. Click inside the stage A task column to move to G
-and run the control you clicked. Below 110 columns
-the stage is kept: 0 and A show the board, G and F show the page, and growing back
-restores the same view.
-
-## Peek and mouse
-
-Below 110 columns, `→` peeks notes under the selected row (up to five wrapped
-lines). `←` closes
-the peek.
-
-Below 110 columns, click a dim task identifier to copy it, click elsewhere on a row
-to peek, and click the same row again to close. At wide widths a board or rail row
-click selects it in place and a fast double-click opens the
-[task page](/docs/task-page/). The wheel scrolls the list.
-
-Everything painted as a control is clickable: the tabs, destination chips, picker
-options, verb-bar entries, `ctrl+u undo` on a delete notice, and the DONE header (which
-closes the drawer). When the list overflows, a scrollbar appears on the right: click
-the track to jump, drag the thumb to scroll. Dragging across text selects it and copies
-on release (`copied`), using the terminal's clipboard protocol. With the quick-add line
-open, clicking a task row discards the draft and selects that row.
-
-## Project picker
-
-`p` opens the project picker with two tabs: main (unarchived projects plus
-Home) and archived. `Tab` or the arrows flip tabs; the archived tab lists every
-archived project and reads `no archived projects` when empty. `ctrl+f` on a
-main-tab project archives it in place. The picker stays open and the project
-leaves the main list, the projects index, desk IN MOTION, and the rail.
-`ctrl+f` or `ctrl+u` on an archived-tab entry unarchives it, and every task
-returns in the status it had. A dim rule sits under the tabs row. The main tab's
-footer reads `↑↓ move · enter choose · ctrl+f archive · esc close`; the archived tab's
-footer reads `ctrl+u unarchive · enter open · esc close`.
-
-## Read-only archived focus
-
-`Enter` on an archived-tab entry opens that project in read-only focus: the chip
-reads `<name> · archived`, its tasks paint dim, and nothing is written by
-entering. It is the only lens that paints an archived project's tasks; `Esc`,
-`p`, or `1`/`2`/`3` leave it for your desk and hide them again (`Esc` there never quits,
-and `p` leaves the lens before the picker paints). If the project is unarchived by any
-other route while you sit in it, the focus becomes an ordinary project focus. Every mutating verb (`ctrl+s`,
-`ctrl+d`, `ctrl+o`, `ctrl+b`, `ctrl+r`, `ctrl+e`, `ctrl+n`, `ctrl+x`, `ctrl+f`, `+`, and
-step toggles) refuses with `project <name> is archived · ctrl+u unarchive` and
-changes nothing; the task page opens view-only for the same reason. `ctrl+u`
-unarchives the project in place and the focus becomes an ordinary project
-focus.
-
-No scope dropdown offers an archived project: not the task page's scope footer,
-not an expanded quick-add draft, not the capture surface. A task already inside
-an archived project still shows that scope as its own value.
-
-## Launch inside an archived project
-
-When the board starts with its quick-add default inside an archived project, a
-card asks `project <name> is archived, would you like to unarchive it?` before
-the first keypress, with `y unarchive · n keep archived` in its footer (both
-clickable): `y` unarchives it durably, `n` or `Esc` keeps it archived and sends
-quick-add to your desk for this session (a dim status line says so). The card
-shows at most once per session, and launching anywhere else paints nothing.
-
-## Pane size
-
-| Pane | What you get |
+| View | What you see |
 | --- | --- |
-| at least 110 columns | wide stage slider: board, board beside page, rail beside page, or page. The rail paints no meta, done drawer, or peek |
-| at least 78×24 and below 110 columns | standard single-pane board: section headers, peek-only attribution, full verb legend |
-| smaller | compact: glyph, `T<number>` identifier, and wrapped title; project/thread attribution appears only inside peek; help, palette, and the task page take the full pane |
-| down to 40×10 | still operable |
+| Board | Full-width board |
+| Split | Board beside task details; selecting another task updates the details |
+| Task | Task details beside a narrow board rail |
+| Full screen | Task details only |
 
-A typical herdr split is 78 columns, which is the standard board.
+Press `Enter` from the board to open a task full screen. `Esc` returns to the view you left. From task focus, `Esc` returns focus to the board beside it.
 
-## Palette and help
+Click inside the task column to focus it. Click a rail row to bring back the split board. While editing, arrows move the text cursor instead.
 
-`:` opens a searchable command palette. Type to filter: the query matches when its
-letters appear in order anywhere in a label, so `ssr` finds `set status: review`.
-`q` is a query character here, not quit. `↑` `↓` or `Tab` / `Shift+Tab` move,
-`Enter` runs, `Esc` closes.
+Narrowing the pane shows one surface; widening it restores the selected view. Each new session starts with the board alone.
 
-| Command | Shows when |
+| Pane size | Layout |
 | --- | --- |
-| `set status: ready` · `started` · `blocked` · `review` | a task is selected |
-| `edit notes` · `change scope` | a task is selected |
-| `new task` | always |
-| `delete` | a task is selected |
-| `reopen` | the selected task is done |
-| `undo` · `done drawer` | always |
-| `help` · `quit` | always |
-| `Retry save` · `Cancel save` | a save is waiting on you (the only two entries then) |
+| 110 columns or wider | Board and task views |
+| At least 78×24, below 110 columns | Single board or task page |
+| Smaller | Compact layout; usable down to 40×10 |
 
-Mutating keys always use Ctrl.
+## Completed tasks
 
-`?` opens the help card, which lists the board chords and, below them, the task-page
-chords. `Esc`, `?`, or `q` closes it. Help, the palette, and the project
-picker are boxed cards: the `[x]` in the corner or a click outside also closes them.
+Press `d` to open or close the done drawer. Select a done task and press `ctrl+o` to return it to ready.
 
-## When a save fails
+The drawer's **archived** group starts closed. Click its heading or press `Enter` on it to expand. `g` folds or unfolds the group while the drawer is open.
 
-If the store cannot be written, the status row reads `save failed: <reason> ·
-Retry or Cancel` and the board keeps your draft. `r` or `Enter` retries and
-answers `saved`; `c` or `Esc` cancels and drops the change (`save cancelled`).
-Until you choose, mutating verbs are held; moving around, peeking, and quitting
-still work. `Esc` does not skip the choice.
+## Archive
+
+Archiving hides work without changing its status.
+
+| Archive | Restore |
+| --- | --- |
+| Task: select it and press `ctrl+f` | Open the done drawer's archived group, select it, then press `ctrl+u` or `ctrl+f` |
+| Project: press `p`, select it, then `ctrl+f` | Switch to the picker's **archived** tab, select it, then `ctrl+u` or `ctrl+f` |
+
+Use `Tab`, `←`, or `→` to switch project-picker tabs. Archiving has no undo entry.
+
+### View an archived project
+
+Press `Enter` on a project in the picker's **archived** tab. Its tasks open read-only. Press `ctrl+u` to restore the project, or `Esc`, `p`, or `1`–`3` to leave.
+
+Archived projects are excluded from task-destination pickers. Restoring a project leaves individually archived tasks archived.
+
+### Launch inside an archived project
+
+tsk asks whether to restore it. Choose `y` to restore, or `n`/`Esc` to keep it archived. Keeping it archived sends new captures to your desk for that session.
+
+## Delete and undo
+
+Press `ctrl+x` twice to delete the selected task. `ctrl+Delete` is an alternative.
+
+Press `ctrl+u` to undo a deletion or completion. Undo refuses if another writer has changed the task since that action. On an archived selection, `ctrl+u` restores it instead.
+
+Deleted tasks remain available through [trash commands](/docs/cli/#trash) for a limited time. They do not appear on the board.
+
+## Palette
+
+Press `:` and type to find an action. Use arrows or `Tab` to select, `Enter` to run, and `Esc` to close.
+
+| Available actions | When |
+| --- | --- |
+| New task, undo, done drawer, help, quit | Always |
+| Set ready/started/blocked/review, edit notes, change scope, delete | A task is selected |
+| Reopen | A done task is selected |
+| Retry save, cancel save | A save has failed |
+
+Search matches letters in order: `ssr` finds `set status: review`.
+
+## Help
+
+Press `?` for every shortcut. Scroll with arrows, `j`/`k`, page keys, or the wheel. Close with `Esc`, `?`, or `q`.
+
+## Save failures
+
+If saving fails, the draft stays open.
+
+- `r` or `Enter`: retry.
+- `c` or `Esc`: cancel the pending change.
+
+Resolve the failure before making another change. See [storage](/docs/storage/) for directory and backup information.

--- a/site/src/content/docs/docs/capture.md
+++ b/site/src/content/docs/docs/capture.md
@@ -1,84 +1,105 @@
 ---
 title: Capture
-description: Quick-add on the board, title tokens, and the herdr quick-capture popup.
+description: Add a task without leaving your work.
 ---
 
-Press `+` for a one-line title on the status-row slot. The list stays visible. Its
-prompt reads `enter save · tab details · esc close`; `Shift+Enter` still saves and
-stays open, and is listed in help rather than the short prompt.
+Press `+` or click **+ add**. Type a title, then press `Enter`.
 
-- `Enter` saves and closes
-- `Shift+Enter` saves and stays open
-- `Tab` expands onto the [task page](/docs/task-page/) (title · notes · scope), full
-  width at any terminal size
+## Quick-add
 
-A project board defaults the draft to that project. A project-less board defaults
-to your desk. Home keeps the cwd-derived default (the repo you opened from, or
-desk if there is no repo).
+| Key | Action |
+| --- | --- |
+| `Enter` | Save and close |
+| `Shift+Enter` | Save and add another |
+| `Tab` | Open details |
+| `Esc` | Cancel |
 
-A saved task becomes the selection. Success has no status message. The row flash
-is the feedback. Refusals (empty title, bad thread) paint while the line is open
-and clear when it closes.
+The board stays visible. A saved task flashes and becomes selected. Invalid input stays open with an explanation.
 
-Title is required.
+Clicking a task while the quick-add line is open discards the draft and selects that task.
+
+## Details
+
+Press `Tab` from quick-add to add notes, steps, a scope, or a thread. The draft uses the full pane and opens in Notes.
+
+- `Shift+Enter` saves.
+- `Esc` returns to the quick-add line.
+- `Tab` from the line restores your draft details.
+
+Scroll to reach steps below long notes. Typing brings the notes cursor back into view.
+
+## Destination
+
+| Where you add | Default destination |
+| --- | --- |
+| Project board | That project |
+| Desk or Projects | The launch/reopen repository, or directory outside Git |
+| Herdr quick-capture popup | The focused pane's repository, or directory outside Git |
+
+Use title tokens or the draft's scope control to change the destination. Archived projects cannot receive new tasks.
+
+Keeping an archived launch project archived changes the session's default to desk.
 
 ## Title tokens
 
-`!p` and `!t` each consume one whitespace-delimited argument. They can sit anywhere
-in the line, in either order. A token followed by another token or by a `#word` is
-bare. Tokens are stripped from the saved title, and the remaining words are
-rejoined with single spaces.
+Add a project or thread while typing the title:
 
-| Token | Effect |
+```text
+Fix login timeout !p atlas !t auth
+Buy coffee !p
+```
+
+| Token | Destination or thread |
 | --- | --- |
-| `!p` | desk |
-| `!p name` | project by basename (case-insensitive) |
-| `!p /path` | that path verbatim |
-| `!t` | unthread |
-| `!t name` | normalized thread (lowercase ASCII alphanumerics, hyphens, and dots, first character alphanumeric, at most 32 characters) |
+| `!p` | Desk |
+| `!p name` | Project matching that basename, ignoring case |
+| `!p /path` | Project at that path |
+| `!t` | No thread |
+| `!t name` | Named thread |
 
-An ambiguous project basename is stored as typed. `tsk list --all --json` is how
-you find a typo scope later.
+Each token takes one whitespace-separated argument. Put bare `!p` or `!t` at the end, or before another token. A following `#word` also leaves the token bare.
 
-An archived project refuses capture: a title token naming one leaves the line
-open with a refusal that names the project (`project <name> is archived`), and
-the refusal clears when the line closes. `tsk add` refuses the same way with
-error code `project-archived`.
+Tokens are removed from the saved title. Remaining words are joined with single spaces. A title is required.
 
-## Quick capture (herdr)
+A missing or ambiguous project name is kept as typed. Check spelling; use `tsk list --all --json` to find tasks filed under an unexpected project.
 
-**Quick capture** opens the expanded quick-add page in a short-lived popup, without
-first opening a split board:
+## Thread names
 
-```bash
+Thread names are lowercased and must:
+
+- Start with an ASCII letter or digit.
+- Contain only ASCII letters, digits, `-`, or `.`.
+- Be at most 32 characters.
+
+Invalid names leave the draft open with the rule that failed.
+
+## Quick capture
+
+In Herdr, press **prefix+a** after [setup](/docs/install/#add-to-herdr). A popup opens with Title focused.
+
+| Action | Result |
+| --- | --- |
+| Type or edit the title | Name the task |
+| Add notes, a thread, or steps | Include details before saving |
+| `Shift+Enter` | Save and close the popup |
+| `Esc` | Discard and close |
+
+If a step editor or scope picker is open, `Esc` closes that first. During save recovery, it cancels the pending save.
+
+Selected text from the invoking pane prefills the title. An archived launch project falls back to desk. A failed save keeps the draft open for retry or cancel.
+
+You can also invoke the popup explicitly:
+
+```sh
 herdr plugin action invoke quick-capture --plugin herdr-tsk
 ```
 
-It is the same expanded page you get with `+` then `Tab` on the board, but it opens
-with the cursor in Title. Type the title on the page header, notes under it; thread
-and `+ step` are on the page. `Shift+Enter` saves and closes the popup. `Esc` cancels:
-one press discards the draft and closes the popup without creating a task. If the
-save fails, the popup stays open with the draft editable and the usual retry/cancel
-recovery.
+For the same capture flow in your terminal, run `tsk capture`. `TSK_MODE=capture tsk` is equivalent.
 
-If text is selected in the pane you invoked it from, it arrives as the title. Scope
-defaults to the repo of the focused pane, or the desk outside one; change it on the
-page's scope field, or with `!p` tokens in the title. An archived project is never
-a default: the draft falls back to the desk.
+## From an agent or script
 
-An idle board watching the same `~/.tsk` picks up the new task on the next tick.
+```sh
+tsk add -t "Fix login timeout" --thread auth
+```
 
-## Expanded form
-
-From the `+` line, `Tab` opens the task page in notes edit because a draft has
-nothing to view yet. Thread and `+ step` are on that page. `Esc` returns to the
-line. A second `Tab` restores what you typed.
-
-The mouse wheel and page scrollbar can reach `+ step` below long notes without
-leaving the draft. Typing or moving the Notes cursor brings it back into view.
-
-In the capture popup, clicking Title or Notes places the cursor at the clicked
-character, including wrapped and scrolled note lines.
-
-The page scrollbar also works while a new step is being typed. A field click
-that refuses to leave an unfinished step keeps that step’s cursor unchanged.
+[CLI options](/docs/cli/#add) · [Editing tasks](/docs/task-page/)

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -1,282 +1,309 @@
 ---
 title: CLI
-description: Headless tsk add, list, steps, status, edit, trash, and archive. The agents' door to the board.
+description: Commands, arguments, output, and retry rules for the shared task board.
 ---
 
-The same `~/.tsk` store backs the board, herdr, and these commands. The board
-reads a change on its next tick.
+The CLI reads and updates the same tasks as the board. A running board picks up saved changes automatically.
 
-```bash
-tsk add -t "Draft release notes"
+```sh
+tsk add -t "Fix login timeout"
 tsk list
 ```
 
 ## For agents
 
-The CLI is how an agent reaches the board. The rules that matter:
+Install the skill with `tsk setup pi`, or use your [agent's setup target](#setup). `tsk guide` prints the workflow.
 
-- Put work on the board with `tsk add`, one task per call or a JSON plan through
-  `--file`. A repeat of the same title, project, and thread returns the existing
-  task, so a retried plan is safe.
-- Plan with `tsk steps <task> add`. Read back with `tsk list <task>` before a
-  toggle or remove, because those are not idempotent.
-- Move work with `tsk status <task> start` (or `started`, `blocked`, `review`, `ready`, `done`).
-  Repeating the same status is safe. Rewrite title or notes with `tsk edit`.
-- Prefer `--json` and read the exit code. Exit 1 means retry only the failed
-  items. Exit 3 means list before retrying.
+1. Read the task with `tsk list T12`.
+2. Set its status with `tsk status T12 started`.
+3. Update notes or steps as work progresses.
+4. Set `review`, `blocked`, or `done` explicitly.
 
-The repo ships the same rules as an agent skill in
-[`skills/tsk-cli/SKILL.md`](https://github.com/smarzban/herdr-tsk/blob/main/skills/tsk-cli/SKILL.md).
-`tsk guide` prints that skill with the YAML frontmatter removed.
+The CLI can mark a task done with `tsk status <task> done`. Agent lifecycle does not change task status automatically.
+
+Use `--json` on `add` or `list` for machine-readable output. Read the [exit contract](#exit-contract) before retrying a write.
 
 ## Commands
 
-| Command | Does |
+| Command | Action |
 | --- | --- |
-| `tsk` | opens the board |
-| `tsk capture` | opens quick capture: the expanded quick-add page (also `TSK_MODE=capture`) |
-| `tsk add` · `tsk list` · `tsk steps` · `tsk status` · `tsk edit` · `tsk trash` · `tsk archive` · `tsk unarchive` · `tsk project` | headless; below |
-| `tsk guide` | print the agent workflow skill (frontmatter stripped), exit 0 |
-| `tsk --help` | usage, exit 0 |
-| `tsk --find-board-pane` | herdr helper: reads `pane list` JSON on stdin, prints the id of the pane labelled `tsk`; exit 1 when none |
+| `tsk` | Open the board |
+| `tsk capture` | Open capture; save or discard exits |
+| `tsk add` | Add a task or JSON plan |
+| `tsk list` | Read tasks |
+| `tsk status` | Set task status |
+| `tsk edit` | Replace title or notes |
+| `tsk steps` | Add, toggle, rename, or remove steps |
+| `tsk archive` / `tsk unarchive` | Hide or restore a task |
+| `tsk project archive` / `tsk project unarchive` | Hide or restore a project |
+| `tsk trash restore` | Restore a task from trash |
+| `tsk setup` | Configure Herdr or install an agent skill |
+| `tsk guide` | Print the agent workflow |
+| `tsk --help` | Show help |
 
-Every headless command takes `--state-dir <dir>` to work against another store.
+Data commands accept `--state-dir <dir>`. Setup and guide do not use that flag.
 
-## guide
+### Task addresses
 
-Print the embedded agent skill, YAML frontmatter stripped. Stderr is empty.
+`T12`, `t12`, `12`, and a task UUID identify the same task. Direct lookup ignores the current project.
 
-```
-tsk guide
-```
+### Scope
 
-Exit 0. The same body is the source for `/docs/agents/` and `tsk setup <agent>`.
+Without a scope flag, `add` and filtered `list` use the launch repository, or the current directory outside Git. Commands addressed to a task ignore that default.
 
-Human-readable stdout and stderr escape C0/C1 controls in stored titles, step
-text, and project names as `\u{00xx}`. JSON keeps the underlying values.
+| Flag | Scope |
+| --- | --- |
+| `--desk` | Desk |
+| `-p name` / `--project name` | Project matching that basename, ignoring case |
+| `-p /path` | Project path |
+| `--all` on list | All scopes |
+
+A missing or ambiguous basename stays as typed. A typo can create a separate scope. Check with `tsk list --all --json`.
 
 ## add
 
-Create one task, or apply a JSON plan. Human output is `added <title>` or
-`task already exists`.
-
-```
-tsk add -t <title> [-n <notes>] [-p <project> | --desk] [--thread <name>] [--json] [--state-dir <dir>]
-tsk add [--file <path|->] [--state-dir <dir>]
+```sh
+tsk add -t "Fix login timeout" -n "Reproduce on a slow connection" --thread auth
+tsk add -t "Buy coffee" --desk
+tsk add -t "Draft release notes" -p atlas --json
 ```
 
-`--desk` is your desk (stored as scope `global`). `-p` / `--project` uses the
-same basename-or-path rules as capture `!p`. `--thread` normalizes like `!t`.
+| Option | Purpose |
+| --- | --- |
+| `-t`, `--title` | Required task title |
+| `-n`, `--notes` | Optional notes |
+| `-p`, `--project` or `--desk` | Destination |
+| `--thread` | [Thread name](/docs/capture/#thread-names) |
+| `--json` | One result object |
+| `--file <path>` or `--file -` | Read a JSON plan |
+| `--state-dir <dir>` | Alternate state directory |
 
-An add whose trimmed title, resolved project, and normalized thread already
-exist succeeds without changing the task.
+Duplicate detection compares the trimmed title, resolved project, and normalized thread. A matching non-deleted task returns successfully without changes, even if done or individually archived. Adding into an archived project refuses.
 
-Values that start with `-` need `--title=…`, `--notes=…`, `--project=…`,
-`--state-dir=…`, or `--file=…`. Item flags plus `--file` is usage (exit 2,
-nothing persists). Piped stdin with item flags is ignored and not read.
+Plain output: `added <title>` or `task already exists`.
 
-Notes that trim to nothing are dropped.
+JSON output: `outcome` (`created` or `existing`), `id`, `number`, `title`, and `project` (`null` for desk).
 
-`--json` on a flag add prints one object: `outcome` (`created` or `existing`),
-`id`, `number`, `title`, and `project` (or `null`).
+Values starting with `-` use equals syntax: `--title="-fix parser"`, `--notes="-5 degrees"`, `--project="-maintenance"`, `--file=...`, or `--state-dir=...`.
 
-Plan JSON is an array:
+Blank notes are omitted. C0 control characters in titles are rejected before trimming.
+
+### JSON plans
 
 ```json
-[{"title": "...", "notes": "...", "project": "...", "thread": "..."}]
+[
+  {"title": "Reproduce login timeout", "project": "atlas", "thread": "auth"},
+  {"title": "Draft release notes", "notes": "Include migration instructions"}
+]
 ```
 
-`project` null means desk; a missing `project` means the invocation default (the
-repo you ran from, or desk). `thread` may be `null` or missing. The result is
-`{ "created": [...], "existing": [...], "failed": [...] }`, each item carrying its
-index `i`; failed items add `code` and `error`. Notes are not echoed.
-
-```bash
+```sh
 tsk add --file plan.json
 cat plan.json | tsk add
 ```
 
+| Field | Meaning |
+| --- | --- |
+| `title` | Required string |
+| `notes` | Optional notes |
+| `project` omitted | Invocation default |
+| `project: null` | Desk |
+| `project` string | Project name or path |
+| `thread` omitted or `null` | No thread |
+| `thread` string | Normalized thread |
+
+Output contains `created`, `existing`, and `failed` arrays. Items carry their input index `i`; failures include `code` and `error`. Successful entries include task ID, number, and title. Notes are not echoed.
+
+Valid items persist even if another item fails. Retry only failed or confirmed-missing items.
+
+Do not mix item flags with `--file`. Piped input is ignored when item flags are present.
+
 ## list
 
-Prints tasks. It does not change them.
-
+```sh
+tsk list
+tsk list T12
+tsk list --all --json
+tsk list -p atlas --thread auth
+tsk list --done --all
+tsk list --archived --all
+tsk list --deleted --all
 ```
-tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted] [--json] [--state-dir <dir>]
+
+```text
+tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --deleted | --archived] [--json] [--state-dir <dir>]
 ```
 
-Default: ready, started, blocked, and review in the invocation project, or your
-desk outside a repository.
+| Filter | Result |
+| --- | --- |
+| Default | Ready, started, blocked, and review tasks; excludes archived and deleted work |
+| `--done` | Completed tasks |
+| `--archived` | Individually archived tasks and tasks in archived projects, across statuses |
+| `--deleted` | Deleted tasks in the main store and trash, newest first |
+| `--thread` | Filter within the selected scope |
 
-- `--desk` selects desk
-- `--all` every scope
-- `--done` done only
-- `--deleted` soft-deleted only: live soft-deletes plus trash entries from
-  `trash.jsonl` (kept 30 days), deduped by task with the live copy winning,
-  newest deletion first
-- `--archived` archived only: individually archived tasks plus tasks of
-  archived projects, one row per id, each marked `archived` or
-  `project archived`; JSON rows carry the mark in `archived`. Default views
-  never list archived tasks or tasks of archived projects
-- `--thread` filters within the selected scope
+Scope flags are mutually exclusive. So are `--done`, `--deleted`, and `--archived`.
 
-Human output groups rows under `STARTED`, `READY`, `BLOCKED`, `REVIEW`, then
-`DONE` or `DELETED` when asked, as `- <number> <title> #thread`. With `--all`, a
-trailing scope label (`desk` or `project: <path>`) tells the groups apart.
+A direct task address searches the main store, including done, archived, and recently deleted tasks. It cannot be combined with scope, thread, or status filters. A missing task exits 2. Tasks already moved to trash require `--deleted`.
 
-A store-global task number (`T12`, `t12`, or bare `12`) or a task UUID lists
-that one task and its steps (`[x]` / `[ ]` plus the step short id). Direct lookup
-ignores cwd and searches the live store, including done and live soft-deleted
-tasks. A task that has moved to `trash.jsonl` is not found by `tsk list T12`;
-use `tsk list --deleted`, then `tsk trash restore T12`. A task operand cannot
-combine with scope, thread, or status filters. An address that matches nothing
-is a usage error (exit 2).
+Human output groups by status and includes the task number and thread. `--all` adds scope labels. Single-task output includes steps and their short IDs.
 
-`--json` is a flat array of `id`, `number`, `title`, `status`, `project`, and
-`thread`. Single-task JSON also attaches `steps`.
+JSON returns an array with `id`, `number`, `title`, `status`, `project`, and `thread`. Direct lookup also includes `steps`. Archived listings include an `archived` mark: `archived` or `project archived`.
 
-To recover a typo scope: `tsk list --all --json`.
+## status
+
+```sh
+tsk status T12 started
+tsk status T12 review
+```
+
+Accepts `ready`, `started` (or `start`), `blocked`, `review`, and `done`.
+
+Unlike keyboard toggles, this command sets the requested status directly. Repeating the same value is safe.
+
+Output: `status T12 <status> <title>`. The output uses `started`, even when the input was `start`.
+
+## edit
+
+```sh
+tsk edit T12 --title "Fix timeout on slow connections"
+tsk edit T12 --notes "Reproduced with a delayed response"
+```
+
+Requires `--title`, `--notes`, or both. Scope and thread stay unchanged.
+
+Blank notes clear the field. Notes preserve newlines and tabs. Use `--title=...` or `--notes=...` for values starting with `-`.
+
+Output: `edited T12 <title>`. Repeating the same values is safe.
 
 ## steps
 
-```
+```text
 tsk steps <task> add <text> [--state-dir <dir>]
 tsk steps <task> toggle <step-short-id> [--state-dir <dir>]
 tsk steps <task> rename <step-short-id> <text> [--state-dir <dir>]
 tsk steps <task> remove <step-short-id> [--state-dir <dir>]
 ```
 
-Output is `added <short-id> <text>`, `toggled <short-id> [x] <text>`,
-`renamed <short-id> <text>`, or `removed <short-id> <text>`.
+Read short IDs with `tsk list T12`. Full step UUIDs also work.
 
-See [steps](/docs/steps/) for the board side. `toggle` and `remove` are not
-idempotent. `rename` is idempotent on the trimmed text. Verify with
-`tsk list <task>` before a retry of toggle or remove.
+| Action | Output prefix | Safe to repeat unchanged? |
+| --- | --- | --- |
+| Add | `added <short-id> <text>` | No; creates another step |
+| Toggle | `toggled <short-id> [x] <text>` | No; flips the value again |
+| Rename | `renamed <short-id> <text>` | Yes |
+| Remove | `removed <short-id> <text>` | No; refuses after removal |
 
-## status
-
-```
-tsk status <task> <status> [--state-dir <dir>]
-```
-
-`<status>` is `ready`, `started` (or `start`), `blocked`, `review`, or `done` (`tsk status <task> done`). Output is
-`status T<n> <status> <title>` and always uses the stored name (`started`). Repeating the same status is idempotent.
-
-Unknown task: `unknown-task`. Soft-deleted: `soft-deleted-task`.
-
-## edit
-
-```
-tsk edit <task> [--title <title>] [--notes <notes>] [--state-dir <dir>]
-```
-
-At least one of `--title` or `--notes` is required. Scope and thread are
-unchanged. Notes that trim to nothing are cleared. Newlines and tabs in notes are kept, same as add. Output is
-`edited T<n> <title>`. Repeating the stored values is idempotent.
-
-Values that start with `-` need `--title=…` or `--notes=…`.
-
-Refusal tokens: `unknown-task`, `soft-deleted-task`, `empty-title`,
-`invalid-title`.
-
-## trash
-
-```
-tsk trash restore <task> [--state-dir <dir>]
-```
-
-A soft-deleted task leaves the board store once it is no longer undoable, or
-after 7 days, and lives in `trash.jsonl` for 30 days. `tsk list --deleted`
-shows trash entries beside live soft-deletes, with their `T<n>` number.
-
-`tsk trash restore T<n>` puts the task back on the board: not soft-deleted,
-with a `restored` history event, a new revision, and its old number. A missing
-line, or a task that is already live, refuses with `T<n> is not in trash`
-(exit 1). Usage errors exit 2; store I/O exits 3.
+Read back before retrying an uncertain result. [Using steps on the board](/docs/steps/).
 
 ## archive and unarchive
 
-```
-tsk archive <task> [--state-dir <dir>]
-tsk unarchive <task> [--state-dir <dir>]
+```sh
+tsk archive T12
+tsk unarchive T12
 ```
 
-`archive` sets a task's archived flag; `unarchive` clears it. The task keeps its
-human status and its `T<n>`. Repeating the verb is idempotent: the same
-`archived T7 <title>` / `unarchived T7 <title>` line prints and nothing changes.
-An unknown task refuses with `T<n> is not on the board` and a soft-deleted task
-with `T<n> is deleted` (both exit 1); usage errors exit 2; store I/O exits 3.
+Keep the task's status and number. Repeating either command is safe.
+
+Output: `archived T12 <title>` or `unarchived T12 <title>`.
+
+Unknown tasks refuse with `T12 is not on the board`; deleted tasks with `T12 is deleted`.
 
 ## project archive / unarchive
 
+```sh
+tsk project archive atlas
+tsk project unarchive atlas
 ```
-tsk project archive <name> [--state-dir <dir>]
-tsk project unarchive <name> [--state-dir <dir>]
+
+Accepts a project basename or path. Repeating an action is safe. An unknown project refuses with `no project named <name> has tasks`.
+
+Restoring a project preserves task statuses and leaves individually archived tasks archived.
+
+Output: `archived project <name>` or `unarchived project <name>`.
+
+## trash
+
+```sh
+tsk list --deleted --all
+tsk trash restore T12
 ```
 
-`<name>` follows the `!p` rules: a project basename (case-insensitive) or a
-`/path` verbatim. Archiving writes one lazy project record; unarchiving removes
-it, and every task returns in the status it had. A task's own archived flag is
-independent. Output is `archived project <short>` / `unarchived project <short>`,
-idempotent on repeat. A name matching no project that has tasks exits 1 with
-`no project named <name> has tasks`.
+Restore returns a task from trash with its original number. A task absent from trash, or already live, refuses with `T12 is not in trash`.
 
-## Exit contract
-
-| Exit | Meaning |
-| --- | --- |
-| 0 | listed, every add item created/existed, the step applied, status or edit written (or already had the value), the task restored, or the archive flag written (or already had the value) |
-| 1 | one or more item refusals (add/steps/status/edit), a trash restore with no matching line, an unknown or deleted `archive`/`unarchive` task, or a project action matching nothing. Retry only the failed subset. For toggle and remove, list first. |
-| 2 | usage or parse error, including a `list` address that matches nothing. Nothing persisted. |
-| 3 | store I/O. Commit is indeterminate. `tsk list` before retrying. |
-
-Add refusal codes: `empty-title`, `invalid-title`, `invalid-thread`, `invalid-item`,
-`project-archived`. `project-archived` prints `project <name> is archived. Use
---desk, -p <other project>, or tsk project unarchive <name>` and persists
-nothing. This covers the cwd default and an explicit `-p`.
-Any C0 control in a title or step text is `invalid-title` / `invalid-step-text`
-before trimming.
-
-Steps refusals (exit 1): `empty-step-text`, `invalid-step-text`, `unknown-task`,
-`soft-deleted-task`, `unknown-step`, `ambiguous-step`.
-
-Status refusals (exit 1): `unknown-task`, `soft-deleted-task`.
-
-Edit refusals (exit 1): `unknown-task`, `soft-deleted-task`, `empty-title`,
-`invalid-title`.
+Recent deletions may still be in the main store; use board undo until they move to trash. [Retention and storage](/docs/storage/#deleted-tasks).
 
 ## setup
 
-```
+```sh
 tsk setup
 tsk setup herdr
-tsk setup claude | pi | cursor | grok | codex
-tsk setup --skill-dir <path> [--force] [--json]
+tsk setup pi
+tsk setup --skill-dir /path/to/skills
 ```
 
-Bare `tsk setup` lists targets and writes nothing. `tsk setup herdr` registers
-the embedded plugin assets and adds prefix+t (board) and prefix+a (quick capture).
-It uses the same installed binary, with no source checkout or second build. Herdr
-0.9+ must be on PATH. Conflicting shortcuts require interactive confirmation;
-declining preserves them. A noninteractive conflict aborts without writes.
-`tsk setup herdr --help` is read-only.
+Bare `tsk setup` lists targets and writes nothing. Choose one target per call.
 
-Agent targets write the embedded `skills/tsk-cli/SKILL.md` (frontmatter kept) into
-that tool's user-level skills directory as `tsk-cli/SKILL.md`:
+### Herdr
 
-- `claude` → `~/.claude/skills/`
-- `pi` → `~/.pi/agent/skills/`
-- `cursor` → `~/.cursor/skills/`
-- `grok` → `~/.grok/skills/`
-- `codex` → `~/.agents/skills/`
-- `--skill-dir <path>` → `<path>/tsk-cli/SKILL.md`
+Requires Herdr 0.9+ on PATH. Registers the installed binary and adds **prefix+t** and **prefix+a**. Shortcut conflicts require confirmation; noninteractive conflicts stop before writes.
 
-A second run without `--force` exits 1 with `skill-exists` and leaves the file.
-`--force` overwrites. `--json` emits `outcome` (`written`, `exists`, or `listed`),
-`target`, and `path`. Two targets, or `herdr` plus `--skill-dir`, is usage (exit 2).
-An empty `--skill-dir` is usage. A symlink at the skills root, the `tsk-cli`
-directory, or `SKILL.md` is refused.
+[Reload, upgrades, and removal](/docs/install/#herdr-setup-with-an-installed-binary).
 
-Exit codes: 0 success/help/list, 1 setup or confirmation failure or `skill-exists`,
-2 invalid arguments. Herdr setup does not edit task data. See
-[installation](/docs/install/#herdr-setup-with-an-installed-binary)
-for config paths, backups, reload, upgrades and removing integration.
+### Agent skills
+
+| Target | Skills directory |
+| --- | --- |
+| `pi` | `~/.pi/agent/skills/` |
+| `claude` | `~/.claude/skills/` |
+| `cursor` | `~/.cursor/skills/` |
+| `grok` | `~/.grok/skills/` |
+| `codex` | `~/.agents/skills/` |
+| `--skill-dir <path>` | The supplied directory |
+
+Setup writes `tsk-cli/SKILL.md` under the selected directory.
+
+| Option | Action |
+| --- | --- |
+| `--force` | Replace an existing skill |
+| `--json` | Return `outcome`, `target`, and `path` |
+
+Without `--force`, an existing skill returns `skill-exists` and exits 1. Symlinks at the skills root, skill directory, or file are refused. Herdr setup does not accept these agent options.
+
+Setup exits 0 for success/help/list, 1 for setup failure, or 2 for invalid arguments.
+
+## guide
+
+```sh
+tsk guide
+```
+
+Prints the embedded [agent skill](/docs/agents/) without YAML frontmatter. Exits 0. It is the same workflow installed by agent setup.
+
+## Exit contract
+
+For data commands:
+
+| Exit | Meaning | Next step |
+| --- | --- | --- |
+| `0` | Success, including an already-existing task or unchanged value | Continue |
+| `1` | Refusal; a plan may have saved other items | Correct refusals; retry only failed items |
+| `2` | Invalid arguments or input; nothing saved | Fix the invocation |
+| `3` | Storage error; a write may have committed | Read back before retrying |
+
+After an uncertain add, inspect `tsk list --all --json`. Also check `--done` and `--archived` when a duplicate could be hidden there. If you know the task number, use direct lookup.
+
+| Command | Refusal codes |
+| --- | --- |
+| Add | `empty-title`, `invalid-title`, `invalid-thread`, `invalid-item`, `project-archived` |
+| Steps | `empty-step-text`, `invalid-step-text`, `unknown-task`, `soft-deleted-task`, `unknown-step`, `ambiguous-step` |
+| Status | `unknown-task`, `soft-deleted-task` |
+| Edit | `unknown-task`, `soft-deleted-task`, `empty-title`, `invalid-title` |
+
+Invalid thread flags fail argument parsing with exit 2; an invalid thread in a JSON plan is an item refusal with exit 1. An archived-project refusal saves nothing for that item; other valid plan items can still save.
+
+Human-readable output escapes stored terminal control characters. JSON retains the underlying text.
+
+## Herdr helper
+
+`tsk --find-board-pane` reads Herdr `pane list` JSON from stdin and prints the ID of the pane labelled `tsk`. It exits 1 if none matches.

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -1,45 +1,48 @@
 ---
 title: Overview
-description: What tsk is, who moves the work, and where to read next.
+description: A shared task board for you and your agents.
 ---
 
-**tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.** You both put work on one board and move it through human status: ready, started, blocked, review, done.
+**tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.**
 
-It ships as the herdr plugin `herdr-tsk`. The `tsk` binary also runs standalone
-against `~/.tsk`. The pane, the quick-capture popup, and the CLI edit the same store.
-
-This site is the user guide.
-
-## One board, two kinds of hands
-
-- **You** work the board: tabs, peek, the task page, and the status verbs behind
-  Ctrl.
-- **Agents** work the [CLI](/docs/cli/): `tsk add` puts work on the board,
-  `tsk steps` plans it, `tsk status` and `tsk edit` move it, `tsk list` reads it
-  back. Adding a task that already exists returns the existing one, so a retried
-  plan is safe.
-- **Status is shared.** Agents set ready, started, blocked, review, or done with
-  `tsk status`. Nothing auto-completes a task from agent lifecycle.
-
-Assigning a task to an agent, and starting that agent from the board, are in
-progress. They are not in the current build.
-
-## What you can do
-
-- Keep a queue with **desk**, a selected project board, and a **projects** index.
-  The desk is your own planning space: general to-dos, future projects, anything outside
-  a repository. The projects index can show a flat cross-project thread.
-- Capture with `+` on the board, or the herdr quick-capture popup
-- Open a task page for title, notes, thread, scope, and steps
-- Script the same store with `tsk add`, `tsk list`, `tsk status`, `tsk edit`, and `tsk steps`
-
-Park, resume, attention, linking, and dispatch are not in this product.
+Use it beside your agent in Herdr, or run `tsk` in any terminal. Both use the same tasks.
 
 ## Start here
 
-1. [Install](/docs/install/) and open the board
-2. [Board](/docs/board/) for tabs, sections, and status
-3. [Keys](/docs/keys/) for the keymap
-4. [Capture](/docs/capture/) to add work
-5. [Task page](/docs/task-page/) and [steps](/docs/steps/) for detail
-6. [CLI](/docs/cli/) for agents, scripts, and the board without the TUI
+1. [Install tsk and connect Herdr](/docs/install/).
+2. Press `+`, type a title, and press `Enter`.
+3. Open the task for notes and steps.
+4. Give your agent its task number.
+
+Agents read tasks with `tsk list` and update them with `tsk status`. [Install the agent skill](/docs/cli/#setup) for the full workflow.
+
+## Find your work
+
+**No project setup needed.** Open tsk in your project directory and add your first task—the project appears on your board automatically. To add a task to another project, include `!p /path/to/project` in quick add, or use `-p /path/to/project` with `tsk add`.
+
+| View | Use it for |
+| --- | --- |
+| **desk** | Personal tasks, plus work needing attention across projects |
+| **selected project** | One project's tasks |
+| **projects** | Browse projects or follow a thread across them |
+
+| Section | Contains |
+| --- | --- |
+| **NEEDS YOU** | Blocked tasks and work ready for review |
+| **IN MOTION** | Started tasks |
+| **ON DECK** | Ready tasks |
+
+You or your agent set task status. Completing steps or ending an agent session does not mark a task done.
+
+## Guides
+
+| I want to… | Read |
+| --- | --- |
+| Find, filter, or archive work | [Board](/docs/board/) |
+| Use keyboard shortcuts | [Keys](/docs/keys/) |
+| Add a task or capture an idea | [Capture](/docs/capture/) |
+| Edit notes, scope, or thread | [Task page](/docs/task-page/) |
+| Break work into a checklist | [Steps](/docs/steps/) |
+| Work through an agent | [Agent guide](/docs/agents/) |
+| Script the board | [CLI](/docs/cli/) |
+| Find data, backups, or settings | [Storage](/docs/storage/) |

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -1,10 +1,9 @@
 ---
 title: Install
-description: Install tsk, open the board, and connect it to Herdr.
+description: Install tsk, connect Herdr, and give your agent the skill.
 ---
 
-Install tsk with the installer or Homebrew, then open the board from a
-repository. Optional Herdr setup registers the plugin and shortcuts.
+Available for macOS and Linux, on ARM64 and x86-64.
 
 ## Install
 
@@ -12,74 +11,128 @@ repository. Optional Herdr setup registers the plugin and shortcuts.
 curl -fsSL https://gettsk.sh/install.sh | sh
 ```
 
-Or install with Homebrew:
+Or use Homebrew:
 
 ```sh
 brew install smarzban/tap/tsk
 ```
 
-The installer sets up PATH for Bash and Zsh. If prompted, reopen your terminal
-or run the printed `export` command before continuing.
+Reopen your terminal if prompted, or run the printed `export` command.
 
-## Add to Herdr (optional)
+## Add to Herdr
 
-With Herdr 0.9+ installed:
+[Install Herdr](https://herdr.dev/docs/install/) first. Installed-binary setup requires Herdr 0.9+.
 
 ```sh
 tsk setup herdr
 herdr server reload-config
 ```
 
-To give an agent the CLI skill instead, run `tsk setup claude` (or `pi`,
-`cursor`, `grok`, `codex`) after tsk is on PATH. That writes `tsk-cli/SKILL.md`
-into the tool's user-level skills directory. `tsk setup --skill-dir <path>` is
-the same write against any directory. See [CLI setup](/docs/cli/#setup).
+| Shortcut | Action |
+| --- | --- |
+| **prefix+t** | Open the board |
+| **prefix+a** | Quick capture |
 
-## Open the board
+Use your configured Herdr prefix. [Herdr keyboard guide](https://herdr.dev/docs/keyboard/).
 
-Run `tsk`, or press **prefix+t** in Herdr.
+## Agent skill
 
-## Add a task
+```sh
+tsk setup pi
+```
+
+Use `claude`, `cursor`, `grok`, or `codex` instead of `pi` for another agent. Setup installs the CLI skill in that agent's user-level skills directory.
+
+[Custom directories and overwrite options](/docs/cli/#setup).
+
+## First task
+
+Open the board and press `+`, type a title, then `Enter`. Or use the CLI:
 
 ```sh
 tsk add -t "your task title"
 ```
 
-Or press **prefix+a** in Herdr.
+Give your agent the task number to work on it. [Board guide](/docs/board/).
+
+For standalone use, run `tsk` directly in your terminal.
+
+## Upgrade
+
+| Installed with | Upgrade |
+| --- | --- |
+| Installer | Run the installer again |
+| Homebrew | `brew update && brew upgrade tsk` |
+| Source | Pull changes and rebuild |
+
+Close and reopen running boards to use the new binary. After upgrading an installed Herdr plugin, rerun `tsk setup herdr`, then reload Herdr's config.
+
+The board shows a notice when a newer release is available. [Update-check settings](/docs/storage/#update-check).
+
+## Uninstall
+
+| Installed with | Remove |
+| --- | --- |
+| Installer | Delete `tsk` from its installation directory |
+| Homebrew | `brew uninstall tsk` |
+
+Task data remains in place.
+
+To remove Herdr integration, run `herdr plugin unlink herdr-tsk`, remove the two shortcut bindings, and reload Herdr's config.
+
+To undo installer PATH changes, remove the `# tsk PATH` comment and its following `case` line from the startup files named during installation.
 
 ## Installer details
 
-The script verifies the latest stable release's SHA-256 and installs to `~/.local/bin`.
-It adds a duplicate-safe PATH entry to Bash or Zsh startup files when the directory
-isn't already on PATH, without replacing existing content. Reopen the terminal or
-run the printed `export` command to use `tsk` in the current shell.
+The installer verifies the release's SHA-256 checksum and installs to `~/.local/bin`. It does not require sudo or change task data.
 
-Zsh uses `$ZDOTDIR/.zshrc` (otherwise `~/.zshrc`). Bash uses `~/.bashrc` and the
-first existing login file (`~/.bash_profile`, `~/.bash_login`, or `~/.profile`).
-Symlinked, non-regular or unwritable startup files are left alone. Other shells
-require manual PATH setup; the installer prints guidance without undoing the install.
+| Setting | Purpose |
+| --- | --- |
+| `TSK_INSTALL_DIR` | Choose an absolute installation directory; no colons or newlines |
+| `TSK_VERSION=vX.Y.Z` | Install a specific stable release |
+| `--help` | Show help without downloading |
 
-Requires `curl`, `tar`, `sed`, and `sha256sum` or `shasum`. `TSK_INSTALL_DIR` selects
-another absolute directory (no colons or newlines); `TSK_VERSION=vX.Y.Z` pins a
-stable release tag. `--help` makes no downloads. Rerun to upgrade; remove the
-installed executable to uninstall. To undo PATH setup too, remove the `# tsk PATH`
-comment and its following `case` line from the startup files listed above.
-No sudo or task-data changes. Checksum failures
-and symlink destinations are refused without replacing the binary or editing PATH.
-For Homebrew upgrades, use `brew update && brew upgrade tsk`; remove it with
-`brew uninstall tsk`. Reopen running boards after upgrades.
+Requires `curl`, `tar`, `sed`, and `sha256sum` or `shasum`.
+
+### PATH
+
+If the install directory is missing from PATH, the installer adds it to:
+
+| Shell | Startup files |
+| --- | --- |
+| Zsh | `$ZDOTDIR/.zshrc`, or `~/.zshrc` |
+| Bash | `~/.bashrc` and the first existing login profile; defaults to `~/.profile` |
+
+The installer does not source these files. Symlinked, non-regular, or unwritable files are skipped with manual instructions. Other shells require manual PATH setup. Successful edits remain if another file cannot be updated.
+
+## Herdr setup with an installed binary
+
+Setup registers bundled plugin files using the installed executable. No source checkout is needed.
+
+- Shortcut conflicts ask for confirmation. Declining keeps the existing binding.
+- A noninteractive conflict stops before writing.
+- Config changes create a backup.
+- Rerunning setup updates the registration without duplicating bindings.
+- Use the stable command on PATH, not a versioned Homebrew Cellar path.
+
+Installation alone does not update an existing plugin registration. [Setup recovery and configuration](https://github.com/smarzban/herdr-tsk/blob/main/packaging/README.md#herdr-setup-and-upgrades).
 
 ## Manual archives
 
-Download `tsk-vX.Y.Z-<target>.tar.gz` and `SHA256SUMS` from the same
-[release](https://github.com/smarzban/herdr-tsk/releases). Choose macOS ARM64/Intel
-or Linux ARM64/x86-64 musl. Check the archive with `sha256sum` (Linux) or
-`shasum -a 256` (macOS), compare its full digest with `SHA256SUMS`, then extract
-`tsk` into a directory on PATH. Never run a binary whose checksum differs.
+Download the archive for your platform and `SHA256SUMS` from the same [release](https://github.com/smarzban/herdr-tsk/releases).
+
+| Platform | Archive target |
+| --- | --- |
+| macOS Apple silicon | `aarch64-apple-darwin` |
+| macOS Intel | `x86_64-apple-darwin` |
+| Linux ARM64 | `aarch64-unknown-linux-musl` |
+| Linux x86-64 | `x86_64-unknown-linux-musl` |
+
+Archives are named `tsk-vX.Y.Z-<target>.tar.gz`. Verify with `shasum -a 256` on macOS or `sha256sum` on Linux. Compare the full digest with `SHA256SUMS`, then extract `tsk` into a directory on PATH.
 
 ## Source build
 
-Requires Rust 1.96.0 and Linux or macOS:
+Requires Rust 1.96.0:
 
 ```sh
 git clone https://github.com/smarzban/herdr-tsk.git
@@ -88,49 +141,6 @@ cargo build --release
 export PATH="$PWD/target/release:$PATH"
 ```
 
-For source-checkout plugin development with Herdr 0.7.5+, run
-`herdr plugin link "$PWD"` after building. Rebuild after pulling changes.
+For plugin development from a checkout, Herdr 0.7.5+ supports `herdr plugin link "$PWD"`. Rebuild after pulling changes.
 
-## Herdr setup with an installed binary
-
-Requires Herdr 0.9+ on PATH:
-
-```sh
-tsk setup herdr
-herdr server reload-config
-```
-
-Setup registers bundled plugin assets and the same stable installed binary, without
-a checkout or second build. It adds **prefix+t** for the board and **prefix+a** for
-quick capture, asking before replacing conflicts. Declining preserves the shortcut;
-a noninteractive conflict aborts without changes. Accepted builtin conflicts remove
-the override, restoring Herdr's default for that action. Successful config edits get a backup;
-failed linking leaves no backup file.
-
-Rerun setup after upgrading: it replaces the registration and removes the intact old
-managed asset root. Use the normal PATH command, not a versioned Homebrew Cellar path.
-Installation alone never relinks a plugin. To remove integration, run
-`herdr plugin unlink herdr-tsk`, remove its two command bindings, and reload Herdr.
-[Setup details and recovery](https://github.com/smarzban/herdr-tsk/blob/main/packaging/README.md#herdr-setup-and-upgrades).
-
-## Run and store
-
-Run `tsk` to open the board, or `tsk add -t "Draft release notes"` to capture from
-the CLI. Use one installation channel and reopen running boards after upgrading.
-An older binary may refuse a newer store format.
-
-Board and CLI share `~/.tsk/tsk.json`. Uninstalling the binary keeps task data.
-Use `TSK_STATE_DIR` / `TSK_CONFIG_DIR` to override state/config directories. Keep them
-on a local disk, not NFS or a synced folder, and use real directories, not symlinks.
-Herdr-injected plugin directories do not change where tsk stores tasks.
-
-On launch the board reads `update.json` in the state directory. If that check is
-older than 24 hours and `TSK_NO_UPDATE_CHECK` is unset, it `GET`s
-`https://api.github.com/repos/smarzban/herdr-tsk/releases/latest` and stores the
-`tag_name`. The request sends nothing else. A tag newer than this binary paints a
-dim `vX.Y.Z available` on the status row, behind any other status message or
-bottom input. Set `TSK_NO_UPDATE_CHECK` to skip the check and the notice.
-
-## Next
-
-[Board](/docs/board/) · [Keys](/docs/keys/) · [Capture](/docs/capture/)
+[Contributing](https://github.com/smarzban/herdr-tsk/blob/main/CONTRIBUTING.md) · [Storage and configuration](/docs/storage/)

--- a/site/src/content/docs/docs/keys.md
+++ b/site/src/content/docs/docs/keys.md
@@ -1,148 +1,125 @@
 ---
 title: Keys
-description: Board, task page, and capture key chords.
+description: Keyboard shortcuts by action and surface.
 ---
 
-Mutating keys need **Ctrl**. Bare letters do nothing, so typing in a focused
-board cannot complete or delete work.
+Use the mouse, the keyboard, or both. Tabs, selectors, tasks, and footer actions are clickable; double-click a task to open it.
 
-Nav, peek, `Enter`, `p`, `1` / `2` / `3`, `d`, `g`, `t`, `v`, `:`, `?`, `+`, and
-`Esc` stay bare.
-
-The web demo on the landing page uses bare verb letters on purpose. Browsers
-steal control chords. `g` only answers when the done drawer has a visible
-archived group.
-
-## Footer
-
-The footer is two rows under a rule. The **status row** carries context and feedback:
-`desk` on Desk, the project basename (and `#thread` when filtered) on a project
-board, `<name> · archived` in read-only archived focus, or the selected project's
-full path on the projects index. It also carries the last action's message, a delete
-notice, and at wide widths the stage crumb. The **verb row** is a prompt, not a
-keymap: the few things you are most likely to do next from where the cursor is, then
-the way out, then `? help`. Every surface reads the same shape, `open · status verbs
-· + add · ? help` on the board, `ctrl+e edit · status verbs · esc close` on the task
-page, `shift+enter save · esc cancel` while editing. Archive, delete, the drawer,
-the pickers and the palette are not seats: they live in `?` (every key, scrollable)
-and `:` (every action). A visible delete notice prefixes the board prompt with
-`ctrl+u undo`.
-
-## Wide stage slider
-
-At 110 usable columns or wider the board is a four-stage slider, and focus is the
-stage: **0** the board alone · **A** board beside the task page (board focus) ·
-**G** a dim rail beside the page (task focus) · **F** the page alone.
-
-| Stage | `→` | `←` | `Enter` | `Esc` | `j` `k` |
-| --- | --- | --- | --- | --- | --- |
-| 0 | → A | nothing | → F | nothing | select |
-| A | → G | → 0 | → F | nothing | select, retarget pane |
-| G | → F | → A | task-page verb | → A | task-page nav |
-| F | nothing | → G | task-page verb | → back where `Enter` left | task-page nav |
-
-`Enter` remembers the stage it left; `Esc` from F returns there. `Tab` is never a
-stage key. `→` never peeks at wide widths. Active task editors keep the field, step,
-and save keys listed below; the status row's right side names the keys that apply
-right now. Mouse clicks follow the same stage: a click in the stage A task column
-moves to G, then runs the control you clicked.
+Press `?` on the board for all shortcuts. Status and delete shortcuts use **Ctrl**; navigation uses bare keys. The website demo uses bare status keys because browsers reserve control chords.
 
 ## Board
 
-| Key | Does |
+| Action | Key |
 | --- | --- |
-| `j` `k` or `↑` `↓` | move selection |
-| wheel | scroll the list |
-| `ctrl+s` | start the selected task, or reopen it if it is done |
-| `ctrl+d` | done |
-| `ctrl+o` | reopen |
-| `ctrl+b` | toggle blocked ↔ ready |
-| `ctrl+r` | toggle review ↔ ready |
-| `Enter` | open the [task page](/docs/task-page/) full width (stage F at wide widths) |
-| `→` `←` | peek notes below 110 columns; at wide widths, slide the stage |
-| `+` | [quick-add](/docs/capture/) |
-| `ctrl+e` | edit title |
-| `ctrl+x` or `ctrl+Delete` | delete (`ctrl+u` undoes) |
-| `ctrl+f` | file: toggle the task's archived flag. No undo entry. In the picker, archives the selected project; on the picker's archived tab (or `ctrl+u` on an archived selection) it unarchives |
-| `Enter` on the picker's archived tab | open that project in read-only focus |
-| `ctrl+u` in read-only focus | unarchive that project in place |
-| `d` | done drawer |
-| `g` | fold or unfold the done drawer's `archived` group when it is visible |
-| `:` | command palette |
-| `?` | help: every key on one scrollable card (`↑` `↓`, `j` `k`, page keys, wheel); `Esc`, `?`, or `q` closes |
-| `p` | project picker |
-| `t` on a project | open its thread filter |
-| `v` on Projects | choose Overview or a thread across projects |
-| `1` `2` `3` | navigation: desk · selected project · projects |
-| `/` on Projects | focus the footer's `/ search` affordance; type or paste, then Enter opens the selected match and Esc clears and closes |
-| `Esc` | close one layer |
-| `ctrl+q` or `ctrl+c` | quit |
+| Select previous / next task | `↑` / `↓` or `k` / `j` |
+| Open task full screen | `Enter` |
+| Peek / close peek below 110 columns | `→` / `←` |
+| Move through wide views | `→` / `←` |
+| Add task | `+` |
+| Edit title | `ctrl+e` |
+| Start ready task; return done task to ready | `ctrl+s` |
+| Mark done | `ctrl+d` |
+| Set ready | `ctrl+o` |
+| Toggle blocked / ready | `ctrl+b` |
+| Toggle review / ready | `ctrl+r` |
+| Delete, with a second press to confirm | `ctrl+x` or `ctrl+Delete` |
+| Undo completion/deletion; restore an archived selection | `ctrl+u` |
+| Archive / restore selected task | `ctrl+f` |
+| Open / close done drawer | `d` |
+| Expand / collapse its archived group | `g` |
+| Desk / selected project / projects | `1` / `2` / `3` |
+| Project picker | `p` |
+| Project thread filter | `t` |
+| Cross-project view selector | `v` on Projects |
+| Search projects | `/` on Projects |
+| Command palette | `:` |
+| All shortcuts | `?` |
+| Close a layer | `Esc` |
+| Quit from board view | `ctrl+q` or `ctrl+c` |
 
-Click a dim task identifier (`T30`) to copy it. Click elsewhere on a row to peek, click it again to close, and fast double-click to open the page. On the projects index a click selects the row and a fast double-click opens the project.
-
-`Esc` closes one layer at a time.
+Done tasks cannot be blocked or sent to review until reopened. `ctrl+s` leaves started, blocked, and review tasks unchanged.
 
 ## Task page
 
-The page is view-first. Verbs still need the modifier, except Tab and arrows.
+These keys apply in **view mode**:
 
-| Key | Does |
+| Action | Key |
 | --- | --- |
-| `ctrl+e` | edit title, or start task editing with the highlighted step inline |
-| `ctrl+n` | edit notes |
-| `Tab` / `Shift+Tab` | in view, loop forward or backward through stored steps and `+ step`; in task editing, loop Title, Notes, stored steps, `+ step`, Scope, Thread |
-| `ctrl+a` | open an independent inline [step](/docs/steps/) editor from view or any task-edit focus |
-| `Enter` | on a stored step, toggles it done ↔ ready; in a new-step row saves it and opens the next empty row; parks an existing-step rename; opens Scope's picker; toggles Thread's selected text editor |
-| click a step | selects it in view, opens it inline only during task editing; click `   + step` to add from any page edit state |
-| `↓` `↑` | Down activates the first stored step, then arrows move selected steps; an open add row scrolls the page |
-| `ctrl+s` | start or reopen the task (never the step, even with one selected) |
-| `ctrl+d` / `ctrl+o` / `ctrl+b` / `ctrl+r` | complete / reopen / block / review the task |
-| `ctrl+x` | in view, first mark then remove a selected step on a second press; in task edit immediately hide and stage its removal, otherwise ask once then delete the task |
-| `Shift+Enter` | task-edit save, or save a new step and exit task editing. The only whole-session save chord; `Alt+Enter` does nothing on the board |
-| `Enter` in Title | move on to Notes |
-| `Esc` | cancel the field, restore staged task-edit changes, or close the page |
+| Select steps and **+ step** | `Tab` / `Shift+Tab` |
+| Activate first step, then move among steps | `↓`, then `↑` / `↓` |
+| Toggle selected step | `Enter` |
+| Add step | `ctrl+a` |
+| Edit title or selected step | `ctrl+e` |
+| Edit notes | `ctrl+n` |
+| Change task status | Board status shortcuts above |
+| Mark/remove selected step; otherwise confirm/delete task | `ctrl+x` |
+| Close task | `Esc` |
 
-Title, Notes, Thread, and Scope clicks are inert until task editing starts. Once it
-has, Title and Notes open their fields, Scope opens its picker, and Thread first
-selects, then opens or closes its text editor on a second click.
+Click a step to select it. Click **+ step** to add. Field clicks become editable only after task editing starts.
 
-## Any text field
+## Editing
 
-Title, notes, thread, step, and quick-add share one editor. The palette query takes
-only typing, arrows, Tab, Enter, Esc, and Backspace. The Projects overview search is focused with `/` or by clicking the footer's `/ search`
-affordance, shows its query and caret in that shared slot, and accepts letters, digits,
-Backspace, and paste.
-
-| Key | Does |
+| Action | Key |
 | --- | --- |
-| `ctrl+a` / `ctrl+e` | line start / end (on the task page `ctrl+a` adds a step instead) |
-| `ctrl+←` / `ctrl+→` | word left / right |
-| `Home` / `End` | line start / end |
-| `Backspace` / `Delete` | delete back / forward |
-| `↑` `↓` in notes | move between wrapped rows |
-| paste | inserts; line breaks stay in notes, elsewhere they become spaces |
+| Next / previous field | `Tab` / `Shift+Tab` |
+| Save task edit | `Shift+Enter` |
+| Cancel field | `Esc` or `ctrl+c` |
+| Move from Title to Notes | `Enter` in Title |
+| New line | `Enter` in Notes |
+| Add another step | `ctrl+a` on the task page |
+| Save new step and open next empty row | `Enter` in new step |
+| Retain existing-step rename in session | `Enter` in existing step |
+| Stage selected-step removal | `ctrl+x` in task edit |
+| Open Scope picker / confirm selection | `Enter` |
+| Cycle Scope | `Space` or `←` / `→` |
+| Open / close selected Thread editor | `Enter` |
+| Line start / end | `Home` / `End` |
+| Word left / right | `ctrl+←` / `ctrl+→` |
+| Delete backward / forward | `Backspace` / `Delete` |
+| Move through wrapped notes | `↑` / `↓` |
 
-## Palette, picker, and recovery
+`ctrl+e` moves to line end in text editors. `ctrl+a` moves to line start in quick-add; on the task page it adds a step instead. Paste preserves line breaks in Notes and converts them to spaces in single-line fields.
 
-| Surface | Keys |
+Editing keys take precedence over view-mode status shortcuts. In the step editor, `ctrl+d` and `ctrl+o` still address the task. `Alt+Enter` does not save the task edit.
+
+## Quick-add
+
+| Action | Key |
 | --- | --- |
-| `:` palette | type to filter · `↑` `↓` or `Tab` / `Shift+Tab` move · `Enter` run · `Esc` close |
-| `t` / `v` thread selectors | type or paste to filter (`j` and `k` are text) · arrows or `Tab` / `Shift+Tab` move · `Enter` choose · `Esc` close |
-| `p` project picker | `j` `k` or arrows · `Tab` main/archived tabs · `Enter` choose · `ctrl+f` archive (archived tab: unarchive) · `Esc` or `q` cancel |
-| launch card | `y` unarchive · `n` or `Esc` keep archived |
-| `?` help | `↑` `↓`, `j` `k`, page keys, wheel scroll · `Esc`, `?`, or `q` close |
-| save failed | `r` or `Enter` retry · `c` or `Esc` cancel |
+| Save and close | `Enter` |
+| Save and keep adding | `Shift+Enter` |
+| Expand details | `Tab` |
+| Cancel line / return from details | `Esc` |
 
-## Quick-add and quick capture
+In Herdr quick capture, `Shift+Enter` saves and closes the popup. `Esc` closes an active step editor or scope picker first; otherwise it discards the popup. During save recovery, it cancels the pending save. [Capture guide](/docs/capture/).
 
-| Key | Does |
+## Pickers
+
+| Surface | Controls |
 | --- | --- |
-| `Enter` on the `+` line | save and close |
-| `Shift+Enter` on the `+` line | save and stay open |
-| `Tab` on the `+` line | expand onto the task page (notes edit) |
-| `Esc` | close the line, or return to it from the expanded page |
+| Project picker | Arrows or `j`/`k` select; `Tab` or `←`/`→` switch tabs; `Enter` opens; `Esc` or `q` closes |
+| Project archive | `ctrl+f` archives; on archived tab, `ctrl+f` or `ctrl+u` restores |
+| Archived project view | `ctrl+u` restores; `Esc`, `p`, or `1`–`3` leaves |
+| Thread/view selector | Type or paste to filter; arrows or `Tab` select; `Enter` chooses; `Esc` closes |
+| Projects search | Type or paste; `Backspace` edits; `Enter` opens result; `Esc` clears and closes |
+| Palette | Type to filter; arrows or `Tab` select; `Enter` runs; `Esc` closes |
+| Help | Arrows, `j`/`k`, page keys, or wheel scroll; `Esc`, `?`, or `q` closes |
+| Archived-project launch prompt | `y` restores; `n` or `Esc` keeps archived |
+| Failed save | `r` or `Enter` retries; `c` or `Esc` cancels |
 
-The herdr quick-capture popup is that expanded page with the cursor in Title:
-`Shift+Enter` saves and closes the popup, `Esc` cancels and closes in one press. A
-failed save keeps the draft editable with retry/cancel. Editing keys are the task
-page's and the shared text-field set above.
+`j` and `k` are text in thread/view filters, not navigation.
+
+## Wide stage slider
+
+At 110 usable columns or wider, arrows move through these views when you are not editing:
+
+| View | `→` | `←` | `Esc` |
+| --- | --- | --- | --- |
+| Board | Split | No change | No change |
+| Split, board focused | Task with rail | Board | No change |
+| Task with rail | Full screen | Split | Split |
+| Full screen | No change | Task with rail | Return to the view remembered when opening |
+
+`Enter` from the board opens full screen and remembers the previous view. `Tab` navigates task fields or steps; it does not switch wide views.
+
+[Board views and mouse behavior](/docs/board/#wide-stage-slider).

--- a/site/src/content/docs/docs/steps.md
+++ b/site/src/content/docs/docs/steps.md
@@ -1,72 +1,71 @@
 ---
 title: Steps
-description: Flat checklists on a task, from the page and from the CLI.
+description: Add, check, rename, and remove checklist steps.
 ---
 
-A task can carry a flat, ordered list of steps. One level. No nesting. Each step
-has a stable id, one line of text, and a done flag.
+Steps are a flat, ordered checklist. Checking every step does not complete the task.
 
-Checking every step does **not** mark the task done. Steps are progress on the
-page, not a second status.
+## Add
 
-Markdown `- [ ]` in notes is ordinary text. Use steps for checklists.
+1. Open a task.
+2. Click **+ step**, or press `ctrl+a`.
+3. Type the step and press `Enter`.
 
-## On the task page
+`Enter` saves the step and opens another empty row. `Shift+Enter` saves it and finishes any active task edit. Click elsewhere to discard an empty new-step row.
 
-Open the task with `Enter`. The step cursor begins inactive. In view mode, `Tab`
-and `Shift+Tab` cycle stored steps and the trailing dim `+ step` target without
-leaving task view. The target sits immediately below the final stored step as `   + step`.
-`Enter`, `ctrl+a`, or a click on it opens an independent new-step editor, it does not
-start task editing. `ctrl+a` also opens that editor from every task-edit field or
-inline step state.
+New steps save independently, including during task editing. Cancelling the task edit does not undo steps already added.
 
-- `Enter` on a selected stored step toggles it done ↔ ready
-- `ctrl+s`, `ctrl+d`, `ctrl+o`, `ctrl+b`, `ctrl+r` act on the task, never the step
-- `ctrl+e` on a selected stored step starts task editing and opens it inline
-- In task editing, Tab runs Title, Notes, stored steps, `+ step`, Scope, Thread
-- Reaching a stored step through Tab or arrows opens its inline editor
-- `ctrl+x` in view first marks the selected step and the second press removes it,
-  while task editing immediately hides and stages its removal until save
+## Complete
 
-The section is labelled `steps <done>/<total>`. Rows paint `▪` open, `✓` done, and
-`✗` while a step is marked for removal.
+Select a step with a click, `Tab`, or the arrows. Press `Enter` to check or uncheck it.
 
-A new-step draft lives in the steps section. From view or task edit, it persists
-independently: it never joins the enclosing task edit session. Plain `Enter` saves one new
-step and opens the next empty editor. `Shift+Enter` saves that step and the enclosing
-task-edit session. An empty new-step row discards if you click elsewhere. Existing-step
-renames and removals are staged with Title, Notes, Thread, and Scope. Plain `Enter` parks
-an existing-step rename in that session, then `Shift+Enter` saves all staged changes
-(the only session save chord; `Alt+Enter` does nothing on the board). `Esc` cancels a
-field; Esc from task
-editing restores staged removals. A failed save keeps its drafts until you retry or cancel.
+| Mark | Meaning |
+| --- | --- |
+| `▪` | Open |
+| `✓` | Done |
+| `✗` | Marked for removal |
 
-Wheel still scrolls the page. Bare `↓` activates the first stored step, then arrows
-move the selected stored step. In an existing-step editor, arrows move among stored
-steps and stage the prior draft; in an add editor, arrows scroll the shared page
-without closing or trapping that row.
+The heading shows completed/total steps. In view mode, status shortcuts change the task, not the selected step.
 
-## From the CLI
+## Rename
 
-```bash
-tsk steps <task> add "Write the failing test"
-tsk steps <task> toggle <step-short-id>
-tsk steps <task> rename <step-short-id> "Pin the saved id"
-tsk steps <task> remove <step-short-id>
-tsk list <task>
+1. Select a step and press `ctrl+e`.
+2. Edit its text.
+3. Press `Shift+Enter` to save the task edit.
+
+`Enter` retains the rename in the edit session without saving that session. Moving to another existing step retains the previous draft. `Esc` cancels the field; cancelling task editing restores staged changes.
+
+## Remove
+
+| Mode | Action |
+| --- | --- |
+| Task view | Select a step; press `ctrl+x` to mark it, then again to remove it |
+| Task editing | Select a step; `ctrl+x` stages removal; `Shift+Enter` saves |
+
+Cancelling task editing restores staged removals.
+
+## Navigate
+
+- In view mode, `Tab` / `Shift+Tab` cycle steps and **+ step**.
+- `↓` activates the first stored step; arrows then move between steps.
+- During task editing, `Tab` includes the task fields.
+- While adding a step, arrows scroll the page.
+- Wheel and scrollbar remain available during editing.
+
+## CLI
+
+Use the task number and the step's short ID from `tsk list`:
+
+```sh
+tsk list T12
+tsk steps T12 add "Reproduce the timeout"
+tsk steps T12 toggle <step-short-id>
+tsk steps T12 rename <step-short-id> "Reproduce on a slow connection"
+tsk steps T12 remove <step-short-id>
 ```
 
-The task is a store-global number (`T12`, `t12`, or bare `12`) or a UUID from
-`tsk add --json` or `tsk list --json`. Direct lookup ignores cwd.
+A short ID is the shortest unique prefix of a step ID. Full UUIDs also work.
 
-A step short id is the shortest unambiguous prefix of that step's id, as printed
-by `tsk list <task>`.
+Read the task before retrying an uncertain change. Repeating `add` adds another step; repeating `toggle` reverses it; repeating `remove` refuses after success. Repeating the same rename is safe.
 
-`toggle` flips the flag. A blind retry after an unseen success flips it back.
-`rename` is idempotent on the trimmed text. `remove` is not: a retry after an
-unseen success is `unknown-step`. Verify with `tsk list <task>` before retrying
-toggle or remove.
-
-Soft-deleted tasks refuse step changes.
-
-Full flags and exit codes: [CLI](/docs/cli/).
+Deleted tasks refuse step changes. [CLI errors and exit codes](/docs/cli/#exit-contract).

--- a/site/src/content/docs/docs/storage.md
+++ b/site/src/content/docs/docs/storage.md
@@ -1,0 +1,55 @@
+---
+title: Storage
+description: Task data, backups, deleted tasks, and update checks.
+---
+
+The board, CLI, and Herdr plugin share `~/.tsk/tsk.json`.
+
+## Location
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `TSK_STATE_DIR` | `~/.tsk` | Task data, backups, trash, and release-check cache |
+| `TSK_CONFIG_DIR` | `~/.tsk` | Walkthrough preferences |
+| `--state-dir <dir>` | State directory | Override storage for a data command |
+
+Use a local disk. NFS and synced folders such as Dropbox or iCloud Drive are unsupported. Directory roots must be real directories, not symlinks.
+
+Herdr's plugin-specific state/config directories do not override these locations. Removing tsk leaves its task data intact.
+
+## Backups
+
+| File | Contains |
+| --- | --- |
+| `tsk.json` | Current tasks and archived-project records |
+| `tsk.json.1` | Previous valid task document |
+| `tsk.json.v<N>` | Backup made when migrating an older store format |
+| `walkthrough.json` | Whether onboarding was dismissed |
+
+An older binary refuses a newer or unversioned store instead of rewriting it. Use a compatible tsk version to open it.
+
+Archived tasks stay in the task document with their existing status. [Archive and restore](/docs/board/#archive).
+
+## Deleted tasks
+
+Deleted tasks move to `trash.jsonl` once undo can no longer restore them, or after seven days. They are purged 30 days after deletion.
+
+```sh
+tsk list --deleted --all
+tsk trash restore T12
+```
+
+The list includes both recently deleted tasks still in the main store and tasks in trash. Restore reads trash; use board undo for a recent deletion that has not moved there yet.
+
+## Update check
+
+On launch, tsk checks for a newer release if its cached check is older than 24 hours. A newer version appears on the board's idle status row.
+
+| Setting or file | Purpose |
+| --- | --- |
+| `TSK_NO_UPDATE_CHECK` | Set to disable the check and notice |
+| `update.json` | Cached release check in the state directory |
+
+The check requests the latest release tag from GitHub. It does not upload task data. Failures are silent.
+
+[Upgrade tsk](/docs/install/#upgrade).

--- a/site/src/content/docs/docs/task-page.md
+++ b/site/src/content/docs/docs/task-page.md
@@ -1,91 +1,87 @@
 ---
 title: Task page
-description: "View and edit one task: title, notes, thread, and scope."
+description: Read and edit a task's title, notes, project, and thread.
 ---
 
-Below 110 usable columns, `Enter` opens the selected task full height. At 110
-usable columns or wider the page is the right column of the
-[stage slider](/docs/board/#wide-stage-slider): a preview beside the board in stage
-A, the focused page beside a dim rail in G, or the whole frame in F. Its header sits
-on the selector row, `● T12 title … started · tsk` with the status glyph restored,
-dim in A and bold in G and F, and a dash rule on the row under it.
-With no selection the column reads `no task` and is inert. `←` from G parks the page
-beside the board without resetting page scroll or the step cursor; `→` brings it back.
+Read notes and steps, then edit the task when you need to change it.
 
-The dim `T30` prefix in the header copies that task identifier when clicked. A click
-inside the stage A task column moves to G before running the same action the control
-has in the single-pane page. The footer reads `scope · #thread · created … · updated …`. In a wide column
-the project lives in the header slot and the scope slot shows only while an edit
-session can change it.
+## Open
 
-It is view-first. Nothing is in edit mode until you ask. `ctrl+e` edits the title,
-`ctrl+n` edits notes. In view, Tab and Shift+Tab loop only through stored steps and
-`+ step`, never task fields. The trailing dim target paints as `   + step`. `Enter`,
-`ctrl+a`, or a click on it opens its independent editor, then Enter saves one step
-and opens the next empty step editor.
+Double-click a task or select it and press `Enter`.
 
-Bare `↓` activates the first stored step, then arrows move the selection. `Enter` on
-that selected step toggles it done ↔ ready without changing the task's human status.
-The status verbs (`ctrl+s`, `ctrl+d`, `ctrl+o`, `ctrl+b`, `ctrl+r`) always act on the
-task, whatever the step cursor is doing.
+At 110 usable columns or wider, `→` opens details beside the board. Use `→` and `←` to move between [board and task views](/docs/board/#wide-stage-slider). Press `Enter` from the board for full screen; `Esc` returns.
 
-`ctrl+e` on a stored-step selection starts task editing with the step inline. In task
-editing, Tab runs Title, Notes, stored steps, `+ step`, Scope, Thread, then Title.
-Shift+Tab reverses that same loop. Clicking a field or another existing step moves
-the one active text cursor there and stages the prior step change. Scope and Thread
-first show as selected controls, with no blinking cursor. `Enter` on Scope opens its
-picker and `Enter` again chooses the highlighted scope. `Enter` on Thread, or a
-second click, opens or closes its text editor without leaving the task edit session.
-The scope footer does nothing until task editing starts.
+Click the task's `T` number to copy it. The page shows its status, notes, steps, project, thread, and dates. Long text wraps.
 
-Plain `Enter` parks an existing-step rename without saving the task session, and in
-the Title editor it moves on to Notes. `Shift+Enter` is the one task-session save
-chord: it saves Title, Notes, Thread, Scope, staged existing-step edits, and staged
-removals, then exits editing. `Alt+Enter` does nothing on the board. A staged
-`ctrl+x` removal disappears immediately and returns if task editing is cancelled. New
-steps save independently from view or task edit: Enter saves one and opens the next empty
-editor, Shift+Enter saves that step and the task-edit session. An empty new-step row
-discards if you click elsewhere. Field `Esc` cancels that
-field, while Esc from task editing restores staged removals.
+## Edit
 
-Notes are multiline, so `Enter` inserts a line. `Shift+Enter` saves and does not
-insert a line. Mouse-wheel scrolling and the page scrollbar work during field editing,
-so long notes do not hide `+ step`. Scrolling leaves the draft intact; typing or
-moving the Notes cursor brings it back into view.
+The page opens in view mode.
 
-Thread uses the same name rules as capture `!t`. The field is optional.
+| Action | Key |
+| --- | --- |
+| Edit title, or the selected step | `ctrl+e` |
+| Edit notes | `ctrl+n` |
+| Move through editable fields | `Tab` / `Shift+Tab`, after starting an edit |
+| Save the task edit | `Shift+Enter` |
+| Cancel the current field | `Esc` or `ctrl+c` |
 
-While an edit is unsaved, moving the selection to another task refuses with
-`save or cancel edits before switching tasks`. Saving a task that another writer
-deleted meanwhile answers `that task is deleted`. An empty step paints
-`text required` on its own row.
+Clicking Title, Notes, Scope, or Thread does not start an edit from view mode. Start editing first; then click the field you want.
+
+In view mode, `Tab` selects steps and **+ step**. It does not cycle task fields.
+
+During task editing, the order is Title → Notes → steps → **+ step** → Scope → Thread. A field click moves the cursor and retains staged changes.
+
+## Scope and thread
+
+**Scope** is the task's project or desk. **Thread** groups related work within a project.
+
+| Field | Change it |
+| --- | --- |
+| Scope | Select it while editing, press `Enter`, choose a destination, then `Enter` again |
+| Thread | Select it, then press `Enter` or click again to edit its name |
+
+Scope also supports cycling with `Space`, `←`, or `→`. Archived projects are not offered.
+
+Thread is optional and follows the [thread name rules](/docs/capture/#thread-names).
+
+## Save
+
+`Shift+Enter` saves the task's title, notes, scope, thread, and staged changes to existing steps.
+
+| While editing | `Enter` does this |
+| --- | --- |
+| Title | Move to Notes |
+| Notes | Insert a line |
+| Existing step | Keep the rename in the current edit session |
+| New step | Save that step and open another empty row |
+
+New steps save independently. Cancelling the task edit does not remove new steps already saved. [Step editing details](/docs/steps/).
+
+Press `Esc` to discard changes to the current field. Other staged changes remain until you save or cancel the task edit. Cancelling the task edit also restores removed steps. Save or cancel before selecting a different task.
+
+If another writer deletes the task, saving refuses. If a save fails, use [retry or cancel](/docs/board/#save-failures).
+
+## Status and steps
+
+In task view, status shortcuts act on the task even when a step is selected. `Enter` toggles the selected step only.
+
+While editing a field, use its edit keys. Save or cancel to return to the task's status actions.
+
+Scroll with the wheel or scrollbar while editing. Typing or moving the Notes cursor brings it back into view.
 
 ## Notes markdown
 
-View and peek style a small markdown subset. Edit is always the raw source. No
-color.
+Notes display basic Markdown. Editing shows the original text.
 
-| Marker | Paint |
+| Write | Display |
 | --- | --- |
-| `**bold**` | bold |
-| `*em*` or `_em_` | underline |
-| `` `code` `` | dim, ticks kept |
-| `#` … `######` | bold + underline, dim hashes |
-| `-` or `*` lists | dim bullet |
-| fenced ` ``` ` | dim fence and body, no inline inside |
+| `**bold**` | Bold |
+| `*emphasis*` or `_emphasis_` | Underlined |
+| `` `code` `` | Dim, with backticks |
+| `# Heading` through `###### Heading` | Bold and underlined |
+| `- item` or `* item` | List |
+| Triple-backtick fenced block | Dim block; inline styling disabled |
 
-Unmatched `*` and word-internal `_` stay literal. `- [ ]` stays text.
-[Steps](/docs/steps/) own checklists.
+Unmatched asterisks and underscores inside words stay literal. Markdown checkboxes such as `- [ ]` are text; use [steps](/docs/steps/) for an interactive checklist.
 
-Peek paints the same markers, then dims every span, with a `│` gutter closed by
-an L-shaped `└` connector.
-
-## Peek vs page
-
-Below 110 columns, `→` or a row click peeks up to five wrapped note lines, then
-`… N more lines` if there are more, or `no notes yet`. At wide widths, selection
-updates the task column and no inline peek opens.
-
-Text on the page wraps. It does not truncate.
-
-See [keys](/docs/keys/) for the full chord table.
+Peeks use the same formatting, dimmed. Narrow-pane peeks show up to five wrapped lines; open the task for the full notes.

--- a/site/src/lib/agent-docs.mjs
+++ b/site/src/lib/agent-docs.mjs
@@ -10,14 +10,15 @@ export const DEFINITION_SENTENCE =
   "tsk is a terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them.";
 export const SIDEBAR_SLUGS = [
   "index",
-  "agents",
   "install",
   "board",
   "keys",
   "capture",
   "task-page",
   "steps",
+  "agents",
   "cli",
+  "storage",
 ];
 export const SOURCE_REPO_BASE = "https://github.com/smarzban/herdr-tsk/blob/main";
 export const AGENTS_SKILL_REPO_PATH = "skills/tsk-cli/SKILL.md";

--- a/site/test/agent-surface.test.mjs
+++ b/site/test/agent-surface.test.mjs
@@ -210,14 +210,15 @@ const DEFINITION_SENTENCE =
 
 const SIDEBAR_TITLES = [
   "Overview",
-  "tsk for agents",
   "Install",
   "Board",
   "Keys",
   "Capture",
   "Task page",
   "Steps",
+  "tsk for agents",
   "CLI",
+  "Storage",
 ];
 
 test("llms_txt_is_under_60_lines_starts_with_definition_sentence_and_has_no_key_chords", async () => {
@@ -304,12 +305,11 @@ test("docs_jsonld_is_tech_article_with_headline_description_date_and_is_part_of"
   }
 });
 
-test("definition_sentence_appears_verbatim_in_index_astro_llms_txt_docs_index_and_readme", async () => {
+test("definition_sentence_appears_in_discovery_surfaces_and_readme_keeps_the_tagline", async () => {
   const files = [
     join(siteRoot, "src/pages/index.astro"),
     join(siteRoot, "public/llms.txt"),
     join(docsDir, "index.mdx"),
-    join(repoRoot, "README.md"),
   ];
   for (const filePath of files) {
     const text = await read(filePath);
@@ -318,6 +318,8 @@ test("definition_sentence_appears_verbatim_in_index_astro_llms_txt_docs_index_an
       `${filePath} is missing the definition sentence`,
     );
   }
+  const readme = await read(join(repoRoot, "README.md"));
+  assert.ok(readme.includes("A terminal task board for you and your agents: one shared queue, a TUI for you, a CLI for them."));
 });
 
 const NOTICE =
@@ -384,4 +386,3 @@ test("npm_start_and_deploy_paths_watch_the_skill", async () => {
   const vercelJson = JSON.parse(await read(join(siteRoot, "vercel.json")));
   assert.match(String(vercelJson.ignoreCommand), /\.\.\/skills/);
 });
-

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -94,13 +94,13 @@ test("docs and demo describe the wide stage slider and threshold", async () => {
 
   assert.match(board, /110 usable columns/);
   assert.match(board, /four-stage slider/);
-  assert.match(board, /\| G \| dim rail, 32 columns \| task page \| task \|/);
+  assert.match(board, /\| Task \| Task details beside a narrow board rail \|/);
   assert.doesNotMatch(board, /bordered|cyan/);
   assert.match(keys, /Wide stage slider/);
-  assert.match(keys, /\| F \| nothing \| → G \|/);
+  assert.match(keys, /\| Full screen \| No change \| Task with rail \|/);
   assert.doesNotMatch(keys, /cyan/);
   assert.match(taskPage, /110 usable columns/);
-  assert.match(taskPage, /● T12 title … started · tsk/);
+  assert.match(taskPage, /Click the task's `T` number to copy it/);
   assert.doesNotMatch(taskPage, /bordered panel/);
   assert.match(demo, /const WIDE_SPLIT_MIN_COLUMNS = 110;/);
   assert.match(demo, /function stageRight\(\)/);
@@ -194,7 +194,7 @@ test("attribution is peek-only in demo and static anatomy", async () => {
   assert.doesNotMatch(guide, /section headers, row meta/);
 });
 
-test("quickstarts use the installer, optional Herdr setup, and task capture", async () => {
+test("quickstarts use the installer, Herdr setup, and task capture", async () => {
   for (const file of ["../../README.md", "../src/content/docs/docs/install.md", "../src/pages/index.astro"]) {
     const text = await read(file);
     assert.ok(text.includes("curl -fsSL https://gettsk.sh/install.sh | sh"), file);

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -48,9 +48,11 @@ persist and the command exits 1.
   `existing` items both succeeded, so you must never whole-plan-retry an exit 1 run.
 - exit 2: usage or parse error, nothing persisted. Correct the invocation, then run it.
 - exit 3: store I/O, commit indeterminate. Run `tsk list --all --json` to
-  check every scope, then retry only missing work. You must never whole-plan-retry an exit 3 run.
+  check open work across scopes. Also check `--done` and `--archived` if a matching
+  task could be hidden there; use direct lookup when its number is known. Retry
+  only missing work. Never whole-plan-retry an exit 3 run.
 
-Add is idempotent by trimmed title and resolved project scope. A non-soft-deleted
+Add is idempotent by trimmed title, resolved project scope, and normalized thread. A non-soft-deleted
 matching task is a success: plain flag add prints `task already exists`, and plan add
 reports it in `existing` with its `i`, `id`, and `title`.
 


### PR DESCRIPTION
The user guides mixed everyday actions with long implementation and storage explanations. This rewrite uses short instructions and reference tables, groups navigation into getting started, everyday use, and reference, and moves storage details to their own page.

Adds the agreed “No project setup needed” explanation to the README and Overview, with project-path examples in the Overview. Directory-default wording matches the behavior described in #57. Corrects the embedded agent guide’s deduplication and uncertain-write lookup guidance.

Validation:
- Site build and all 42 site tests passed.
- 481 internal links and anchors checked; 58 feature sections accounted for.
- Desktop and mobile layout checks passed across all ten pages before the final short project explanation was added; site build and tests were rerun afterward.
- Rust formatting and Clippy passed. Core unit tests and completed integration tests passed, but the full suite stalled in the macOS loader before test execution, including outside the sandbox. Full Rust validation and release build remain incomplete locally; CI must pass before merge.
