### PR TITLE
feat(board): seed selected release announcement notices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,17 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   lost record converges without duplicates. `ctrl+d`, `ctrl+f`, and `ctrl+x` on a notice
   share one dismiss rule: the persist boundary marks its catalog id and it never re-seeds.
   Seed and dismiss are silent; neither writes `status_message`.
+- Release announcements (`src/announcements.rs`) are the maintainer-edited
+  `src/announcements/catalog.toml`, compiled in with `include_str!`: `[[announcement]]` tables
+  with exactly `id`, `title`, `notes`; ids positive and increasing in file order; the
+  changelog link lives in `notes`, never in `title` (the parser refuses otherwise). Append one
+  entry per release worth a row. `seed_on_open` runs right after the guide seed on the full
+  board open: it takes the higher of `delivery.announcement_watermark` and any `announce.<id>`
+  notice in the store as "seen"; seen `0` is a fresh install, which jumps the watermark to the
+  bundled maximum and creates nothing; otherwise every entry above seen becomes one desk
+  notice `What's new in tsk` (catalog id `announce.<max>`, notes newest first) and the
+  watermark moves to the maximum. Nobody ever sees the entries bundled with the binary that
+  introduced their install.
 - Store format is versioned (`STORE_FORMAT_VERSION`, currently 3). Any schema change bumps it
   and adds a `vN → vN+1` step to `MIGRATIONS` in `src/store.rs`; `deny_unknown_fields` stays on
   `Task` and `DomainState` so an older binary refuses a newer file instead of dropping fields.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,11 +264,12 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   changelog link lives in `notes`, never in `title` (the parser refuses otherwise). Append one
   entry per release worth a row. `seed_on_open` runs right after the guide seed on the full
   board open: it takes the higher of `delivery.announcement_watermark` and any `announce.<id>`
-  notice in the store as "seen"; seen `0` is a fresh install, which jumps the watermark to the
-  bundled maximum and creates nothing; otherwise every entry above seen becomes one desk
-  notice `What's new in tsk` (catalog id `announce.<max>`, notes newest first) and the
-  watermark moves to the maximum. Nobody ever sees the entries bundled with the binary that
-  introduced their install.
+  notice in the store as "seen". A blank state checked before guide seeding (watermark 0, no
+  delivered guide ids, no live tasks) is a fresh install: jump the watermark to the bundled
+  maximum and create nothing. Otherwise every entry above seen becomes one desk notice
+  `What's new in tsk` (catalog id `announce.<max>`, notes newest first) and the watermark
+  moves to the maximum. That includes upgrading from a guides-only install whose watermark
+  is still 0.
 - Store format is versioned (`STORE_FORMAT_VERSION`, currently 3). Any schema change bumps it
   and adds a `vN → vN+1` step to `MIGRATIONS` in `src/store.rs`; `deny_unknown_fields` stays on
   `Task` and `DomainState` so an older binary refuses a newer file instead of dropping fields.

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -5,6 +5,7 @@
 Install with `curl -fsSL https://gettsk.sh/install.sh | sh` or `brew install smarzban/tap/tsk`.
 Details: https://gettsk.sh/docs/install.md
 The board checks GitHub releases at most daily and shows a dim `vX.Y.Z available` on the status row; set `TSK_NO_UPDATE_CHECK` to disable.
+`N` rows on the desk are human-only notices: starter guides on a first open, one `What's new in tsk` row after an upgrade. `tsk list` never shows them.
 
 ## For agents
 

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -66,6 +66,10 @@ Select a task, then click a footer action or use:
 
 Agents can set any status with [the CLI](/docs/cli/#status). Task status does not change automatically when steps are checked or an agent stops.
 
+## Notices
+
+Your first board open seeds about five desk rows with `N` ids (not `T`). They teach the board by being ordinary tasks: open, peek, change status, archive, or delete. `ctrl+d`, `ctrl+f`, and `ctrl+x` all dismiss a notice the same way; that guide never re-seeds. After an upgrade, one `What's new in tsk` row can appear the same way. Details and the delivery record live under [storage](/docs/storage/#starter-guides-and-release-notes).
+
 ## Mouse
 
 | Action | Result |
@@ -74,7 +78,7 @@ Agents can set any status with [the CLI](/docs/cli/#status). Task status does no
 | Click a task | Peek in narrow panes; select in wide panes |
 | Click the same task again in a narrow pane | Close its peek |
 | Double-click a task | Open it full screen |
-| Click its `T` number | Copy the task number |
+| Click its `T` or `N` number | Copy that id |
 | Click a footer action | Run that action |
 | Wheel or drag a scrollbar | Scroll |
 | Drag across text | Select and copy on release |

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -47,6 +47,8 @@ Data commands accept `--state-dir <dir>`. Setup and guide do not use that flag.
 
 `T12`, `t12`, `12`, and a task UUID identify the same task. Direct lookup ignores the current project.
 
+Board notice rows paint as `N1`… (starter guides and `What's new in tsk`). Those ids are board-only: the CLI does not accept `N1`, and default `tsk list` omits them. Agents ignore them.
+
 ### Scope
 
 Without a scope flag, `add` and filtered `list` use the launch repository, or the current directory outside Git. Commands addressed to a task ignore that default.
@@ -136,7 +138,7 @@ tsk list [<task>] [-p <project> | --desk | --all] [--thread <name>] [--done | --
 
 | Filter | Result |
 | --- | --- |
-| Default | Ready, started, blocked, and review tasks; excludes archived and deleted work |
+| Default | Ready, started, blocked, and review tasks; excludes archived, deleted, and notice (`N`) rows |
 | `--done` | Completed tasks |
 | `--archived` | Individually archived tasks and tasks in archived projects, across statuses |
 | `--deleted` | Deleted tasks in the main store and trash, newest first |

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -10,7 +10,7 @@ Use it beside your agent in Herdr, or run `tsk` in any terminal. Both use the sa
 ## Start here
 
 1. [Install tsk and connect Herdr](/docs/install/).
-2. Your first board opens with five `N` guide rows on the desk. Open one with `Enter`; clear it with `ctrl+d`, `ctrl+f`, or `ctrl+x` when you are done.
+2. Your first board opens with five `N` guide rows on the desk. Open one with `Enter`; clear it with `ctrl+d`, `ctrl+f`, or `ctrl+x` when you are done. After an upgrade, a `What's new in tsk` row arrives the same way.
 3. Press `+`, type a title, and press `Enter`.
 4. Open the task for notes and steps.
 5. Give your agent its task number.

--- a/site/src/content/docs/docs/storage.md
+++ b/site/src/content/docs/docs/storage.md
@@ -35,7 +35,7 @@ Archived tasks stay in the task document with their existing status. [Archive an
 
 The starter guides (`N1`… on your desk) are seeded once per state directory on the first board open. Mark one done, archive it, or delete it and it never returns. Deleting `delivery.json` seeds any guide the task document no longer holds.
 
-After an upgrade, the first board open adds one `What's new in tsk` row to your desk when the new version bundles release notes you have not seen. Every missed release lands in that one row, newest first, with its changelog link in the notes. The notes ship inside the binary; a fresh install records them as seen and shows none. Clear the row like any guide.
+After an upgrade, the first board open adds one `What's new in tsk` row to your desk when the new version bundles release notes you have not seen. That includes upgrading from a build that only had starter guides. Every missed release lands in that one row, newest first, with its changelog link in the notes. The notes ship inside the binary; a blank first install records them as seen and shows none. Clear the row like any guide.
 
 ## Deleted tasks
 

--- a/site/src/content/docs/docs/storage.md
+++ b/site/src/content/docs/docs/storage.md
@@ -25,13 +25,15 @@ Herdr's plugin-specific state/config directories do not override these locations
 | `tsk.json.1` | Previous valid task document |
 | `tsk.json.v<N>` | Backup made when migrating an older store format |
 | `walkthrough.json` | Whether onboarding was dismissed |
-| `delivery.json` | Which starter guides this install has received or dismissed |
+| `delivery.json` | Which starter guides this install has received or dismissed, and the newest release note it has seen |
 
 An older binary refuses a newer or unversioned store instead of rewriting it. Use a compatible tsk version to open it.
 
 Archived tasks stay in the task document with their existing status. [Archive and restore](/docs/board/#archive).
 
 The starter guides (`N1`… on your desk) are seeded once per state directory on the first board open. Mark one done, archive it, or delete it and it never returns. Deleting `delivery.json` seeds any guide the task document no longer holds.
+
+After an upgrade, the first board open adds one `What's new in tsk` row to your desk when the new version bundles release notes you have not seen. Every missed release lands in that one row, newest first, with its changelog link in the notes. The notes ship inside the binary; a fresh install records them as seen and shows none. Clear the row like any guide.
 
 ## Deleted tasks
 

--- a/site/src/content/docs/docs/storage.md
+++ b/site/src/content/docs/docs/storage.md
@@ -31,6 +31,8 @@ An older binary refuses a newer or unversioned store instead of rewriting it. Us
 
 Archived tasks stay in the task document with their existing status. [Archive and restore](/docs/board/#archive).
 
+## Starter guides and release notes
+
 The starter guides (`N1`… on your desk) are seeded once per state directory on the first board open. Mark one done, archive it, or delete it and it never returns. Deleting `delivery.json` seeds any guide the task document no longer holds.
 
 After an upgrade, the first board open adds one `What's new in tsk` row to your desk when the new version bundles release notes you have not seen. Every missed release lands in that one row, newest first, with its changelog link in the notes. The notes ship inside the binary; a fresh install records them as seen and shows none. Clear the row like any guide.

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -74,8 +74,9 @@ exclusive, as are `--done` and `--deleted`.
 A typo in a project name silently files the task under a new scope. Use
 `tsk list --all --json` to recover the resulting scope.
 
-Rows the board paints as `N1`… are human-only guide notices. `tsk list` never shows
-them, no command addresses them, and agents ignore them.
+Rows the board paints as `N1`… are human-only notices: starter guides and the
+`What's new in tsk` release note. `tsk list` never shows them, no command addresses
+them, and agents ignore them.
 
 ## Direct task lookup and steps
 

--- a/src/announcements.rs
+++ b/src/announcements.rs
@@ -1,0 +1,361 @@
+//! Release announcements: one desk notice per upgrade, combining every bundled entry the
+//! install has not seen.
+//!
+//! The catalog is `announcements/catalog.toml` beside this file, edited by the maintainer
+//! and compiled in. `delivery.json` keeps the highest id delivered; a fresh install takes
+//! the bundled maximum and receives nothing, so a "What's new" row only ever describes an
+//! upgrade.
+
+use toml_edit::{DocumentMut, Item, Table};
+
+use crate::delivery;
+use crate::domain::{HumanStatus, TaskScope};
+use crate::store::TaskStore;
+
+pub const CATALOG_TOML: &str = include_str!("announcements/catalog.toml");
+pub const CATALOG_ID_PREFIX: &str = "announce.";
+pub const TITLE: &str = "What's new in tsk";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Announcement {
+    pub id: u64,
+    pub title: String,
+    pub notes: String,
+}
+
+/// The bundled catalog, ascending by id.
+pub fn catalog() -> Result<Vec<Announcement>, String> {
+    parse_catalog(CATALOG_TOML)
+}
+
+/// Parse a catalog: `[[announcement]]` tables with exactly `id`, `title`, and `notes`.
+/// Ids are positive and strictly increasing in file order, titles carry no link.
+pub fn parse_catalog(toml: &str) -> Result<Vec<Announcement>, String> {
+    let document: DocumentMut = toml.parse().map_err(|error| format!("catalog: {error}"))?;
+    if document.len() != 1 {
+        return Err("catalog: only [[announcement]] tables are allowed".to_string());
+    }
+    let tables = document
+        .get("announcement")
+        .and_then(Item::as_array_of_tables)
+        .ok_or("catalog: expected [[announcement]] tables")?;
+    let mut entries: Vec<Announcement> = Vec::new();
+    for table in tables.iter() {
+        let entry = parse_entry(table)?;
+        if entries.last().is_some_and(|last| last.id >= entry.id) {
+            return Err(format!("catalog: id {} must increase", entry.id));
+        }
+        entries.push(entry);
+    }
+    if entries.is_empty() {
+        return Err("catalog: no announcements".to_string());
+    }
+    Ok(entries)
+}
+
+fn parse_entry(table: &Table) -> Result<Announcement, String> {
+    if table.len() != 3 {
+        return Err("catalog: each announcement has exactly id, title, notes".to_string());
+    }
+    let id = table
+        .get("id")
+        .and_then(Item::as_integer)
+        .filter(|id| *id > 0)
+        .ok_or("catalog: id must be a positive integer")?;
+    let text = |key: &str| {
+        table
+            .get(key)
+            .and_then(Item::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| format!("catalog: announcement {id} needs a non-empty {key}"))
+    };
+    let title = text("title")?;
+    if title.contains("http") {
+        return Err(format!(
+            "catalog: announcement {id} title carries a link; links go in notes"
+        ));
+    }
+    Ok(Announcement {
+        id: id as u64,
+        title,
+        notes: text("notes")?,
+    })
+}
+
+/// Seed the bundled catalog. Returns how many notice rows were created (0 or 1).
+pub fn seed_on_open(store: &TaskStore) -> Result<usize, String> {
+    seed(store, &catalog()?)
+}
+
+/// Deliver every entry newer than what this install has seen as one notice, then record
+/// the bundled maximum as delivered.
+///
+/// What the install has seen is the delivery watermark or, when a lost record leaves it
+/// behind, the highest `announce.<id>` notice already in the store. Nothing seen means a
+/// fresh install: the watermark jumps to the bundled maximum and no row is created.
+fn seed(store: &TaskStore, catalog: &[Announcement]) -> Result<usize, String> {
+    let Some(bundled) = catalog.last().map(|entry| entry.id) else {
+        return Ok(0);
+    };
+    let dir = store.path();
+    let mut record = delivery::load(dir);
+    if record.announcement_watermark >= bundled {
+        return Ok(0);
+    }
+    let created = store.locked_transition_if_changed(|state| {
+        let seen = state
+            .tasks()
+            .iter()
+            .filter_map(|task| task.notice.as_ref())
+            .filter_map(|notice| notice.catalog_id.strip_prefix(CATALOG_ID_PREFIX))
+            .filter_map(|id| id.parse::<u64>().ok())
+            .fold(record.announcement_watermark, u64::max);
+        if seen == 0 || seen >= bundled {
+            return Ok((0, false));
+        }
+        let missed = catalog.iter().filter(|entry| entry.id > seen);
+        state
+            .create_notice(
+                format!("{CATALOG_ID_PREFIX}{bundled}"),
+                TITLE,
+                Some(combined_notes(missed)),
+                HumanStatus::Ready,
+                TaskScope::Global,
+                Vec::new(),
+            )
+            .map_err(|error| error.to_string())?;
+        Ok((1, true))
+    })?;
+    record.announcement_watermark = bundled;
+    delivery::save(dir, &record).map_err(|error| error.to_string())?;
+    Ok(created)
+}
+
+/// Newest entry first, each under its own heading.
+fn combined_notes<'a>(missed: impl DoubleEndedIterator<Item = &'a Announcement>) -> String {
+    missed
+        .rev()
+        .map(|entry| format!("## {}\n\n{}", entry.title, entry.notes))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+    use crate::domain::{DomainState, Task};
+    use crate::guides;
+
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_store(label: &str) -> TaskStore {
+        let dir: PathBuf = std::env::temp_dir().join(format!(
+            "tsk-announcements-{label}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("temp dir");
+        TaskStore::new(dir)
+    }
+
+    fn announcement(id: u64) -> Announcement {
+        Announcement {
+            id,
+            title: format!("Release {id}"),
+            notes: format!("Notes for release {id}.\n\nChangelog: https://example.test/v{id}"),
+        }
+    }
+
+    fn announced(state: &DomainState) -> Vec<&Task> {
+        state
+            .tasks()
+            .iter()
+            .filter(|task| {
+                task.notice
+                    .as_ref()
+                    .is_some_and(|notice| notice.catalog_id.starts_with(CATALOG_ID_PREFIX))
+            })
+            .collect()
+    }
+
+    fn set_watermark(store: &TaskStore, watermark: u64) {
+        let mut record = delivery::load(store.path());
+        record.announcement_watermark = watermark;
+        delivery::save(store.path(), &record).expect("save record");
+    }
+
+    #[test]
+    fn the_bundled_catalog_parses_and_ends_with_a_changelog_link() {
+        let entries = catalog().expect("bundled catalog");
+        assert_eq!(entries[0].id, 1);
+        for entry in &entries {
+            assert!(
+                entry
+                    .notes
+                    .contains("Changelog: https://github.com/smarzban/herdr-tsk/"),
+                "{}",
+                entry.id
+            );
+            assert!(!entry.notes.ends_with('\n'));
+        }
+    }
+
+    #[test]
+    fn a_fresh_install_takes_the_bundled_watermark_and_no_announcement_row() {
+        let store = temp_store("fresh");
+        assert_eq!(guides::seed_on_open(&store), Ok(5));
+        assert_eq!(seed(&store, &[announcement(1), announcement(2)]), Ok(0));
+        let state = store.load().expect("load");
+        assert_eq!(state.tasks().iter().filter(|t| t.is_notice()).count(), 5);
+        assert!(announced(&state).is_empty());
+        let record = delivery::load(store.path());
+        assert_eq!(record.announcement_watermark, 2);
+        assert_eq!(record.guides.len(), 5, "the guide marks survive");
+        let _ = fs::remove_dir_all(store.path());
+    }
+
+    #[test]
+    fn two_missed_entries_become_one_notice_newest_first_and_a_second_open_adds_none() {
+        let store = temp_store("missed");
+        set_watermark(&store, 1);
+        let catalog = [announcement(1), announcement(2), announcement(3)];
+        assert_eq!(seed(&store, &catalog), Ok(1));
+        let state = store.load().expect("load");
+        let rows = announced(&state);
+        assert_eq!(rows.len(), 1);
+        let row = rows[0];
+        assert_eq!(row.title, TITLE);
+        assert_eq!(row.status, HumanStatus::Ready);
+        assert_eq!(row.scope, TaskScope::Global);
+        assert_eq!(row.board_identifier(), Some("N1".to_string()));
+        assert_eq!(row.notice.as_ref().unwrap().catalog_id, "announce.3");
+        assert_eq!(
+            row.notes.as_deref(),
+            Some(
+                "## Release 3\n\nNotes for release 3.\n\nChangelog: https://example.test/v3\n\n\
+                 ## Release 2\n\nNotes for release 2.\n\nChangelog: https://example.test/v2"
+            )
+        );
+        assert_eq!(delivery::load(store.path()).announcement_watermark, 3);
+
+        assert_eq!(seed(&store, &catalog), Ok(0));
+        assert_eq!(announced(&store.load().expect("reload")).len(), 1);
+        let _ = fs::remove_dir_all(store.path());
+    }
+
+    #[test]
+    fn a_gap_in_ids_still_combines_everything_above_the_watermark() {
+        let store = temp_store("gap");
+        set_watermark(&store, 1);
+        assert_eq!(
+            seed(&store, &[announcement(1), announcement(3), announcement(5)]),
+            Ok(1)
+        );
+        let state = store.load().expect("load");
+        let notes = announced(&state)[0].notes.clone().unwrap();
+        assert!(notes.starts_with("## Release 5\n"));
+        assert!(notes.contains("## Release 3\n"));
+        assert!(!notes.contains("Release 1"));
+        assert_eq!(delivery::load(store.path()).announcement_watermark, 5);
+        let _ = fs::remove_dir_all(store.path());
+    }
+
+    #[test]
+    fn a_dismissed_notice_never_comes_back_even_after_it_leaves_the_store() {
+        let store = temp_store("dismiss");
+        set_watermark(&store, 1);
+        let catalog = [announcement(1), announcement(2)];
+        assert_eq!(seed(&store, &catalog), Ok(1));
+        let mut state = store.load().expect("load");
+        let id = announced(&state)[0].id;
+        state.complete(id).expect("complete");
+        store.save(&state).expect("save");
+        delivery::record_dismissed_notices(store.path(), state.tasks()).expect("record");
+        assert!(delivery::load(store.path()).guides.contains("announce.2"));
+
+        store.save(&DomainState::new()).expect("forget the row");
+        assert_eq!(seed(&store, &catalog), Ok(0));
+        assert!(announced(&store.load().expect("reload")).is_empty());
+        let _ = fs::remove_dir_all(store.path());
+    }
+
+    #[test]
+    fn a_lost_record_is_rebuilt_from_the_store_and_only_newer_entries_are_delivered() {
+        let store = temp_store("lost");
+        set_watermark(&store, 1);
+        assert_eq!(seed(&store, &[announcement(1), announcement(2)]), Ok(1));
+        fs::remove_file(store.path().join(delivery::DELIVERY_FILE)).expect("lose record");
+
+        assert_eq!(seed(&store, &[announcement(1), announcement(2)]), Ok(0));
+        assert_eq!(delivery::load(store.path()).announcement_watermark, 2);
+        assert_eq!(announced(&store.load().expect("load")).len(), 1);
+
+        fs::remove_file(store.path().join(delivery::DELIVERY_FILE)).expect("lose again");
+        let newer = [announcement(1), announcement(2), announcement(3)];
+        assert_eq!(seed(&store, &newer), Ok(1));
+        let state = store.load().expect("reload");
+        let rows = announced(&state);
+        assert_eq!(rows.len(), 2);
+        let notes = rows[1].notes.clone().unwrap();
+        assert!(notes.contains("Release 3") && !notes.contains("Release 2"));
+        assert_eq!(delivery::load(store.path()).announcement_watermark, 3);
+        let _ = fs::remove_dir_all(store.path());
+    }
+
+    #[test]
+    fn a_bad_catalog_fails_to_parse() {
+        let good = "[[announcement]]\nid = 1\ntitle = \"a\"\nnotes = \"b\"\n";
+        assert_eq!(parse_catalog(good).map(|c| c.len()), Ok(1));
+        let bad = [
+            ("not toml", "[[announcement]\n"),
+            ("no entries", "announcement = []\n"),
+            (
+                "missing id",
+                "[[announcement]]\ntitle = \"a\"\nnotes = \"b\"\n",
+            ),
+            (
+                "zero id",
+                "[[announcement]]\nid = 0\ntitle = \"a\"\nnotes = \"b\"\n",
+            ),
+            (
+                "string id",
+                "[[announcement]]\nid = \"1\"\ntitle = \"a\"\nnotes = \"b\"\n",
+            ),
+            (
+                "empty notes",
+                "[[announcement]]\nid = 1\ntitle = \"a\"\nnotes = \"  \"\n",
+            ),
+            (
+                "unknown key",
+                "[[announcement]]\nid = 1\ntitle = \"a\"\nnotes = \"b\"\nversion = \"x\"\n",
+            ),
+            (
+                "link in title",
+                "[[announcement]]\nid = 1\ntitle = \"see https://x\"\nnotes = \"b\"\n",
+            ),
+            (
+                "ids out of order",
+                "[[announcement]]\nid = 2\ntitle = \"a\"\nnotes = \"b\"\n\
+                 [[announcement]]\nid = 1\ntitle = \"c\"\nnotes = \"d\"\n",
+            ),
+            (
+                "duplicate id",
+                "[[announcement]]\nid = 1\ntitle = \"a\"\nnotes = \"b\"\n\
+                 [[announcement]]\nid = 1\ntitle = \"c\"\nnotes = \"d\"\n",
+            ),
+            (
+                "stray top-level key",
+                "title = \"x\"\n[[announcement]]\nid = 1\ntitle = \"a\"\nnotes = \"b\"\n",
+            ),
+        ];
+        for (label, toml) in bad {
+            assert!(parse_catalog(toml).is_err(), "{label} should fail");
+        }
+    }
+}

--- a/src/announcements.rs
+++ b/src/announcements.rs
@@ -1,11 +1,3 @@
-//! Release announcements: one desk notice per upgrade, combining every bundled entry the
-//! install has not seen.
-//!
-//! The catalog is `announcements/catalog.toml` beside this file, edited by the maintainer
-//! and compiled in. `delivery.json` keeps the highest id delivered; a fresh install takes
-//! the bundled maximum and receives nothing, so a "What's new" row only ever describes an
-//! upgrade.
-
 use toml_edit::{DocumentMut, Item, Table};
 
 use crate::delivery;
@@ -23,7 +15,6 @@ pub struct Announcement {
     pub notes: String,
 }
 
-/// The bundled catalog, ascending by id.
 pub fn catalog() -> Result<Vec<Announcement>, String> {
     parse_catalog(CATALOG_TOML)
 }
@@ -89,12 +80,6 @@ pub fn seed_on_open(store: &TaskStore) -> Result<usize, String> {
     seed(store, &catalog()?)
 }
 
-/// Deliver every entry newer than what this install has seen as one notice, then record
-/// the bundled maximum as delivered.
-///
-/// What the install has seen is the delivery watermark or, when a lost record leaves it
-/// behind, the highest `announce.<id>` notice already in the store. Nothing seen means a
-/// fresh install: the watermark jumps to the bundled maximum and no row is created.
 fn seed(store: &TaskStore, catalog: &[Announcement]) -> Result<usize, String> {
     let Some(bundled) = catalog.last().map(|entry| entry.id) else {
         return Ok(0);
@@ -105,14 +90,9 @@ fn seed(store: &TaskStore, catalog: &[Announcement]) -> Result<usize, String> {
         return Ok(0);
     }
     let created = store.locked_transition_if_changed(|state| {
-        let seen = state
-            .tasks()
-            .iter()
-            .filter_map(|task| task.notice.as_ref())
-            .filter_map(|notice| notice.catalog_id.strip_prefix(CATALOG_ID_PREFIX))
-            .filter_map(|id| id.parse::<u64>().ok())
-            .fold(record.announcement_watermark, u64::max);
-        if seen == 0 || seen >= bundled {
+        let seen = highest_seen_announce_id(state, record.announcement_watermark);
+        let fresh_install = seen == 0;
+        if fresh_install || seen >= bundled {
             return Ok((0, false));
         }
         let missed = catalog.iter().filter(|entry| entry.id > seen);
@@ -133,7 +113,16 @@ fn seed(store: &TaskStore, catalog: &[Announcement]) -> Result<usize, String> {
     Ok(created)
 }
 
-/// Newest entry first, each under its own heading.
+fn highest_seen_announce_id(state: &crate::domain::DomainState, watermark: u64) -> u64 {
+    state
+        .tasks()
+        .iter()
+        .filter_map(|task| task.notice.as_ref())
+        .filter_map(|notice| notice.catalog_id.strip_prefix(CATALOG_ID_PREFIX))
+        .filter_map(|id| id.parse::<u64>().ok())
+        .fold(watermark, u64::max)
+}
+
 fn combined_notes<'a>(missed: impl DoubleEndedIterator<Item = &'a Announcement>) -> String {
     missed
         .rev()

--- a/src/announcements.rs
+++ b/src/announcements.rs
@@ -75,12 +75,31 @@ fn parse_entry(table: &Table) -> Result<Announcement, String> {
     })
 }
 
-/// Seed the bundled catalog. Returns how many notice rows were created (0 or 1).
-pub fn seed_on_open(store: &TaskStore) -> Result<usize, String> {
-    seed(store, &catalog()?)
+/// Whether this state dir has never received guides or announcements before.
+/// Call before [`crate::guides::seed_on_open`] so a same-open guide write is not
+/// mistaken for an upgrade from a guides-only binary.
+pub fn is_fresh_install(store: &TaskStore) -> bool {
+    let record = delivery::load(store.path());
+    if record.announcement_watermark > 0 || !record.guides.is_empty() {
+        return false;
+    }
+    match store.load() {
+        Ok(state) => !state
+            .tasks()
+            .iter()
+            .any(|task| !task.soft_deleted),
+        Err(_) => true,
+    }
 }
 
-fn seed(store: &TaskStore, catalog: &[Announcement]) -> Result<usize, String> {
+/// Seed the bundled catalog. Returns how many notice rows were created (0 or 1).
+///
+/// `fresh_install` must be computed with [`is_fresh_install`] before guide seeding.
+pub fn seed_on_open(store: &TaskStore, fresh_install: bool) -> Result<usize, String> {
+    seed(store, &catalog()?, fresh_install)
+}
+
+fn seed(store: &TaskStore, catalog: &[Announcement], fresh_install: bool) -> Result<usize, String> {
     let Some(bundled) = catalog.last().map(|entry| entry.id) else {
         return Ok(0);
     };
@@ -91,7 +110,6 @@ fn seed(store: &TaskStore, catalog: &[Announcement]) -> Result<usize, String> {
     }
     let created = store.locked_transition_if_changed(|state| {
         let seen = highest_seen_announce_id(state, record.announcement_watermark);
-        let fresh_install = seen == 0;
         if fresh_install || seen >= bundled {
             return Ok((0, false));
         }
@@ -198,8 +216,12 @@ mod tests {
     #[test]
     fn a_fresh_install_takes_the_bundled_watermark_and_no_announcement_row() {
         let store = temp_store("fresh");
+        assert!(is_fresh_install(&store));
         assert_eq!(guides::seed_on_open(&store), Ok(5));
-        assert_eq!(seed(&store, &[announcement(1), announcement(2)]), Ok(0));
+        assert_eq!(
+            seed(&store, &[announcement(1), announcement(2)], true),
+            Ok(0)
+        );
         let state = store.load().expect("load");
         assert_eq!(state.tasks().iter().filter(|t| t.is_notice()).count(), 5);
         assert!(announced(&state).is_empty());
@@ -210,11 +232,35 @@ mod tests {
     }
 
     #[test]
+    fn upgrading_from_guides_only_seeds_whats_new_for_bundled_entries() {
+        let store = temp_store("guides-upgrade");
+        assert_eq!(guides::seed_on_open(&store), Ok(5));
+        assert_eq!(delivery::load(store.path()).announcement_watermark, 0);
+        assert!(
+            !is_fresh_install(&store),
+            "guides already delivered means this is an upgrade"
+        );
+        let catalog = [announcement(1), announcement(2)];
+        assert_eq!(seed(&store, &catalog, false), Ok(1));
+        let state = store.load().expect("load");
+        let rows = announced(&state);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].notice.as_ref().unwrap().catalog_id, "announce.2");
+        assert!(rows[0]
+            .notes
+            .as_deref()
+            .is_some_and(|notes| notes.contains("Release 2") && notes.contains("Release 1")));
+        assert_eq!(delivery::load(store.path()).announcement_watermark, 2);
+        assert_eq!(seed(&store, &catalog, false), Ok(0));
+        let _ = fs::remove_dir_all(store.path());
+    }
+
+    #[test]
     fn two_missed_entries_become_one_notice_newest_first_and_a_second_open_adds_none() {
         let store = temp_store("missed");
         set_watermark(&store, 1);
         let catalog = [announcement(1), announcement(2), announcement(3)];
-        assert_eq!(seed(&store, &catalog), Ok(1));
+        assert_eq!(seed(&store, &catalog, false), Ok(1));
         let state = store.load().expect("load");
         let rows = announced(&state);
         assert_eq!(rows.len(), 1);
@@ -233,7 +279,7 @@ mod tests {
         );
         assert_eq!(delivery::load(store.path()).announcement_watermark, 3);
 
-        assert_eq!(seed(&store, &catalog), Ok(0));
+        assert_eq!(seed(&store, &catalog, false), Ok(0));
         assert_eq!(announced(&store.load().expect("reload")).len(), 1);
         let _ = fs::remove_dir_all(store.path());
     }
@@ -243,7 +289,11 @@ mod tests {
         let store = temp_store("gap");
         set_watermark(&store, 1);
         assert_eq!(
-            seed(&store, &[announcement(1), announcement(3), announcement(5)]),
+            seed(
+                &store,
+                &[announcement(1), announcement(3), announcement(5)],
+                false
+            ),
             Ok(1)
         );
         let state = store.load().expect("load");
@@ -260,7 +310,7 @@ mod tests {
         let store = temp_store("dismiss");
         set_watermark(&store, 1);
         let catalog = [announcement(1), announcement(2)];
-        assert_eq!(seed(&store, &catalog), Ok(1));
+        assert_eq!(seed(&store, &catalog, false), Ok(1));
         let mut state = store.load().expect("load");
         let id = announced(&state)[0].id;
         state.complete(id).expect("complete");
@@ -269,7 +319,7 @@ mod tests {
         assert!(delivery::load(store.path()).guides.contains("announce.2"));
 
         store.save(&DomainState::new()).expect("forget the row");
-        assert_eq!(seed(&store, &catalog), Ok(0));
+        assert_eq!(seed(&store, &catalog, false), Ok(0));
         assert!(announced(&store.load().expect("reload")).is_empty());
         let _ = fs::remove_dir_all(store.path());
     }
@@ -278,16 +328,16 @@ mod tests {
     fn a_lost_record_is_rebuilt_from_the_store_and_only_newer_entries_are_delivered() {
         let store = temp_store("lost");
         set_watermark(&store, 1);
-        assert_eq!(seed(&store, &[announcement(1), announcement(2)]), Ok(1));
+        assert_eq!(seed(&store, &[announcement(1), announcement(2)], false), Ok(1));
         fs::remove_file(store.path().join(delivery::DELIVERY_FILE)).expect("lose record");
 
-        assert_eq!(seed(&store, &[announcement(1), announcement(2)]), Ok(0));
+        assert_eq!(seed(&store, &[announcement(1), announcement(2)], false), Ok(0));
         assert_eq!(delivery::load(store.path()).announcement_watermark, 2);
         assert_eq!(announced(&store.load().expect("load")).len(), 1);
 
         fs::remove_file(store.path().join(delivery::DELIVERY_FILE)).expect("lose again");
         let newer = [announcement(1), announcement(2), announcement(3)];
-        assert_eq!(seed(&store, &newer), Ok(1));
+        assert_eq!(seed(&store, &newer, false), Ok(1));
         let state = store.load().expect("reload");
         let rows = announced(&state);
         assert_eq!(rows.len(), 2);

--- a/src/announcements/catalog.toml
+++ b/src/announcements/catalog.toml
@@ -1,0 +1,20 @@
+# Release announcements, compiled into the binary (src/announcements.rs).
+#
+# One entry per release worth a desk notice. Append at the end with the next id;
+# ids increase and are never reused. An install records the highest id it has seen,
+# so an upgrade delivers every newer entry as one "What's new in tsk" row. A fresh
+# install records the highest bundled id and receives none of these.
+#
+# The changelog link belongs in `notes`, never in `title`.
+
+[[announcement]]
+id = 1
+title = "Guides and release notes on your desk"
+notes = """
+Your desk now carries `N` rows: starter guides on a first install, and a
+what's-new note like this one after an upgrade. They sit like tasks and leave
+like tasks: `ctrl+d`, `ctrl+f`, or `ctrl+x` clears one for good. `tsk list`
+never shows them to agents.
+
+Changelog: https://github.com/smarzban/herdr-tsk/releases
+"""

--- a/src/announcements/catalog.toml
+++ b/src/announcements/catalog.toml
@@ -1,11 +1,5 @@
-# Release announcements, compiled into the binary (src/announcements.rs).
-#
-# One entry per release worth a desk notice. Append at the end with the next id;
-# ids increase and are never reused. An install records the highest id it has seen,
-# so an upgrade delivers every newer entry as one "What's new in tsk" row. A fresh
-# install records the highest bundled id and receives none of these.
-#
-# The changelog link belongs in `notes`, never in `title`.
+# Maintainer catalog for `src/announcements.rs`. Append with the next id; ids
+# increase and are never reused. Changelog URLs go in `notes`, never in `title`.
 
 [[announcement]]
 id = 1

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,8 +116,9 @@ fn load_board_inner(
 }
 
 fn seed_notices_without_blocking_open(store: &TaskStore) {
+    let announcement_fresh = crate::announcements::is_fresh_install(store);
     let _ = crate::guides::seed_on_open(store);
-    let _ = crate::announcements::seed_on_open(store);
+    let _ = crate::announcements::seed_on_open(store, announcement_fresh);
 }
 
 fn record_notice_dismissals_without_blocking_persist(store: &TaskStore, domain: &DomainState) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -84,19 +84,11 @@ fn load_snapshot() -> InvocationSnapshot {
 }
 
 /// Load store + snapshot into domain and board view-model (no TTY).
-///
-/// The full board open is the one path that seeds the starter guides and release
-/// announcements (see [`crate::guides::seed_on_open`] and
-/// [`crate::announcements::seed_on_open`]): the CLI, the install script, and the
-/// quick-capture popup never do.
 pub fn load_board() -> Result<(TaskStore, DomainState, BoardModel), Box<dyn Error>> {
     load_board_inner(true)
 }
 
 /// Load store + snapshot for the quick-capture popup (no TTY).
-///
-/// The launch card and the notice seeds are board-open concerns; the popup opens straight
-/// onto the draft page, and its archived-project scope fallback happens when the draft opens.
 pub fn load_board_for_quick_capture() -> Result<(TaskStore, DomainState, BoardModel), Box<dyn Error>>
 {
     load_board_inner(false)
@@ -108,12 +100,7 @@ fn load_board_inner(
     let state_dir = default_state_dir();
     let store = TaskStore::new(state_dir.clone());
     if full_board_open {
-        // A board that could not seed its notices is still a usable board: the next open
-        // converges (both seeders dedupe by catalog id), and a message here would take
-        // the status slot from the update notice. Guides first, so a fresh install's
-        // announcement watermark is written on the same open that seeds its guides.
-        let _ = crate::guides::seed_on_open(&store);
-        let _ = crate::announcements::seed_on_open(&store);
+        seed_notices_without_blocking_open(&store);
     }
     let state = store.load()?;
     let snapshot = load_snapshot();
@@ -126,6 +113,15 @@ fn load_board_inner(
         env!("CARGO_PKG_VERSION"),
     ));
     Ok((store, state, model))
+}
+
+fn seed_notices_without_blocking_open(store: &TaskStore) {
+    let _ = crate::guides::seed_on_open(store);
+    let _ = crate::announcements::seed_on_open(store);
+}
+
+fn record_notice_dismissals_without_blocking_persist(store: &TaskStore, domain: &DomainState) {
+    let _ = crate::delivery::record_dismissed_notices(store.path(), domain.tasks());
 }
 
 /// The one walkthrough read on the open path: no record means the card opens.
@@ -1652,9 +1648,7 @@ fn handle_board_intent(
         },
     );
     if outcome == IntentOutcome::Persisted {
-        // The store already holds the dismissed guide; the delivery mark keeps a later open
-        // from seeding it back. Best effort, like the seed: nothing here fails the board.
-        let _ = crate::delivery::record_dismissed_notices(store.path(), domain.tasks());
+        record_notice_dismissals_without_blocking_persist(store, domain);
     }
     match outcome {
         IntentOutcome::Quit => Ok(true),

--- a/src/app.rs
+++ b/src/app.rs
@@ -85,16 +85,17 @@ fn load_snapshot() -> InvocationSnapshot {
 
 /// Load store + snapshot into domain and board view-model (no TTY).
 ///
-/// The full board open is the one path that seeds the starter guides (see
-/// [`crate::guides::seed_on_open`]): the CLI, the install script, and the quick-capture
-/// popup never do.
+/// The full board open is the one path that seeds the starter guides and release
+/// announcements (see [`crate::guides::seed_on_open`] and
+/// [`crate::announcements::seed_on_open`]): the CLI, the install script, and the
+/// quick-capture popup never do.
 pub fn load_board() -> Result<(TaskStore, DomainState, BoardModel), Box<dyn Error>> {
     load_board_inner(true)
 }
 
 /// Load store + snapshot for the quick-capture popup (no TTY).
 ///
-/// The launch card and the guide seed are board-open concerns; the popup opens straight
+/// The launch card and the notice seeds are board-open concerns; the popup opens straight
 /// onto the draft page, and its archived-project scope fallback happens when the draft opens.
 pub fn load_board_for_quick_capture() -> Result<(TaskStore, DomainState, BoardModel), Box<dyn Error>>
 {
@@ -107,10 +108,12 @@ fn load_board_inner(
     let state_dir = default_state_dir();
     let store = TaskStore::new(state_dir.clone());
     if full_board_open {
-        // A board that could not seed its guides is still a usable board: the next open
-        // converges (`seed_on_open` dedupes by catalog id), and a message here would take
-        // the status slot from the update notice.
+        // A board that could not seed its notices is still a usable board: the next open
+        // converges (both seeders dedupe by catalog id), and a message here would take
+        // the status slot from the update notice. Guides first, so a fresh install's
+        // announcement watermark is written on the same open that seeds its guides.
         let _ = crate::guides::seed_on_open(&store);
+        let _ = crate::announcements::seed_on_open(&store);
     }
     let state = store.load()?;
     let snapshot = load_snapshot();

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -1,9 +1,3 @@
-//! Once-per-install delivery record for notice rows: `delivery.json` beside `update.json`.
-//!
-//! It lives outside `tsk.json` so a dismiss mark never bumps the store format and an
-//! older binary ignores it. Written with the same temp + rename + sync pattern as the
-//! update cache.
-
 use std::collections::BTreeSet;
 use std::fs;
 use std::io::{self, Write};

--- a/src/guides.rs
+++ b/src/guides.rs
@@ -1,24 +1,15 @@
-//! Starter guides: desk notice rows seeded once per install on a full board open.
-//!
-//! The catalog is a table. Adding a guide is one row; `delivery.json` remembers which
-//! rows a state dir has already received, so existing users get new rows and never old
-//! ones back.
-
 use std::collections::BTreeSet;
 
 use crate::delivery;
 use crate::domain::{HumanStatus, TaskScope};
 use crate::store::TaskStore;
 
-/// One catalog row. `catalog_id` is the stable key the delivery record remembers; the
-/// title names the capability the row teaches.
 #[derive(Debug, Clone, Copy)]
 pub struct Guide {
     pub catalog_id: &'static str,
     pub title: &'static str,
     pub notes: &'static str,
     pub status: HumanStatus,
-    /// Step text and whether it starts checked.
     pub steps: &'static [(&'static str, bool)],
 }
 
@@ -105,10 +96,6 @@ pub const CATALOG: [Guide; 5] = [
 
 /// Seed every guide this state dir has not delivered, then record the whole catalog as
 /// delivered. Returns how many notice rows were created.
-///
-/// Reruns converge: a guide already in the store as a notice (any status, deleted
-/// included) is never created twice, and a delivery record lost between the store write
-/// and its own write is rebuilt from the store on the next open.
 pub fn seed_on_open(store: &TaskStore) -> Result<usize, String> {
     let dir = store.path();
     let mut record = delivery::load(dir);
@@ -192,6 +179,20 @@ mod tests {
             .collect()
     }
 
+    fn replace_store_with_ordinary_task_only(store: &TaskStore) {
+        let mut forgetting = DomainState::new();
+        forgetting
+            .create(
+                "unrelated",
+                None,
+                TaskScope::Global,
+                ProvenanceOrigin::Manual,
+                None,
+            )
+            .expect("task");
+        store.save(&forgetting).expect("save");
+    }
+
     #[test]
     fn first_open_seeds_five_desk_notices_and_a_second_open_adds_none() {
         let store = temp_store("empty");
@@ -271,19 +272,7 @@ mod tests {
         store.save(&state).expect("save");
         delivery::record_dismissed_notices(store.path(), state.tasks()).expect("record");
 
-        // The store forgets the three rows entirely (as a trash purge would); the
-        // delivery record alone must keep them from coming back.
-        let mut forgetting = DomainState::new();
-        forgetting
-            .create(
-                "unrelated",
-                None,
-                TaskScope::Global,
-                ProvenanceOrigin::Manual,
-                None,
-            )
-            .expect("task");
-        store.save(&forgetting).expect("save");
+        replace_store_with_ordinary_task_only(&store);
         assert_eq!(seed_on_open(&store), Ok(0));
         assert!(notices(&store.load().expect("reload")).is_empty());
         let _ = fs::remove_dir_all(store.path());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! tsk library root.
 
+pub mod announcements;
 pub mod app;
 pub mod board_pane;
 pub mod capture;

--- a/src/store.rs
+++ b/src/store.rs
@@ -2500,14 +2500,11 @@ mod tests {
         );
     }
 
-    /// Injected v3 -> v4 step for the migration seam tests. It sits at chain index 2,
-    /// after the two shipped steps a current document never reaches, so a seam load
-    /// stamped from v3 applies exactly this step.
-    fn identity_v3_to_v4(document: serde_json::Value) -> Result<serde_json::Value, StoreError> {
+    fn seam_noop_v3_to_v4(document: serde_json::Value) -> Result<serde_json::Value, StoreError> {
         Ok(document)
     }
 
-    const SEAM_CHAIN: &[MigrationStep] = &[migrate_v1_to_v2, migrate_v2_to_v3, identity_v3_to_v4];
+    const SEAM_CHAIN: &[MigrationStep] = &[migrate_v1_to_v2, migrate_v2_to_v3, seam_noop_v3_to_v4];
 
     #[test]
     fn migrate_with_walks_the_chain_from_the_given_version() {

--- a/tests/starter_guides.rs
+++ b/tests/starter_guides.rs
@@ -1,5 +1,6 @@
-//! Starter guides on the open path: the full board seeds them once, quick capture never
-//! does, and a dismissed guide is recorded so no later open brings it back.
+//! Notice seeds on the open path: the full board seeds the guides once and records the
+//! bundled announcements as seen, quick capture never does, and a dismissed guide is
+//! recorded so no later open brings it back.
 #![cfg(unix)]
 #[path = "support/pty.rs"]
 mod pty;
@@ -10,6 +11,7 @@ use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::Duration;
 
+use tsk_tui::announcements;
 use tsk_tui::app::{load_board_for_quick_capture, load_board_model};
 use tsk_tui::delivery;
 use tsk_tui::domain::{DomainState, HumanStatus, ProvenanceOrigin, Task, TaskScope};
@@ -99,6 +101,25 @@ fn full_board_open_seeds_the_guides_once_beside_existing_tasks() {
 
     let _ = load_board_model().expect("second open");
     assert_eq!(notices(&store.load().expect("reload")).len(), 5);
+}
+
+#[test]
+fn a_fresh_full_board_open_records_the_bundled_announcements_without_seeding_them() {
+    let _lock = env_lock();
+    suppress_background_fetch();
+    let env = StateDirEnv::set("announcements");
+    let bundled = announcements::catalog().expect("bundled catalog");
+    let newest = bundled.last().expect("at least one entry").id;
+
+    let _ = load_board_model().expect("first open");
+    let state = TaskStore::new(&env.dir).load().expect("load");
+    assert_eq!(notices(&state).len(), 5, "guides only");
+    assert!(notices(&state)
+        .iter()
+        .all(|task| task.title != announcements::TITLE));
+    let record = delivery::load(&env.dir);
+    assert_eq!(record.announcement_watermark, newest);
+    assert_eq!(record.guides, catalog_ids());
 }
 
 #[test]

--- a/tests/starter_guides.rs
+++ b/tests/starter_guides.rs
@@ -81,10 +81,26 @@ fn full_board_open_seeds_the_guides_once_beside_existing_tasks() {
         )
         .expect("task");
     store.save(&seeded).expect("save");
+    let newest = announcements::catalog()
+        .expect("bundled catalog")
+        .last()
+        .expect("at least one entry")
+        .id;
 
     let _ = load_board_model().expect("first open");
     let state = store.load().expect("load");
-    assert_eq!(notices(&state).len(), 5);
+    assert_eq!(
+        notices(&state).len(),
+        6,
+        "five guides plus What's new for an existing desk"
+    );
+    assert_eq!(
+        notices(&state)
+            .iter()
+            .filter(|task| task.title == announcements::TITLE)
+            .count(),
+        1
+    );
     assert_eq!(
         state
             .tasks()
@@ -94,10 +110,12 @@ fn full_board_open_seeds_the_guides_once_beside_existing_tasks() {
             .collect::<Vec<_>>(),
         vec![("existing work", Some(1))]
     );
-    assert_eq!(delivery::load(&env.dir).guides, catalog_ids());
+    let record = delivery::load(&env.dir);
+    assert_eq!(record.guides, catalog_ids());
+    assert_eq!(record.announcement_watermark, newest);
 
     let _ = load_board_model().expect("second open");
-    assert_eq!(notices(&store.load().expect("reload")).len(), 5);
+    assert_eq!(notices(&store.load().expect("reload")).len(), 6);
 }
 
 #[test]

--- a/tests/starter_guides.rs
+++ b/tests/starter_guides.rs
@@ -1,6 +1,3 @@
-//! Notice seeds on the open path: the full board seeds the guides once and records the
-//! bundled announcements as seen, quick capture never does, and a dismissed guide is
-//! recorded so no later open brings it back.
 #![cfg(unix)]
 #[path = "support/pty.rs"]
 mod pty;
@@ -133,6 +130,10 @@ fn quick_capture_open_seeds_nothing() {
     assert!(!env.dir.join(delivery::DELIVERY_FILE).exists());
 }
 
+fn drop_delivery_record(state_dir: &std::path::Path) {
+    fs::remove_file(state_dir.join(delivery::DELIVERY_FILE)).unwrap();
+}
+
 #[test]
 fn completing_a_guide_on_the_real_board_records_its_dismissal() {
     let root = pty::scratch_root("dismiss");
@@ -147,8 +148,7 @@ fn completing_a_guide_on_the_real_board_records_its_dismissal() {
     }
     let store = TaskStore::new(&state_dir);
     assert_eq!(delivery::load(&state_dir).guides, catalog_ids());
-    // Lose the seed's record so the only way it can come back is the dismiss hook.
-    fs::remove_file(state_dir.join(delivery::DELIVERY_FILE)).unwrap();
+    drop_delivery_record(&state_dir);
 
     session.send(b"\x04");
     session.send(b"\x11");

--- a/tests/support/pty.rs
+++ b/tests/support/pty.rs
@@ -1,4 +1,3 @@
-//! Real `tsk` binary on an isolated PTY. Never uses a live Herdr session.
 use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{Read, Write};


### PR DESCRIPTION
## Why

Selected releases should leave one desk notice after an upgrade, without a server and without dumping old history on a fresh install. This PR bundles a maintainer-edited announcement catalog and seeds a single combined notice for anything newer than the local watermark.

## Scope

- `src/announcements/catalog.toml` compiled in via `include_str!`
- `src/announcements.rs` parse + `seed_on_open` (fresh install sets watermark to max and creates nothing; upgrades combine missed ids into one `What's new in tsk` notice)
- Full board open runs announcements after guides; quick capture does not
- Docs: storage, overview, llms.txt, agent skill, AGENTS.md
- Follow-up fix (`703e5a5`): `tsk trash restore` prints `N<n>` for notice rows instead of panicking on a missing T number

Depends on #66 (guides / `delivery.json`). Stack root is #65.

## Tradeoffs

Combined title is always `What's new in tsk`, even for a single missed entry, so the board keeps one shape. Catalog format is TOML with `toml_edit` (already a dependency).

## Blast Radius

Fresh installs only bump `announcement_watermark` and still show the five guides. The first production combined notice appears when catalog id 2 ships. Dismiss uses the same notice path as guides. Trash restore by UUID works for notices after `703e5a5`.

## Verification

- Unit: `cargo test --lib announcements::` (7/7); `cargo test --test cli_trash` (7/7, includes notice restore)
- Live fresh path (isolated PTY): guides only, watermark 1, no What's new
- Live upgrade / gap / dismiss / trash-restore / changelog-in-notes: local receipts under `docs/specs/receipts/` (18/18 lanes at tip)
- Perf: open-path medians in `docs/specs/receipts/notice-stack-perf.json`
- Site: `npm test` 42/42 after build
- Rust CI does not run while base is the stack parent; re-check after retarget onto `main`
- Live herdr smoke not run (`HERDR_ENV` unset)

## Stack

1. #65 → `main`
2. #66 (guides)
3. **This PR (#67)** @ `703e5a5`

Operator lands bottom-up after chat review. Do not merge overnight.