### PR TITLE
feat(site): replace why pillars with a five-whys chain

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -310,47 +310,72 @@ const softwareApplication = {
             <span class="index">02 <span class="index-label">why</span></span>
             <h2 id="why-heading">Not another to-do app.</h2>
             <p class="band-lede">
-              tsk is the shared surface between a developer and the agents working beside
-              them. It lives in the pane you already have open. No browser tab, no sync
-              service, no form takeover.
+              Start from the failure. Your agent ends a session. Two tasks are blocked, one
+              wants a review, and you find out tomorrow. Each why below is the cause of the
+              one above it.
             </p>
           </header>
 
-          <div class="pillars">
-            <article class="pillar">
-              <h3>Capture never leaves the list.</h3>
+          <ol class="pillars is-chain" aria-label="Five whys">
+            <li class="pillar">
+              <h3>Why isn't a to-do app enough?</h3>
               <p>
-                <kbd>+</kbd> opens one line on the status row. <kbd>Enter</kbd> saves,
-                <kbd>Shift+Enter</kbd> keeps the line open, <kbd>Tab</kbd> expands onto the task
-                page. Two tokens set project and thread from inside the title.
+                You and the agent both plan, pick up, and finish work. A personal list is a tab
+                the agent cannot open. tsk is one board both of you write: a TUI for you,
+                <code>tsk add</code>, <code>tsk list</code>, <code>tsk status</code>, and
+                <code>tsk steps</code> for them.
+              </p>
+            </li>
+
+            <li class="pillar">
+              <h3>Why isn't the chat the board?</h3>
+              <p>
+                A transcript has no <b>ready</b>, <b>started</b>, <b>blocked</b>, <b>review</b>,
+                or <b>done</b>. It has no <code>T12</code> you can click to copy and paste into
+                the agent. A checklist in a reply dies with the session. The board keeps the
+                number, the status, and the steps.
+              </p>
+            </li>
+
+            <li class="pillar">
+              <h3>Why isn't a web tracker the board?</h3>
+              <p>
+                The work is already in a pane. In Herdr, prefix+t opens the board and prefix+a
+                opens capture. <code>tsk</code> also runs standalone. <kbd>+</kbd> opens one
+                line on the status row. <kbd>Enter</kbd> saves, <kbd>Shift+Enter</kbd> keeps
+                the line open, <kbd>Tab</kbd> expands onto the task page. Two tokens in the
+                title set project and thread. You never leave the list to add to it.
               </p>
               <pre class="mini" aria-label="Quick-add example"><span class="prompt">+</span> Fix the flaky bench <span class="tok">!p</span> tsk <span class="tok">!t</span> ci<span class="cursor" aria-hidden="true">█</span>
 <span class="dim">enter save · shift+enter stay · tab page · esc close</span></pre>
-            </article>
+            </li>
 
-            <article class="pillar">
-              <h3>Nothing completes itself.</h3>
+            <li class="pillar">
+              <h3>Why isn't a markdown file the board?</h3>
               <p>
-                Every mutating verb needs <kbd>Ctrl</kbd>. Bare letters do nothing, so a stray
-                keystroke in a focused board cannot finish or delete work. Undo is one chord
-                away.
+                A file is not a board. There is no NEEDS YOU, IN MOTION, or ON DECK. Whoever
+                writes the file can mark the work done. Checking every step on tsk leaves the
+                task status unchanged. You press <kbd>ctrl+d</kbd>, or the agent runs
+                <code>tsk status T12 done</code>. Mutating keys need <kbd>Ctrl</kbd>. Bare
+                letters do nothing.
               </p>
               <pre class="mini" aria-label="Verb bar"><span class="dim">enter</span> open · <span class="dim">ctrl+d</span> done · <span class="dim">ctrl+b</span> block · <span class="dim">:</span> palette
 <span class="dim">ctrl+x</span> delete · <span class="dim">ctrl+u</span> undo · <span class="dim">?</span> help · <span class="dim">+</span> capture</pre>
-            </article>
+            </li>
 
-            <article class="pillar">
-              <h3>One store. Everyone at the table.</h3>
+            <li class="pillar">
+              <h3>Why a file on disk, then?</h3>
               <p>
-                You, herdr's quick-capture popup, and your agents edit the same
-                <code>~/.tsk</code>. An agent drops a plan in as JSON and the board shows it on
-                the next tick.
+                The TUI, the CLI, and Herdr's capture popup all edit <code>~/.tsk/tsk.json</code>.
+                No account. No sync service. An agent pipes a plan in as JSON and the next
+                board tick shows it. Human status is the source of truth on that file. That is
+                the root.
               </p>
               <pre class="mini" aria-label="Three ways in"><span class="prompt">$</span> cat plan.json | tsk add
 <span class="dim">&#123; "created": [T33, T34, T35], "existing": [], "failed": [] &#125;</span>
 <span class="prompt">$</span> herdr plugin action invoke quick-capture --plugin herdr-tsk</pre>
-            </article>
-          </div>
+            </li>
+          </ol>
         </div>
       </section>
 

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -1711,6 +1711,57 @@ html[data-theme="light"] .pane {
   white-space: pre-wrap;
 }
 
+ol.pillars.is-chain {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  grid-template-columns: 1fr;
+  gap: 0;
+  background: transparent;
+  border: none;
+  overflow: visible;
+}
+
+.pillars.is-chain > .pillar {
+  --chain-indent: 0;
+  background: transparent;
+  padding-left: 1.25rem;
+  margin-left: var(--chain-indent);
+}
+
+.pillars.is-chain > .pillar:nth-child(2) {
+  --chain-indent: 1.15rem;
+}
+
+.pillars.is-chain > .pillar:nth-child(3) {
+  --chain-indent: 2.3rem;
+}
+
+.pillars.is-chain > .pillar:nth-child(4) {
+  --chain-indent: 3.45rem;
+}
+
+.pillars.is-chain > .pillar:nth-child(5) {
+  --chain-indent: 4.6rem;
+}
+
+.pillars.is-chain > .pillar:not(:first-child) {
+  border-left: 1px solid var(--line);
+}
+
+.pillars.is-chain > .pillar:last-child {
+  position: relative;
+}
+
+.pillars.is-chain > .pillar:last-child::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 1.4rem;
+  width: 0.7rem;
+  border-bottom: 1px solid var(--line);
+}
+
 /* ── 03 · board anatomy ──────────────────────────────────────────────────── */
 
 .anatomy {
@@ -2332,6 +2383,22 @@ html[data-theme="light"] .pane {
 
   .pillars {
     grid-template-columns: 1fr;
+  }
+
+  ol.pillars.is-chain {
+    border-left: 1px solid var(--line);
+  }
+
+  .pillars.is-chain > .pillar {
+    --chain-indent: 0;
+  }
+
+  .pillars.is-chain > .pillar:not(:first-child) {
+    border-left: 0;
+  }
+
+  .pillars.is-chain > .pillar:last-child::after {
+    content: none;
   }
 
   .anatomy,

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -1729,37 +1729,39 @@ ol.pillars.is-chain {
   margin-left: var(--chain-indent);
 }
 
-.pillars.is-chain > .pillar:nth-child(2) {
-  --chain-indent: 1.15rem;
-}
+@media (min-width: 961px) {
+  .pillars.is-chain > .pillar:nth-child(2) {
+    --chain-indent: 1.15rem;
+  }
 
-.pillars.is-chain > .pillar:nth-child(3) {
-  --chain-indent: 2.3rem;
-}
+  .pillars.is-chain > .pillar:nth-child(3) {
+    --chain-indent: 2.3rem;
+  }
 
-.pillars.is-chain > .pillar:nth-child(4) {
-  --chain-indent: 3.45rem;
-}
+  .pillars.is-chain > .pillar:nth-child(4) {
+    --chain-indent: 3.45rem;
+  }
 
-.pillars.is-chain > .pillar:nth-child(5) {
-  --chain-indent: 4.6rem;
-}
+  .pillars.is-chain > .pillar:nth-child(5) {
+    --chain-indent: 4.6rem;
+  }
 
-.pillars.is-chain > .pillar:not(:first-child) {
-  border-left: 1px solid var(--line);
-}
+  .pillars.is-chain > .pillar:not(:first-child) {
+    border-left: 1px solid var(--line);
+  }
 
-.pillars.is-chain > .pillar:last-child {
-  position: relative;
-}
+  .pillars.is-chain > .pillar:last-child {
+    position: relative;
+  }
 
-.pillars.is-chain > .pillar:last-child::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: 1.4rem;
-  width: 0.7rem;
-  border-bottom: 1px solid var(--line);
+  .pillars.is-chain > .pillar:last-child::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: 1.4rem;
+    width: 0.7rem;
+    border-bottom: 1px solid var(--line);
+  }
 }
 
 /* ── 03 · board anatomy ──────────────────────────────────────────────────── */
@@ -2387,18 +2389,6 @@ ol.pillars.is-chain {
 
   ol.pillars.is-chain {
     border-left: 1px solid var(--line);
-  }
-
-  .pillars.is-chain > .pillar {
-    --chain-indent: 0;
-  }
-
-  .pillars.is-chain > .pillar:not(:first-child) {
-    border-left: 0;
-  }
-
-  .pillars.is-chain > .pillar:last-child::after {
-    content: none;
   }
 
   .anatomy,

--- a/site/test/site.test.mjs
+++ b/site/test/site.test.mjs
@@ -194,6 +194,16 @@ test("attribution is peek-only in demo and static anatomy", async () => {
   assert.doesNotMatch(guide, /section headers, row meta/);
 });
 
+test("why band is five substitute pillars in one chain", async () => {
+  const page = await read("../src/pages/index.astro");
+  const why = page.match(/<section class="band band-alt" id="why"[\s\S]*?<\/section>/)?.[0];
+  assert.ok(why, "expected the #why band");
+  const chain = why.match(/<ol class="pillars is-chain"[^>]*>[\s\S]*?<\/ol>/)?.[0];
+  assert.ok(chain, "expected #why .pillars.is-chain");
+  const pillars = chain.match(/<li class="pillar">/g) ?? [];
+  assert.equal(pillars.length, 5);
+});
+
 test("quickstarts use the installer, Herdr setup, and task capture", async () => {
   for (const file of ["../../README.md", "../src/content/docs/docs/install.md", "../src/pages/index.astro"]) {
     const text = await read(file);


### PR DESCRIPTION
## Why

The landing `#why` band listed three peer product traits. Visitors who already have a task app, a chat log, or a markdown file did not get a causal answer for why work should move into tsk.

This PR turns that band into a nested five-whys substitute chain: to-do app, chat, web tracker, markdown file, then the root at `~/.tsk/tsk.json`. The three shipped mini samples stay, reassigned to the rungs that need them. The band stays landing-only so docs, README, and `llms.txt` do not gain a second copy to drift.

## Scope

- `site/src/pages/index.astro` `#why` band markup and copy
- `site/src/styles/landing.css` `.pillars.is-chain` layout (wide stepped indent, narrow left rule)
- `site/test/site.test.mjs` asserts exactly five chain pillars

Out of scope: docs page, README, `llms.txt`, board demo, Rust binary.

## Tradeoffs

- Rejected five parallel cards / a 3+2 grid. Peers are not whys, and mid widths leave a hole.
- Rejected a `/docs/why/` mirror. A second surface buys drift for little value on short explanation copy.
- The band is taller and must be read top to bottom. That is the point of the form.

## Blast Radius

Site landing only. Site CI exercises the new count test. No board or CLI behavior changes.

## Verification

- `cd site && npm test` → 43/43, including `why band is five substitute pillars in one chain`
- `cd site && npm run build` succeeded on the feature commit
- Confirmed and fixed a CSS specificity bug where `nth-child` indent beat the 960px reset; indent now lives under `min-width: 961px`
- Live herdr smoke not run (`HERDR_ENV` unset; site-only change)
- Painted layout not confirmed in a browser in this session