### PR TITLE
setup: add omp agent target honoring OMP_PROFILE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,9 +290,10 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   project refuses with error code `project-archived`. `tsk status` accepts ready, started
   (or start), blocked, review, or done. `tsk steps` also renames and removes.
   `tsk guide` prints the embedded `skills/tsk-cli/SKILL.md` body (also published at
-  `/docs/agents/`, generated at site build). `tsk setup <claude|pi|cursor|grok|codex|opencode|--skill-dir p>`
-  writes that skill into the agent's skills dir (`src/setup_agent.rs`); bare `tsk setup` lists
-  and writes nothing. `tsk --help` ends with a two-line agent footer.
+  `/docs/agents/`, generated at site build). `tsk setup <claude|pi|omp|cursor|grok|codex|opencode|--skill-dir p>`
+  writes that skill into the agent's skills dir (`src/setup_agent.rs`). On a TTY, bare `tsk setup`
+  detects agents and asks once to install or update; without a TTY it lists guidance and writes
+  nothing. `tsk --help` ends with a two-line agent footer.
 - `~/.tsk` must live on a local disk (flock plus rename-based replace); synced folders are
   unsupported, `TSK_STATE_DIR` is the escape hatch. State/config directory roots must be real
   directories, not symlinks; permission hardening refuses a symlink instead of chmodding its target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `tsk setup omp` installs the agent skill for the active OMP profile and participates in detected-agent setup.
+
 ## v0.7.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ tsk setup
 ```
 
 On a TTY that detects agents once and asks to install. Or name one agent
-(`pi`, `claude`, `cursor`, `grok`, `codex`, or `opencode`) to install into its
+(`pi`, `omp`, `claude`, `cursor`, `grok`, `codex`, or `opencode`) to install into its
 user-level skills directory.
 [Other skill directories and setup options](https://gettsk.sh/docs/cli/#setup).
 

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -259,6 +259,7 @@ Requires Herdr 0.9+ on PATH. Registers the installed binary and adds **prefix+t*
 | Target | Skills directory |
 | --- | --- |
 | `pi` | `~/.pi/agent/skills/` |
+| `omp` | Active OMP profile's user skills directory (normally `~/.omp/agent/skills/`) |
 | `claude` | `~/.claude/skills/` |
 | `cursor` | `~/.cursor/skills/` |
 | `grok` | `~/.grok/skills/` |
@@ -266,7 +267,7 @@ Requires Herdr 0.9+ on PATH. Registers the installed binary and adds **prefix+t*
 | `opencode` | `~/.config/opencode/skills/` |
 | `--skill-dir <path>` | The supplied directory |
 
-Setup writes `tsk-cli/SKILL.md` under the selected directory. Skill `version:` is independent of the crate version. A matching installed version exits 1 with `skill-exists`; a missing or different version updates without `--force`. `--force` always overwrites. `tsk setup agents --yes` installs or updates every detected agent without asking. Only global skill roots are offered (project-local roots are out of scope).
+Setup writes `tsk-cli/SKILL.md` under the selected directory. OMP follows `OMP_PROFILE`, using legacy `PI_PROFILE` only when `OMP_PROFILE` is unset; an empty, whitespace, or `default` value explicitly selects the default profile. It also follows `PI_CONFIG_DIR` and the default profile's `PI_CODING_AGENT_DIR`; invalid profile names are refused. Skill `version:` is independent of the crate version. A matching installed version exits 1 with `skill-exists`; a missing or different version updates without `--force`. `--force` always overwrites. `tsk setup agents --yes` installs or updates every detected agent without asking. Only global skill roots are offered (project-local roots are out of scope).
 
 | Option | Action |
 | --- | --- |

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -44,7 +44,7 @@ tsk setup
 tsk setup pi
 ```
 
-On a TTY, bare `tsk setup` detects installed agents and asks once to install or update the skill. Use `claude`, `cursor`, `grok`, `codex`, or `opencode` instead of `pi` for a single named target. Setup installs the CLI skill in that agent's user-level skills directory.
+On a TTY, bare `tsk setup` detects installed agents and asks once to install or update the skill. Use `omp`, `claude`, `cursor`, `grok`, `codex`, or `opencode` instead of `pi` for a single named target. Setup installs the CLI skill in that agent's user-level skills directory; OMP uses its active profile.
 
 [Detection, version updates, and overwrite options](/docs/cli/#setup).
 

--- a/src/setup_agent.rs
+++ b/src/setup_agent.rs
@@ -4,19 +4,20 @@ use std::env;
 use std::fmt;
 use std::fs;
 use std::io::{self, BufRead, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::cli::guide::SKILL_MD;
 
 const SKILL_FOLDER: &str = "tsk-cli";
 const SKILL_FILE: &str = "SKILL.md";
 
-pub const USAGE: &str = "usage: tsk setup [herdr | agents | claude | pi | cursor | grok | codex | opencode | --skill-dir <path>] [--yes] [--force] [--json]\n       tsk setup --detected-ids";
+pub const USAGE: &str = "usage: tsk setup [herdr | agents | claude | pi | omp | cursor | grok | codex | opencode | --skill-dir <path>] [--yes] [--force] [--json]\n       tsk setup --detected-ids";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Target {
     Claude,
     Pi,
+    Omp,
     Cursor,
     Grok,
     Codex,
@@ -29,6 +30,7 @@ impl Target {
         match self {
             Self::Claude => "claude",
             Self::Pi => "pi",
+            Self::Omp => "omp",
             Self::Cursor => "cursor",
             Self::Grok => "grok",
             Self::Codex => "codex",
@@ -42,6 +44,7 @@ impl Target {
             Self::SkillDir(path) => Ok(path.clone()),
             Self::Claude => Ok(home_dir()?.join(".claude/skills")),
             Self::Pi => Ok(home_dir()?.join(".pi/agent/skills")),
+            Self::Omp => Ok(omp_agent_dir()?.join("skills")),
             Self::Cursor => Ok(home_dir()?.join(".cursor/skills")),
             Self::Grok => Ok(home_dir()?.join(".grok/skills")),
             Self::Codex => Ok(home_dir()?.join(".agents/skills")),
@@ -55,10 +58,11 @@ impl Target {
         Ok(self.skills_root()?.join(SKILL_FOLDER).join(SKILL_FILE))
     }
 
-    fn named_agents() -> [Target; 6] {
+    fn named_agents() -> [Target; 7] {
         [
             Target::Claude,
             Target::Pi,
+            Target::Omp,
             Target::Cursor,
             Target::Grok,
             Target::Codex,
@@ -147,6 +151,7 @@ pub enum Error {
     Symlink(PathBuf),
     Home,
     Io(String),
+    InvalidOmpProfile(String),
     Ended,
 }
 
@@ -158,6 +163,10 @@ impl fmt::Display for Error {
             Self::Symlink(path) => write!(f, "refusing symlink: {}", path.display()),
             Self::Home => write!(f, "HOME is not set"),
             Self::Io(detail) => write!(f, "{detail}"),
+            Self::InvalidOmpProfile(profile) => write!(
+                f,
+                "invalid OMP profile {profile:?}; expected [a-z0-9][a-z0-9._-]{{0,63}}, not ending in a dot or using a reserved device name"
+            ),
             Self::Ended => write!(f, "confirmation ended; no changes made"),
         }
     }
@@ -195,6 +204,7 @@ pub fn parse(args: &[String]) -> Result<Command, Error> {
             }
             "claude" => push_agent(&mut agents, Target::Claude)?,
             "pi" => push_agent(&mut agents, Target::Pi)?,
+            "omp" => push_agent(&mut agents, Target::Omp)?,
             "cursor" => push_agent(&mut agents, Target::Cursor)?,
             "grok" => push_agent(&mut agents, Target::Grok)?,
             "codex" => push_agent(&mut agents, Target::Codex)?,
@@ -368,8 +378,12 @@ pub fn detect() -> Result<Vec<AgentStatus>, Error> {
     let embedded = embedded_skill_version();
     let mut out = Vec::new();
     for target in Target::named_agents() {
-        let skills_root = target.skills_root()?;
-        let skill_path = target.skill_path()?;
+        let skills_root = match target.skills_root() {
+            Ok(path) => path,
+            Err(Error::InvalidOmpProfile(_)) if target == Target::Omp => continue,
+            Err(error) => return Err(error),
+        };
+        let skill_path = skills_root.join(SKILL_FOLDER).join(SKILL_FILE);
         if !agent_present(&home, &target, &skills_root) {
             continue;
         }
@@ -564,6 +578,7 @@ pub fn list_text() -> String {
          agents    detect agents; --yes installs/updates without asking\n\
          claude    {}\n\
          pi        {}\n\
+         omp       {}\n\
          cursor    {}\n\
          grok      {}\n\
          codex     {}\n\
@@ -572,6 +587,7 @@ pub fn list_text() -> String {
          --detected-ids      print detected agent ids (for installers)\n",
         display(".claude/skills"),
         display(".pi/agent/skills"),
+        omp_skill_display_path(),
         display(".cursor/skills"),
         display(".grok/skills"),
         display(".agents/skills"),
@@ -605,6 +621,7 @@ fn named_target(id: &str) -> Result<Target, Error> {
     match id {
         "claude" => Ok(Target::Claude),
         "pi" => Ok(Target::Pi),
+        "omp" => Ok(Target::Omp),
         "cursor" => Ok(Target::Cursor),
         "grok" => Ok(Target::Grok),
         "codex" => Ok(Target::Codex),
@@ -617,16 +634,21 @@ fn agent_present(home: &Path, target: &Target, skills_root: &Path) -> bool {
     let marker = match target {
         Target::Claude => home.join(".claude"),
         Target::Pi => home.join(".pi"),
+        Target::Omp => omp_config_root().unwrap_or_else(|_| home.join(".omp")),
         Target::Cursor => home.join(".cursor"),
         Target::Grok => home.join(".grok"),
         Target::Codex => home.join(".codex"),
         Target::OpenCode => home.join(".config/opencode"),
         Target::SkillDir(_) => return true,
     };
+    let omp_agent_dir_present =
+        matches!(target, Target::Omp) && skills_root.parent().is_some_and(real_dir);
     real_dir(&marker)
         || real_dir(skills_root)
+        || omp_agent_dir_present
         || match target {
             Target::Claude => cli_on_path("claude"),
+            Target::Omp => executable_cli_on_path("omp"),
             Target::Cursor => cli_on_path("cursor"),
             Target::Codex => cli_on_path("codex"),
             Target::OpenCode => cli_on_path("opencode"),
@@ -642,16 +664,37 @@ fn real_dir(path: &Path) -> bool {
 }
 
 fn cli_on_path(name: &str) -> bool {
+    path_contains(name, |candidate| {
+        fs::symlink_metadata(candidate).is_ok_and(|meta| meta.is_file())
+    })
+}
+
+fn executable_cli_on_path(name: &str) -> bool {
+    path_contains(name, |candidate| {
+        fs::metadata(candidate).is_ok_and(|meta| executable_file(&meta))
+    })
+}
+
+fn path_contains(name: &str, predicate: impl Fn(&Path) -> bool) -> bool {
     let Some(path) = env::var_os("PATH") else {
         return false;
     };
-    env::split_paths(&path).any(|dir| {
-        let candidate = dir.join(name);
-        match fs::symlink_metadata(&candidate) {
-            Ok(meta) => meta.is_file(),
-            Err(_) => false,
-        }
-    })
+    env::split_paths(&path).any(|dir| predicate(&dir.join(name)))
+}
+
+fn executable_file(meta: &fs::Metadata) -> bool {
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 enum SkillStatusDetail {
@@ -711,6 +754,137 @@ fn home_dir() -> Result<PathBuf, Error> {
         .ok_or(Error::Home)
 }
 
+/// Resolve OMP's active user agent directory. Named profiles are rooted under
+/// `PI_CONFIG_DIR` and ignore `PI_CODING_AGENT_DIR`; the default profile honors
+/// that agent-directory override, matching OMP's `getAgentDir()` contract.
+fn omp_agent_dir() -> Result<PathBuf, Error> {
+    if let Some(profile) = active_omp_profile()? {
+        return Ok(omp_config_root()?
+            .join("profiles")
+            .join(profile)
+            .join("agent"));
+    }
+    if let Some(override_dir) = env::var_os("PI_CODING_AGENT_DIR").filter(|value| !value.is_empty())
+    {
+        if !profile_derived_agent_override(&override_dir)? {
+            let path = PathBuf::from(override_dir);
+            let absolute = if path.is_absolute() {
+                path
+            } else {
+                env::current_dir().map_err(io_error)?.join(path)
+            };
+            return Ok(normalize_absolute_path(&absolute));
+        }
+    }
+    Ok(omp_config_root()?.join("agent"))
+}
+
+fn omp_config_root() -> Result<PathBuf, Error> {
+    let config_dir = PathBuf::from(
+        env::var_os("PI_CONFIG_DIR")
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| ".omp".into()),
+    );
+    let relative: PathBuf = config_dir
+        .components()
+        .filter_map(|component| match component {
+            Component::Prefix(_) | Component::RootDir => None,
+            Component::CurDir => None,
+            Component::ParentDir => Some("..".into()),
+            Component::Normal(part) => Some(part.to_owned()),
+        })
+        .collect();
+    Ok(normalize_absolute_path(&home_dir()?.join(relative)))
+}
+
+fn profile_derived_agent_override(override_dir: &std::ffi::OsStr) -> Result<bool, Error> {
+    let Some(pi_profile) = env::var_os("PI_PROFILE") else {
+        return Ok(false);
+    };
+    let Ok(Some(pi_profile)) = normalize_omp_profile(pi_profile) else {
+        return Ok(false);
+    };
+    let profile_agent_dir = omp_config_root()?
+        .join("profiles")
+        .join(pi_profile)
+        .join("agent");
+    Ok(Path::new(override_dir) == profile_agent_dir)
+}
+
+fn active_omp_profile() -> Result<Option<String>, Error> {
+    let raw = match env::var_os("OMP_PROFILE") {
+        Some(value) => Some(value),
+        None => env::var_os("PI_PROFILE"),
+    };
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    normalize_omp_profile(raw)
+}
+
+fn normalize_omp_profile(raw: std::ffi::OsString) -> Result<Option<String>, Error> {
+    let profile = raw
+        .into_string()
+        .map_err(|value| Error::InvalidOmpProfile(value.to_string_lossy().into_owned()))?;
+    let profile = profile.trim();
+    if profile.is_empty() || profile == "default" {
+        return Ok(None);
+    }
+    if !valid_omp_profile(profile) {
+        return Err(Error::InvalidOmpProfile(profile.to_owned()));
+    }
+    Ok(Some(profile.to_owned()))
+}
+
+fn valid_omp_profile(profile: &str) -> bool {
+    let bytes = profile.as_bytes();
+    if bytes.is_empty()
+        || bytes.len() > 64
+        || !(bytes[0].is_ascii_lowercase() || bytes[0].is_ascii_digit())
+        || profile.ends_with('.')
+        || !bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+    {
+        return false;
+    }
+    let base = profile.split('.').next().unwrap_or_default();
+    !matches!(base, "con" | "prn" | "aux" | "nul")
+        && !(base.len() == 4
+            && (base.starts_with("com") || base.starts_with("lpt"))
+            && base.as_bytes()[3].is_ascii_digit())
+}
+
+fn normalize_absolute_path(path: &Path) -> PathBuf {
+    debug_assert!(path.is_absolute());
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+fn omp_skill_display_path() -> String {
+    match omp_agent_dir() {
+        Ok(path) => path
+            .join("skills")
+            .join(SKILL_FOLDER)
+            .join(SKILL_FILE)
+            .display()
+            .to_string(),
+        Err(Error::Home) => "$HOME/.omp/agent/skills/tsk-cli/SKILL.md".to_owned(),
+        Err(error) => format!("<{}>", error),
+    }
+}
+
 fn refuse_symlink(path: &Path) -> Result<(), Error> {
     match fs::symlink_metadata(path) {
         Ok(meta) if meta.file_type().is_symlink() => Err(Error::Symlink(path.to_path_buf())),
@@ -739,6 +913,38 @@ mod tests {
             .unwrap_or_else(|poison| poison.into_inner())
     }
 
+    struct OmpEnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+    impl OmpEnvGuard {
+        fn cleared() -> Self {
+            let values = [
+                "OMP_PROFILE",
+                "PI_PROFILE",
+                "PI_CONFIG_DIR",
+                "PI_CODING_AGENT_DIR",
+            ]
+            .into_iter()
+            .map(|key| {
+                let value = env::var_os(key);
+                env::remove_var(key);
+                (key, value)
+            })
+            .collect();
+            Self(values)
+        }
+    }
+
+    impl Drop for OmpEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.0.drain(..) {
+                match value {
+                    Some(value) => env::set_var(key, value),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+
     #[test]
     fn embedded_skill_declares_semver() {
         let version = embedded_skill_version();
@@ -762,6 +968,7 @@ mod tests {
     #[test]
     fn interactive_batch_yes_installs_detected_agent() {
         let _lock = env_lock();
+        let _omp_env = OmpEnvGuard::cleared();
         let root =
             std::env::temp_dir().join(format!("tsk-setup-agent-batch-yes-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);
@@ -799,6 +1006,7 @@ mod tests {
     #[test]
     fn interactive_batch_no_skips_write() {
         let _lock = env_lock();
+        let _omp_env = OmpEnvGuard::cleared();
         let root =
             std::env::temp_dir().join(format!("tsk-setup-agent-batch-no-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);

--- a/tests/cli_setup_agent.rs
+++ b/tests/cli_setup_agent.rs
@@ -40,6 +40,39 @@ fn skill_source() -> &'static str {
     include_str!("../skills/tsk-cli/SKILL.md")
 }
 
+struct OmpEnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+impl OmpEnvGuard {
+    fn cleared() -> Self {
+        let keys = [
+            "OMP_PROFILE",
+            "PI_PROFILE",
+            "PI_CONFIG_DIR",
+            "PI_CODING_AGENT_DIR",
+        ];
+        let values = keys
+            .into_iter()
+            .map(|key| {
+                let value = std::env::var_os(key);
+                std::env::remove_var(key);
+                (key, value)
+            })
+            .collect();
+        Self(values)
+    }
+}
+
+impl Drop for OmpEnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.0.drain(..) {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
 #[test]
 fn skill_dir_writes_full_skill_prints_path_exits_0() {
     let _lock = env_lock();
@@ -161,6 +194,7 @@ fn force_overwrites() {
 #[test]
 fn bare_setup_non_tty_lists_targets_and_writes_nothing() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("list");
     let home = root.join("home");
     fs::create_dir_all(&home).expect("home");
@@ -182,6 +216,7 @@ fn bare_setup_non_tty_lists_targets_and_writes_nothing() {
         "herdr",
         "claude",
         "pi",
+        "omp",
         "codex",
         "cursor",
         "grok",
@@ -203,6 +238,20 @@ fn bare_setup_non_tty_lists_targets_and_writes_nothing() {
         output.stdout.contains(".config/opencode/skills"),
         "bare setup should advertise the opencode skills dir, got {:?}",
         output.stdout
+    );
+    assert!(
+        output.stdout.contains(".omp/agent/skills"),
+        "bare setup should advertise the omp skills dir, got {:?}",
+        output.stdout
+    );
+    std::env::set_var("OMP_PROFILE", "research");
+    let profiled = cli_non_tty(&["tsk", "setup"]);
+    assert_eq!(profiled.code, 0, "{profiled:?}");
+    assert!(
+        profiled
+            .stdout
+            .contains(".omp/profiles/research/agent/skills/tsk-cli/SKILL.md"),
+        "the listing should resolve the active OMP profile: {profiled:?}"
     );
     assert!(
         !home.join(".claude").exists(),
@@ -233,6 +282,7 @@ fn two_targets_or_herdr_plus_skill_dir_are_usage() {
 #[test]
 fn json_emits_written_exists_or_listed() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("json");
     let skill_dir = root.join("skills");
     let path = skill_dir.to_str().expect("utf-8");
@@ -290,6 +340,7 @@ fn empty_skill_dir_is_usage_and_writes_nothing() {
 #[test]
 fn named_agent_targets_write_under_home() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("named");
     let home = root.join("home");
     fs::create_dir_all(&home).expect("home");
@@ -298,6 +349,7 @@ fn named_agent_targets_write_under_home() {
     let cases = [
         ("claude", ".claude/skills"),
         ("pi", ".pi/agent/skills"),
+        ("omp", ".omp/agent/skills"),
         ("cursor", ".cursor/skills"),
         ("codex", ".agents/skills"),
         ("grok", ".grok/skills"),
@@ -316,6 +368,385 @@ fn named_agent_targets_write_under_home() {
     match previous_home {
         Some(value) => std::env::set_var("HOME", value),
         None => std::env::remove_var("HOME"),
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn omp_target_resolves_profiles_and_directory_overrides() {
+    let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
+    let root = temp_dir("omp-paths");
+    let home = root.join("home");
+    fs::create_dir_all(&home).expect("home");
+    let previous_home = std::env::var_os("HOME");
+    std::env::set_var("HOME", &home);
+
+    let default = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(default.code, 0, "{default:?}");
+    let default_skill = home.join(".omp/agent/skills/tsk-cli/SKILL.md");
+    assert_eq!(
+        fs::read_to_string(&default_skill).expect("default skill"),
+        skill_source()
+    );
+    let current = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(
+        current.code, 1,
+        "matching version stays current: {current:?}"
+    );
+    fs::write(&default_skill, "stale without frontmatter\n").expect("stale skill");
+    let updated = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(updated.code, 0, "outdated skill updates: {updated:?}");
+    assert_eq!(
+        fs::read_to_string(&default_skill).expect("updated skill"),
+        skill_source()
+    );
+
+    std::env::set_var("OMP_PROFILE", "  research  ");
+    let named = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(named.code, 0, "named profile: {named:?}");
+    assert!(home
+        .join(".omp/profiles/research/agent/skills/tsk-cli/SKILL.md")
+        .exists());
+
+    std::env::set_var("OMP_PROFILE", "");
+    std::env::set_var("PI_PROFILE", "legacy-ignored");
+    let empty_wins = cli(&["tsk", "setup", "omp", "--force"]);
+    assert_eq!(empty_wins.code, 0, "empty OMP profile wins: {empty_wins:?}");
+    assert!(!home.join(".omp/profiles/legacy-ignored").exists());
+    std::env::set_var("OMP_PROFILE", "   ");
+    let whitespace_wins = cli(&["tsk", "setup", "omp", "--force"]);
+    assert_eq!(
+        whitespace_wins.code, 0,
+        "whitespace OMP profile wins: {whitespace_wins:?}"
+    );
+    assert!(!home.join(".omp/profiles/legacy-ignored").exists());
+    std::env::set_var(
+        "PI_CODING_AGENT_DIR",
+        home.join(".omp/profiles/legacy-ignored/agent"),
+    );
+    let inherited_override = cli(&["tsk", "setup", "omp", "--force"]);
+    assert_eq!(
+        inherited_override.code, 0,
+        "profile-derived override is suppressed: {inherited_override:?}"
+    );
+    assert!(
+        !home
+            .join(".omp/profiles/legacy-ignored/agent/skills/tsk-cli/SKILL.md")
+            .exists(),
+        "an inherited profile agent dir must not move the explicit default profile"
+    );
+
+    std::env::remove_var("OMP_PROFILE");
+    let legacy = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(legacy.code, 0, "legacy PI profile: {legacy:?}");
+    assert!(home
+        .join(".omp/profiles/legacy-ignored/agent/skills/tsk-cli/SKILL.md")
+        .exists());
+
+    std::env::set_var("OMP_PROFILE", "custom");
+    std::env::set_var("PI_CONFIG_DIR", ".config/omp-test");
+    std::env::set_var("PI_CODING_AGENT_DIR", root.join("ignored-agent-dir"));
+    let configured_named = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(
+        configured_named.code, 0,
+        "configured profile: {configured_named:?}"
+    );
+    assert!(
+        home.join(".config/omp-test/profiles/custom/agent/skills/tsk-cli/SKILL.md")
+            .exists(),
+        "named profiles use PI_CONFIG_DIR"
+    );
+    assert!(
+        !root
+            .join("ignored-agent-dir/skills/tsk-cli/SKILL.md")
+            .exists(),
+        "named profiles ignore PI_CODING_AGENT_DIR"
+    );
+
+    std::env::remove_var("PI_CODING_AGENT_DIR");
+    let absolute_config = root.join("absolute-config");
+    std::env::set_var("PI_CONFIG_DIR", &absolute_config);
+    std::env::set_var("OMP_PROFILE", "absolute");
+    let absolute_config_output = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(
+        absolute_config_output.code, 0,
+        "absolute-looking config dir: {absolute_config_output:?}"
+    );
+    let home_relative_config = absolute_config
+        .strip_prefix("/")
+        .expect("absolute path beneath root");
+    assert!(
+        home.join(home_relative_config)
+            .join("profiles/absolute/agent/skills/tsk-cli/SKILL.md")
+            .exists(),
+        "PI_CONFIG_DIR follows OMP's home-relative path.join semantics"
+    );
+    assert!(
+        !absolute_config
+            .join("profiles/absolute/agent/skills/tsk-cli/SKILL.md")
+            .exists(),
+        "an absolute PI_CONFIG_DIR must not escape HOME"
+    );
+
+    std::env::set_var("PI_CONFIG_DIR", ".default-omp-test");
+    std::env::set_var("OMP_PROFILE", "default");
+    let configured_default_root = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(
+        configured_default_root.code, 0,
+        "configured default root: {configured_default_root:?}"
+    );
+    assert!(
+        home.join(".default-omp-test/agent/skills/tsk-cli/SKILL.md")
+            .exists(),
+        "the default profile honors PI_CONFIG_DIR without an agent override"
+    );
+
+    std::env::set_var("PI_CONFIG_DIR", ".config/omp-test");
+    std::env::set_var("PI_CODING_AGENT_DIR", root.join("ignored-agent-dir"));
+    std::env::set_var("OMP_PROFILE", "default");
+    let configured_default = cli(&["tsk", "setup", "omp"]);
+    assert_eq!(
+        configured_default.code, 0,
+        "configured default: {configured_default:?}"
+    );
+    assert!(
+        root.join("ignored-agent-dir/skills/tsk-cli/SKILL.md")
+            .exists(),
+        "the default profile honors PI_CODING_AGENT_DIR"
+    );
+
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn omp_relative_agent_override_is_lexically_normalized() {
+    let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
+    let root = temp_dir("omp-relative-agent-dir");
+    let home = root.join("home");
+    let work = root.join("work");
+    let outside_nested = root.join("outside/nested");
+    fs::create_dir_all(&home).expect("home");
+    fs::create_dir_all(&work).expect("work");
+    fs::create_dir_all(&outside_nested).expect("outside");
+    std::os::unix::fs::symlink(&outside_nested, work.join("link")).expect("directory symlink");
+    let previous_home = std::env::var_os("HOME");
+    let previous_cwd = std::env::current_dir().expect("cwd");
+    std::env::set_var("HOME", &home);
+    std::env::set_var("PI_CODING_AGENT_DIR", "link/..");
+    std::env::set_current_dir(&work).expect("enter work dir");
+
+    let output = cli(&["tsk", "setup", "omp"]);
+    std::env::set_current_dir(previous_cwd).expect("restore cwd");
+    assert_eq!(output.code, 0, "{output:?}");
+    assert!(
+        work.join("skills/tsk-cli/SKILL.md").exists(),
+        "path.resolve normalizes the override before filesystem traversal"
+    );
+    assert!(
+        !root.join("outside/skills/tsk-cli/SKILL.md").exists(),
+        "the symlink must not redirect a parent traversal"
+    );
+
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn omp_target_rejects_invalid_profiles_without_writing() {
+    let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
+    let root = temp_dir("omp-invalid-profile");
+    let home = root.join("home");
+    fs::create_dir_all(&home).expect("home");
+    let previous_home = std::env::var_os("HOME");
+    std::env::set_var("HOME", &home);
+
+    let too_long = "a".repeat(65);
+    for profile in ["../escape", "Upper", "name.", "con", too_long.as_str()] {
+        std::env::set_var("OMP_PROFILE", profile);
+        let output = cli(&["tsk", "setup", "omp"]);
+        assert_eq!(output.code, 1, "profile {profile:?}: {output:?}");
+        assert!(
+            output.stderr.contains("invalid OMP profile"),
+            "profile {profile:?}: {output:?}"
+        );
+    }
+    assert!(
+        !root.join("escape/agent/skills/tsk-cli/SKILL.md").exists(),
+        "a profile cannot escape the OMP config root"
+    );
+
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn invalid_omp_profile_does_not_block_other_agent_detection() {
+    let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
+    let root = temp_dir("omp-invalid-detection");
+    let home = root.join("home");
+    let empty_bin = root.join("empty-bin");
+    fs::create_dir_all(home.join(".claude")).expect("Claude marker");
+    fs::create_dir_all(&empty_bin).expect("empty bin");
+    let previous_home = std::env::var_os("HOME");
+    let previous_path = std::env::var_os("PATH");
+    std::env::set_var("HOME", &home);
+    std::env::set_var("PATH", &empty_bin);
+    std::env::set_var("OMP_PROFILE", "Invalid/Profile");
+
+    let detected = cli_non_tty(&["tsk", "setup", "--detected-ids"]);
+    assert_eq!(detected.code, 0, "{detected:?}");
+    assert_eq!(detected.stdout.trim(), "claude");
+    let installed = cli_non_tty(&["tsk", "setup", "agents", "--yes"]);
+    assert_eq!(installed.code, 0, "{installed:?}");
+    assert!(home.join(".claude/skills/tsk-cli/SKILL.md").exists());
+    let direct = cli_non_tty(&["tsk", "setup", "omp"]);
+    assert_eq!(
+        direct.code, 1,
+        "explicit OMP setup still refuses: {direct:?}"
+    );
+    assert!(direct.stderr.contains("invalid OMP profile"), "{direct:?}");
+
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    match previous_path {
+        Some(value) => std::env::set_var("PATH", value),
+        None => std::env::remove_var("PATH"),
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn omp_detection_uses_configured_and_overridden_roots() {
+    let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
+    let root = temp_dir("omp-detection-roots");
+    let home = root.join("home");
+    let empty_bin = root.join("empty-bin");
+    fs::create_dir_all(&home).expect("home");
+    fs::create_dir_all(&empty_bin).expect("empty bin");
+    let previous_home = std::env::var_os("HOME");
+    let previous_path = std::env::var_os("PATH");
+    std::env::set_var("HOME", &home);
+    std::env::set_var("PATH", &empty_bin);
+
+    std::env::set_var("PI_CONFIG_DIR", ".custom-omp");
+    fs::create_dir_all(home.join(".custom-omp")).expect("custom config root");
+    let configured = cli_non_tty(&["tsk", "setup", "--detected-ids"]);
+    assert_eq!(configured.code, 0, "{configured:?}");
+    assert_eq!(configured.stdout.trim(), "omp");
+
+    fs::remove_dir_all(home.join(".custom-omp")).expect("remove config root");
+    std::env::remove_var("PI_CONFIG_DIR");
+    let agent_dir = root.join("active-agent");
+    fs::create_dir_all(&agent_dir).expect("active agent dir");
+    std::env::set_var("PI_CODING_AGENT_DIR", &agent_dir);
+    let overridden = cli_non_tty(&["tsk", "setup", "--detected-ids"]);
+    assert_eq!(overridden.code, 0, "{overridden:?}");
+    assert_eq!(overridden.stdout.trim(), "omp");
+
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    match previous_path {
+        Some(value) => std::env::set_var("PATH", value),
+        None => std::env::remove_var("PATH"),
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn omp_detection_and_batch_install_use_the_active_profile() {
+    let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
+    let root = temp_dir("omp-detection");
+    let home = root.join("home");
+    let empty_bin = root.join("empty-bin");
+    fs::create_dir_all(home.join(".omp")).expect("OMP config root");
+    fs::create_dir_all(&empty_bin).expect("empty bin");
+    let previous_home = std::env::var_os("HOME");
+    let previous_path = std::env::var_os("PATH");
+    std::env::set_var("HOME", &home);
+    std::env::set_var("PATH", &empty_bin);
+    std::env::set_var("OMP_PROFILE", "research");
+
+    let detected = cli_non_tty(&["tsk", "setup", "--detected-ids"]);
+    assert_eq!(detected.code, 0, "{detected:?}");
+    assert_eq!(detected.stdout.trim(), "omp");
+    let installed = cli_non_tty(&["tsk", "setup", "agents", "--yes"]);
+    assert_eq!(installed.code, 0, "{installed:?}");
+    let skill = home.join(".omp/profiles/research/agent/skills/tsk-cli/SKILL.md");
+    assert_eq!(
+        fs::read_to_string(&skill).expect("batch skill"),
+        skill_source()
+    );
+
+    let report = cli_non_tty(&["tsk", "setup", "--json"]);
+    assert_eq!(report.code, 0, "{report:?}");
+    let report: serde_json::Value =
+        serde_json::from_str(report.stdout.trim()).expect("detection report");
+    let omp = report["agents"]
+        .as_array()
+        .expect("agents")
+        .iter()
+        .find(|agent| agent["id"] == "omp")
+        .expect("OMP row");
+    assert_eq!(omp["state"], "current");
+    assert_eq!(
+        omp["skill_path"],
+        skill.display().to_string(),
+        "detection reports the profile-scoped destination"
+    );
+
+    fs::remove_dir_all(home.join(".omp")).expect("remove config marker");
+    std::env::remove_var("OMP_PROFILE");
+    let omp_bin = empty_bin.join("omp");
+    fs::write(&omp_bin, "#!/bin/sh\n").expect("stub OMP binary");
+    let non_executable = cli_non_tty(&["tsk", "setup", "--detected-ids"]);
+    assert_eq!(non_executable.code, 0, "{non_executable:?}");
+    assert!(
+        non_executable.stdout.trim().is_empty(),
+        "a non-executable file on PATH is not an installed agent: {non_executable:?}"
+    );
+    fs::remove_file(&omp_bin).expect("remove non-executable stub");
+    let real_bin = root.join("real-bin");
+    fs::create_dir_all(&real_bin).expect("real bin");
+    let real_omp = real_bin.join("omp-real");
+    fs::write(&real_omp, "#!/bin/sh\n").expect("real OMP binary");
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = fs::metadata(&real_omp).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&real_omp, permissions).expect("chmod");
+    std::os::unix::fs::symlink(&real_omp, &omp_bin).expect("OMP PATH symlink");
+    let path_detected = cli_non_tty(&["tsk", "setup", "--detected-ids"]);
+    assert_eq!(path_detected.code, 0, "{path_detected:?}");
+    assert_eq!(path_detected.stdout.trim(), "omp");
+
+    match previous_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
+    match previous_path {
+        Some(value) => std::env::set_var("PATH", value),
+        None => std::env::remove_var("PATH"),
     }
     let _ = fs::remove_dir_all(root);
 }
@@ -376,6 +807,7 @@ fn force_refuses_a_symlinked_skill_file_and_directory() {
 #[test]
 fn detected_ids_prints_space_separated_agents() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("ids");
     let home = root.join("home");
     fs::create_dir_all(home.join(".cursor")).expect("cursor");
@@ -408,22 +840,30 @@ fn detected_ids_prints_space_separated_agents() {
 #[test]
 fn opencode_detects_via_path_binary() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("opencode-path");
     let home = root.join("home");
     let bin = root.join("bin");
     fs::create_dir_all(&home).expect("home");
     fs::create_dir_all(&bin).expect("bin");
     fs::write(bin.join("opencode"), "#!/bin/sh\n").expect("stub");
+    let previous_home = std::env::var_os("HOME");
+    let previous_path = std::env::var_os("PATH");
+    std::env::set_var("HOME", &home);
+    std::env::set_var("PATH", &bin);
+    let non_executable = cli_non_tty(&["tsk", "setup", "--detected-ids"]);
+    assert_eq!(non_executable.code, 0, "{non_executable:?}");
+    assert_eq!(
+        non_executable.stdout.trim(),
+        "opencode",
+        "existing agents keep regular-file PATH detection"
+    );
     use std::os::unix::fs::PermissionsExt;
     let mut perms = fs::metadata(bin.join("opencode"))
         .expect("meta")
         .permissions();
     perms.set_mode(0o755);
     fs::set_permissions(bin.join("opencode"), perms).expect("chmod");
-    let previous_home = std::env::var_os("HOME");
-    let previous_path = std::env::var_os("PATH");
-    std::env::set_var("HOME", &home);
-    std::env::set_var("PATH", &bin);
     let output = cli_non_tty(&["tsk", "setup", "--detected-ids"]);
     match previous_home {
         Some(value) => std::env::set_var("HOME", value),
@@ -442,6 +882,7 @@ fn opencode_detects_via_path_binary() {
 #[test]
 fn agents_yes_installs_without_asking() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("agents-yes");
     let home = root.join("home");
     fs::create_dir_all(home.join(".claude")).expect("claude");
@@ -470,6 +911,7 @@ fn agents_yes_installs_without_asking() {
 #[test]
 fn agents_yes_json_is_machine_readable() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("agents-yes-json");
     let home = root.join("home");
     fs::create_dir_all(home.join(".claude")).expect("claude");
@@ -499,6 +941,7 @@ fn agents_yes_json_is_machine_readable() {
 #[test]
 fn agents_yes_reports_blocked_skill_roots() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("agents-blocked");
     let home = root.join("home");
     let outside = root.join("outside");
@@ -531,6 +974,7 @@ fn agents_yes_reports_blocked_skill_roots() {
 #[test]
 fn bare_setup_non_tty_with_detected_agents_prints_guidance_without_writing() {
     let _lock = env_lock();
+    let _omp_env = OmpEnvGuard::cleared();
     let root = temp_dir("bare-nontty");
     let home = root.join("home");
     fs::create_dir_all(home.join(".cursor")).expect("cursor");


### PR DESCRIPTION
`tsk setup omp` writes the embedded `tsk-cli` skill into OMP's user-level skills dir.

Before this, OMP had no named target: users had to pass `--skill-dir ~/.omp/agent/skills`
manually, and the profile nuance was easy to get wrong because an active named profile
resolves `~/.omp/agent` to `~/.omp/profiles/<name>/agent` — the default-profile path is
invisible to profile-scoped sessions.

**Behavior**

- Default profile: writes `~/.omp/agent/skills/tsk-cli/SKILL.md`.
- Named profile: writes `~/.omp/profiles/<name>/agent/skills/tsk-cli/SKILL.md`.
- Profile resolution mirrors omp: `OMP_PROFILE` wins when defined, even if empty; the
  legacy `PI_PROFILE` applies only when `OMP_PROFILE` is unset; `default`, empty, or
  whitespace keeps the default profile.
- Bare `tsk setup` now lists the `omp` target with the resolved path, so users see the
  profile relocation instead of guessing.

`--skill-dir` and all existing targets are unchanged.

**Verification**

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`
  (41 binaries, all pass), `cargo build --release`
- `cd site && npm ci && npm test` (42/42) and `npm run build`
- Regression: `tests/cli_setup_agent.rs::omp_target_resolves_the_active_profile` —
  named profile → `~/.omp/profiles/<name>/agent/skills`, `"default"`/empty → default,
  defined-empty `OMP_PROFILE` beating a named `PI_PROFILE`, `PI_PROFILE` fallback.
  Existing home-based tests now clear `OMP_PROFILE`/`PI_PROFILE` so they hold on
  machines running omp profiles.
- Release-binary smoke test on a machine with `OMP_PROFILE` set: bare `tsk setup`
  lists `omp` pointing at the active profile's skills dir.

Docs updated: README, site CLI setup table, site install guide, AGENTS.md, CHANGELOG Unreleased.
