### PR TITLE
docs(board): rewrite starter tasks into a four-task tour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,7 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   On board launch, if `TSK_NO_UPDATE_CHECK` is unset and that cache is older than 24h,
   a background `curl` of the GitHub latest-release tag updates it; a newer tag paints a
   dim `v<tag> available` on the idle status row. Any check failure is silent.
-- Starter guides (`src/guides.rs`, catalog ids `guide.*`) are desk notice rows seeded once
+- Starter tasks (`src/guides.rs`, catalog ids `guide.*`) are four desk notice tasks seeded once
   per state dir by the full board open only (`load_board`, never quick capture, the CLI, or
   the installer). `delivery.json` (`src/delivery.rs`) holds the delivered or dismissed catalog
   ids and the announcement watermark; the seeder dedupes by catalog id in the store, so a

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -5,7 +5,7 @@
 Install with `curl -fsSL https://gettsk.sh/install.sh | sh` or `brew install smarzban/tap/tsk`.
 Details: https://gettsk.sh/docs/install.md
 The board checks GitHub releases at most daily and shows a dim `vX.Y.Z available` on the status row; set `TSK_NO_UPDATE_CHECK` to disable.
-`N` rows on the desk are human-only notices: starter guides on a first open, one `What's new in tsk` row after an upgrade. `tsk list` never shows them.
+`N` tasks on the desk are human-only notices: four starter tasks on a first open, one `What's new in tsk` task after an upgrade. `tsk list` never shows them.
 
 ## For agents
 

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -68,7 +68,7 @@ Agents can set any status with [the CLI](/docs/cli/#status). Task status does no
 
 ## Notices
 
-Your first board open seeds about five desk rows with `N` ids (not `T`). They teach the board by being ordinary tasks: open, peek, change status, archive, or delete. `ctrl+d`, `ctrl+f`, and `ctrl+x` all dismiss a notice the same way; that guide never re-seeds. After an upgrade, one `What's new in tsk` row can appear the same way. Details and the delivery record live under [storage](/docs/storage/#starter-guides-and-release-notes).
+Your first board open seeds four desk tasks with `N` ids (not `T`). They teach the board by being ordinary tasks: open, peek, change status, archive, or delete. `ctrl+d`, `ctrl+f`, and `ctrl+x` all dismiss a notice the same way; that starter task never re-seeds. After an upgrade, one `What's new in tsk` task can appear the same way. Details and the delivery record live under [storage](/docs/storage/#starter-guides-and-release-notes).
 
 ## Mouse
 

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -47,7 +47,7 @@ Data commands accept `--state-dir <dir>`. Setup and guide do not use that flag.
 
 `T12`, `t12`, `12`, and a task UUID identify the same task. Direct lookup ignores the current project.
 
-Board notice rows paint as `N1`… (starter guides and `What's new in tsk`). Those ids are board-only: the CLI does not accept `N1`, and default `tsk list` omits them. Agents ignore them.
+Board notice tasks paint as `N1`… (starter tasks and `What's new in tsk`). Those ids are board-only: the CLI does not accept `N1`, and default `tsk list` omits them. Agents ignore them.
 
 ### Scope
 

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -10,7 +10,7 @@ Use it beside your agent in Herdr, or run `tsk` in any terminal. Both use the sa
 ## Start here
 
 1. [Install tsk and connect Herdr](/docs/install/).
-2. Your first board opens with five `N` guide rows on the desk. Open one with `Enter`; clear it with `ctrl+d`, `ctrl+f`, or `ctrl+x` when you are done. After an upgrade, a `What's new in tsk` row arrives the same way.
+2. Your first board opens with four `N` starter tasks on the desk. Open one with `Enter`; clear it with `ctrl+d`, `ctrl+f`, or `ctrl+x` when you are done. After an upgrade, a `What's new in tsk` task arrives the same way.
 3. Press `+`, type a title, and press `Enter`.
 4. Open the task for notes and steps.
 5. Give your agent its task number.

--- a/site/src/content/docs/docs/storage.md
+++ b/site/src/content/docs/docs/storage.md
@@ -25,7 +25,7 @@ Herdr's plugin-specific state/config directories do not override these locations
 | `tsk.json.1` | Previous valid task document |
 | `tsk.json.v<N>` | Backup made when migrating an older store format |
 | `walkthrough.json` | Whether onboarding was dismissed |
-| `delivery.json` | Which starter guides this install has received or dismissed, and the newest release note it has seen |
+| `delivery.json` | Which starter tasks this install has received or dismissed, and the newest release note it has seen |
 
 An older binary refuses a newer or unversioned store instead of rewriting it. Use a compatible tsk version to open it.
 
@@ -33,9 +33,9 @@ Archived tasks stay in the task document with their existing status. [Archive an
 
 ## Starter guides and release notes
 
-The starter guides (`N1`… on your desk) are seeded once per state directory on the first board open. Mark one done, archive it, or delete it and it never returns. Deleting `delivery.json` seeds any guide the task document no longer holds.
+The four starter tasks (`N1`… on your desk) are seeded once per state directory on the first board open. Mark one done, archive it, or delete it and it never returns. Deleting `delivery.json` seeds any starter catalog id the task document no longer holds.
 
-After an upgrade, the first board open adds one `What's new in tsk` row to your desk when the new version bundles release notes you have not seen. That includes upgrading from a build that only had starter guides. Every missed release lands in that one row, newest first, with its changelog link in the notes. The notes ship inside the binary; a blank first install records them as seen and shows none. Clear the row like any guide.
+After an upgrade, the first board open adds one `What's new in tsk` task to your desk when the new version bundles release notes you have not seen. That includes upgrading from a build that only had starter tasks. Every missed release lands in that one task, newest first, with its changelog link in the notes. The notes ship inside the binary; a blank first install records them as seen and shows none. Clear it like any starter task.
 
 ## Deleted tasks
 

--- a/skills/tsk-cli/SKILL.md
+++ b/skills/tsk-cli/SKILL.md
@@ -74,7 +74,7 @@ exclusive, as are `--done` and `--deleted`.
 A typo in a project name silently files the task under a new scope. Use
 `tsk list --all --json` to recover the resulting scope.
 
-Rows the board paints as `N1`… are human-only notices: starter guides and the
+Rows the board paints as `N1`… are human-only notices: starter tasks and the
 `What's new in tsk` release note. `tsk list` never shows them, no command addresses
 them, and agents ignore them.
 

--- a/src/announcements.rs
+++ b/src/announcements.rs
@@ -221,17 +221,17 @@ mod tests {
     fn a_fresh_install_takes_the_bundled_watermark_and_no_announcement_row() {
         let store = temp_store("fresh");
         assert!(is_fresh_install(&store));
-        assert_eq!(guides::seed_on_open(&store), Ok(5));
+        assert_eq!(guides::seed_on_open(&store), Ok(4));
         assert_eq!(
             seed(&store, &[announcement(1), announcement(2)], true),
             Ok(0)
         );
         let state = store.load().expect("load");
-        assert_eq!(state.tasks().iter().filter(|t| t.is_notice()).count(), 5);
+        assert_eq!(state.tasks().iter().filter(|t| t.is_notice()).count(), 4);
         assert!(announced(&state).is_empty());
         let record = delivery::load(store.path());
         assert_eq!(record.announcement_watermark, 2);
-        assert_eq!(record.guides.len(), 5, "the guide marks survive");
+        assert_eq!(record.guides.len(), 4, "the guide marks survive");
         let _ = fs::remove_dir_all(store.path());
     }
 
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn upgrading_from_guides_only_seeds_whats_new_for_bundled_entries() {
         let store = temp_store("guides-upgrade");
-        assert_eq!(guides::seed_on_open(&store), Ok(5));
+        assert_eq!(guides::seed_on_open(&store), Ok(4));
         assert_eq!(delivery::load(store.path()).announcement_watermark, 0);
         assert!(
             !is_fresh_install(&store),

--- a/src/app.rs
+++ b/src/app.rs
@@ -3253,7 +3253,7 @@ mod tests {
     fn archiving_or_deleting_a_guide_on_the_board_records_its_dismissal() {
         let run_case = |label: &str, intents: &[BoardIntent]| {
             let temp = TempStore::new(label);
-            assert_eq!(crate::guides::seed_on_open(&temp.store), Ok(5));
+            assert_eq!(crate::guides::seed_on_open(&temp.store), Ok(4));
             std::fs::remove_file(temp.dir.join(crate::delivery::DELIVERY_FILE))
                 .expect("drop the delivery record");
             let mut domain = temp.store.load().expect("load seeded board");

--- a/src/guides.rs
+++ b/src/guides.rs
@@ -13,84 +13,115 @@ pub struct Guide {
     pub steps: &'static [(&'static str, bool)],
 }
 
-pub const CATALOG: [Guide; 5] = [
+pub const CATALOG: [Guide; 4] = [
     Guide {
-        catalog_id: "guide.start-here",
-        title: "Start here: Enter opens a task, Esc comes back",
-        notes: "These `N` rows are guides. They sit on your desk like tasks and leave like tasks.\n\
+        catalog_id: "guide.welcome",
+        title: "Welcome to tsk, start here",
+        notes: "Hi. This is your board. Every task you make lives here. Take a minute with this one.\n\
                 \n\
-                - `j` `k` or the arrows move the selection\n\
-                - `Enter` opens the selected task, `Esc` returns to the board\n\
-                - `?` lists every key\n\
+                **Three tabs, always**\n\
+                - `1` is your desk. It shows anything that needs you or is in motion, from every project, plus the ready tasks that belong to no project.\n\
+                - `2` is one project. Press `p` to pick it.\n\
+                - `3` lists every project. `Enter` on a row opens that project's board.\n\
                 \n\
-                Review rows wait in NEEDS YOU until you decide. `ctrl+r` sends this one to ON DECK.",
+                **Three sections, decided by status**\n\
+                - **NEEDS YOU** holds `blocked` and `review` tasks. Something is waiting on you. This task is in review, so it sits here until you act on it.\n\
+                - **IN MOTION** holds `started` tasks. Work you are doing right now.\n\
+                - **ON DECK** holds `ready` tasks. Up next. A new task lands here.\n\
+                - `done` tasks leave the board for the drawer. Press `d` to open it, `d` again to close it.\n\
+                \n\
+                **Moving around**\n\
+                - `j` and `k` or the arrows move the selection. `Enter` opens a task, `Esc` comes back.\n\
+                - Status keys use Ctrl, so a stray letter never changes anything. `ctrl+s` starts, `ctrl+b` blocks, `ctrl+r` marks review or takes it back to ready, `ctrl+d` finishes, `ctrl+o` reopens.\n\
+                - `ctrl+u` undoes the last change.\n\
+                \n\
+                Try it now. Press `ctrl+r` on this task and watch it move from NEEDS YOU to ON DECK.",
         status: HumanStatus::Review,
         steps: &[
-            ("Find this guide in NEEDS YOU", true),
-            ("Press Enter on this step to check it", false),
-            ("Press Esc to return to the board", false),
+            ("Open this task with Enter", true),
+            ("Press Esc, then 1, 2, and 3 to visit each tab", false),
+            ("Press ctrl+r and watch this task move to ON DECK", false),
         ],
     },
     Guide {
-        catalog_id: "guide.needs-you",
-        title: "Blocked rows wait in NEEDS YOU on every board",
-        notes: "NEEDS YOU collects blocked and review tasks from every project, so the desk \
-                shows what waits on you.\n\
+        catalog_id: "guide.tasks",
+        title: "Make a task, open it, check off steps",
+        notes: "A task holds a title, notes (the description), and steps. You set its status yourself. Optionally put it on a thread to group related work inside a project, and file it under a project (or leave it on your desk).\n\
                 \n\
-                - `ctrl+b` toggles blocked, `ctrl+r` toggles review\n\
-                - `1` desk · `2` selected project · `3` projects\n\
-                - `p` picks a project\n\
+                **Make one**\n\
+                - Press `+`, type a title, press `Enter`. It lands in ON DECK as `ready`.\n\
+                - Press `Tab` instead of `Enter` to open the full page first, where you can add notes, steps, a thread, and a project before you save.\n\
+                - Type `!p widget` in the title to file it under the project named widget. Bare `!p` keeps it on your desk.\n\
+                - Type `!t release` in the title to tag it with the thread `release`. Threads group related work inside one project, and the project board can filter by them.\n\
                 \n\
-                Unblock this guide with `ctrl+b` and watch it move to ON DECK.",
-        status: HumanStatus::Blocked,
-        steps: &[("Press ctrl+b to unblock this guide", false)],
-    },
-    Guide {
-        catalog_id: "guide.in-motion",
-        title: "Started rows sit in IN MOTION, steps never finish a task",
-        notes: "`ctrl+s` starts a task. Steps are a checklist inside it: check them all and the \
-                task still reads started, because only you set status.\n\
+                **Read one**\n\
+                - `→` peeks at the notes under the task. `←` or `Esc` closes the peek.\n\
+                - `Enter` opens the full page. `Esc` comes back.\n\
+                - On a terminal 110 columns or wider there is no peek. `→` slides the task page open beside the board, `→` again gives it more room, and `←` slides it back.\n\
                 \n\
-                - `Enter` on a step checks it\n\
-                - the `+ step` row at the end of the list adds one\n\
-                - `ctrl+d` marks the task done, `ctrl+o` reopens it",
+                **Change one**\n\
+                - On the page, `ctrl+e` edits the title and `ctrl+n` edits the notes. `shift+enter` saves.\n\
+                - `Enter` on a step checks it. The `+ step` row at the bottom adds one.\n\
+                - Steps never finish a task. Check every step below and this task stays `started` until you press `ctrl+d`. You decide when work is done.",
         status: HumanStatus::Started,
         steps: &[
-            ("Check this step with Enter", false),
+            ("Press Enter on this step to check it", false),
             ("Check this one too", false),
             ("Notice the task is still started", false),
+            ("Press + and add a task of your own", false),
         ],
     },
     Guide {
-        catalog_id: "guide.on-deck",
-        title: "Ready rows live in ON DECK until ctrl+s",
-        notes: "`+` adds a task to ON DECK. Type a title and press `Enter`; `Tab` expands the \
-                draft into a full page first.\n\
+        catalog_id: "guide.cli-agents",
+        title: "The command line, and how agents use it",
+        notes: "Everything on this board is also a command. Open another terminal and try these.\n\
                 \n\
-                - `!p name` in the title files the task under a project, bare `!p` keeps it on the desk\n\
-                - `!t name` puts it on a thread\n\
-                - `ctrl+e` edits the open task, `ctrl+n` its notes\n\
+                ```\n\
+                tsk add -t \"Try the CLI\"\n\
+                tsk list\n\
+                tsk status T1 start\n\
+                tsk steps 1 add \"First step\"\n\
+                tsk edit T1 --notes \"Written from the CLI\"\n\
+                ```\n\
                 \n\
-                Agents add and update tasks with `tsk add`, `tsk list`, and `tsk status`. \
-                `tsk guide` prints their instructions.",
+                Every task gets a `T` number, and that number is how each command finds it. Use the number `tsk list` prints for your new task in place of `T1`.\n\
+                \n\
+                `tsk list` shows the tasks of the project you are standing in, or your desk outside a repository. Add `--all` for every project or `--json` for output another program can read.\n\
+                \n\
+                **Let an agent work the board**\n\
+                Run `tsk setup claude` once (or `pi`, `cursor`, `codex`) and that agent learns the CLI. Then ask it in plain words. \"Add a task for each failing test.\" \"Mark T7 as review.\" `tsk guide` prints the same instructions if you want to read them yourself.\n\
+                \n\
+                These starter tasks are yours alone. `tsk list` never shows them, so an agent never sees them.",
         status: HumanStatus::Ready,
         steps: &[
-            ("Press + and add a task of your own", false),
-            ("Press ctrl+s on it", false),
+            ("Run tsk add -t \"Try the CLI\" in another terminal", false),
+            ("Watch it appear in ON DECK", false),
+            ("Run tsk status on it with start", false),
         ],
     },
     Guide {
-        catalog_id: "guide.dismiss",
-        title: "Archive or delete a guide when you are done with it",
-        notes: "Guides are yours to clear. Any of these takes one off the board for good:\n\
+        catalog_id: "guide.wrap-up",
+        title: "That's the tour, clear these when you're ready",
+        notes: "You know the tabs, the sections, and how a task moves between them. That is most of tsk.\n\
                 \n\
-                - `ctrl+d` marks it done, into the `d` drawer\n\
-                - `ctrl+f` files it in the drawer's archived group\n\
-                - `ctrl+x` twice deletes it, `ctrl+u` undoes\n\
+                **Clear these starter tasks**\n\
+                Any of these works. A cleared starter task never comes back.\n\
+                - `ctrl+d` marks it done. Done tasks wait in the drawer. `d` opens and closes it.\n\
+                - `ctrl+f` archives it. Archived tasks fold into a group at the end of the drawer.\n\
+                - `ctrl+x` twice deletes it. `ctrl+u` brings it back if you change your mind.\n\
                 \n\
-                A cleared guide never comes back, and `tsk list` never shows guides to agents.",
+                **When you forget a key**\n\
+                Press `?`. Every key of every screen is on one card.\n\
+                \n\
+                **Say hello**\n\
+                - Something broke, or something is missing? Tell us at https://github.com/smarzban/herdr-tsk/issues\n\
+                - A star at https://github.com/smarzban/herdr-tsk helps other people find tsk.\n\
+                - Say hi at https://x.com/smarzbanX",
         status: HumanStatus::Ready,
-        steps: &[("Press ctrl+d on this guide", false)],
+        steps: &[
+            ("Press ctrl+d on this task", false),
+            ("Press d and find it in the drawer", false),
+        ],
     },
 ];
 
@@ -202,9 +233,9 @@ mod tests {
     }
 
     #[test]
-    fn first_open_seeds_five_desk_notices_and_a_second_open_adds_none() {
+    fn first_open_seeds_four_desk_notices_and_a_second_open_adds_none() {
         let store = temp_store("empty");
-        assert_eq!(seed_on_open(&store), Ok(5));
+        assert_eq!(seed_on_open(&store), Ok(4));
         let state = store.load().expect("load");
         let seeded = notices(&state);
         assert_eq!(
@@ -212,15 +243,12 @@ mod tests {
                 .iter()
                 .map(|task| task.board_identifier())
                 .collect::<Vec<_>>(),
-            (1..=5).map(|n| Some(format!("N{n}"))).collect::<Vec<_>>()
+            (1..=4).map(|n| Some(format!("N{n}"))).collect::<Vec<_>>()
         );
         assert!(seeded.iter().all(|task| task.scope == TaskScope::Global));
         assert!(seeded.iter().all(|task| task.number.is_none()));
         let start = seeded[0];
-        assert_eq!(
-            start.title,
-            "Start here: Enter opens a task, Esc comes back"
-        );
+        assert_eq!(start.title, "Welcome to tsk, start here");
         assert_eq!(start.status, HumanStatus::Review);
         assert_eq!(
             start.steps.iter().map(|step| step.done).collect::<Vec<_>>(),
@@ -229,11 +257,11 @@ mod tests {
         assert!(start
             .notes
             .as_deref()
-            .is_some_and(|notes| notes.contains("`Esc`")));
+            .is_some_and(|notes| notes.contains("NEEDS YOU")));
         assert_eq!(delivery::load(store.path()).guides, catalog_ids());
 
         assert_eq!(seed_on_open(&store), Ok(0));
-        assert_eq!(notices(&store.load().expect("reload")).len(), 5);
+        assert_eq!(notices(&store.load().expect("reload")).len(), 4);
         let _ = fs::remove_dir_all(store.path());
     }
 
@@ -254,7 +282,7 @@ mod tests {
         }
         store.save(&state).expect("save");
 
-        assert_eq!(seed_on_open(&store), Ok(5));
+        assert_eq!(seed_on_open(&store), Ok(4));
         let state = store.load().expect("load");
         let ordinary: Vec<Option<u64>> = state
             .tasks()
@@ -264,14 +292,14 @@ mod tests {
             .collect();
         assert_eq!(ordinary, vec![Some(1), Some(2)]);
         assert_eq!(state.next_task_number, 3);
-        assert_eq!(notices(&state).len(), 5);
+        assert_eq!(notices(&state).len(), 4);
         let _ = fs::remove_dir_all(store.path());
     }
 
     #[test]
     fn a_dismissed_guide_is_not_seeded_again_even_after_it_leaves_the_store() {
         let store = temp_store("dismiss");
-        assert_eq!(seed_on_open(&store), Ok(5));
+        assert_eq!(seed_on_open(&store), Ok(4));
         let mut state = store.load().expect("load");
         let ids: Vec<uuid::Uuid> = notices(&state).iter().map(|task| task.id).collect();
         state.complete(ids[0]).expect("complete");
@@ -289,7 +317,7 @@ mod tests {
     #[test]
     fn a_lost_delivery_record_is_rebuilt_from_the_store_without_duplicates() {
         let store = temp_store("crash");
-        assert_eq!(seed_on_open(&store), Ok(5));
+        assert_eq!(seed_on_open(&store), Ok(4));
         fs::remove_file(store.path().join(delivery::DELIVERY_FILE)).expect("simulate crash");
 
         assert_eq!(seed_on_open(&store), Ok(0));
@@ -298,7 +326,7 @@ mod tests {
             .iter()
             .map(|task| task.notice.as_ref().expect("notice").catalog_id.clone())
             .collect();
-        assert_eq!(notices(&state).len(), 5, "no catalog id is created twice");
+        assert_eq!(notices(&state).len(), 4, "no catalog id is created twice");
         assert_eq!(ids, catalog_ids());
         assert_eq!(delivery::load(store.path()).guides, catalog_ids());
         let _ = fs::remove_dir_all(store.path());

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -562,7 +562,7 @@ fn flag_add_with_a_seeded_notice_title_creates_an_ordinary_task() {
     let _env = env_lock();
     let dir = temp_state_dir("flag-notice-title");
     let store = task_store(&dir);
-    assert_eq!(tsk_tui::guides::seed_on_open(&store), Ok(5));
+    assert_eq!(tsk_tui::guides::seed_on_open(&store), Ok(4));
     let notice_title = tsk_tui::guides::CATALOG[0].title;
 
     let output = add(
@@ -605,7 +605,7 @@ fn plan_add_with_a_seeded_notice_title_creates_an_ordinary_task() {
     let _env = env_lock();
     let dir = temp_state_dir("plan-notice-title");
     let store = task_store(&dir);
-    assert_eq!(tsk_tui::guides::seed_on_open(&store), Ok(5));
+    assert_eq!(tsk_tui::guides::seed_on_open(&store), Ok(4));
     let notice_title = tsk_tui::guides::CATALOG[0].title;
 
     let plan = run_with(

--- a/tests/cli_add.rs
+++ b/tests/cli_add.rs
@@ -583,7 +583,7 @@ fn flag_add_with_a_seeded_notice_title_creates_an_ordinary_task() {
     let state = store.load().expect("reload state");
     assert_eq!(
         state.tasks().iter().filter(|task| task.is_notice()).count(),
-        5
+        4
     );
     let ordinary: Vec<_> = state
         .tasks()

--- a/tests/starter_guides.rs
+++ b/tests/starter_guides.rs
@@ -91,8 +91,8 @@ fn full_board_open_seeds_the_guides_once_beside_existing_tasks() {
     let state = store.load().expect("load");
     assert_eq!(
         notices(&state).len(),
-        6,
-        "five guides plus What's new for an existing desk"
+        5,
+        "four starter tasks plus What's new for an existing desk"
     );
     assert_eq!(
         notices(&state)
@@ -115,7 +115,7 @@ fn full_board_open_seeds_the_guides_once_beside_existing_tasks() {
     assert_eq!(record.announcement_watermark, newest);
 
     let _ = load_board_model().expect("second open");
-    assert_eq!(notices(&store.load().expect("reload")).len(), 6);
+    assert_eq!(notices(&store.load().expect("reload")).len(), 5);
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn a_fresh_full_board_open_records_the_bundled_announcements_without_seeding_the
 
     let _ = load_board_model().expect("first open");
     let state = TaskStore::new(&env.dir).load().expect("load");
-    assert_eq!(notices(&state).len(), 5, "guides only");
+    assert_eq!(notices(&state).len(), 4, "starter tasks only");
     assert!(notices(&state)
         .iter()
         .all(|task| task.title != announcements::TITLE));
@@ -159,9 +159,9 @@ fn completing_a_guide_on_the_real_board_records_its_dismissal() {
     fs::create_dir_all(&outside).unwrap();
     let state_dir = root.join("state");
     let mut session = pty::Session::spawn(root, &outside, &[], &[], 24, 78);
-    // Painted words are split by cursor moves, so wait on the last guide's `N` prefix.
-    let painted = session.output_until("N5");
-    for prefix in ["N1", "N2", "N3", "N4"] {
+    // Painted words are split by cursor moves, so wait on the last starter task's `N` prefix.
+    let painted = session.output_until("N4");
+    for prefix in ["N1", "N2", "N3"] {
         assert!(painted.contains(prefix), "{prefix} painted: {painted}");
     }
     let store = TaskStore::new(&state_dir);
@@ -178,7 +178,7 @@ fn completing_a_guide_on_the_real_board_records_its_dismissal() {
         .filter(|task| task.status == HumanStatus::Done)
         .collect();
     assert_eq!(done.len(), 1, "ctrl+d completed the selected guide");
-    assert_eq!(notices(&state).len(), 5, "the other guides stay");
+    assert_eq!(notices(&state).len(), 4, "the other starter tasks stay");
     let dismissed = done[0].notice.as_ref().unwrap().catalog_id.clone();
     assert_eq!(
         delivery::load(&state_dir).guides,


### PR DESCRIPTION
## Summary
- Replaces the five original starter notices with four approved tasks: welcome (review), tasks (started), CLI and agents (ready), wrap-up (ready).
- New catalog ids (`guide.welcome` … `guide.wrap-up`) so existing installs can receive the tour; docs and counts updated to four.

## Test plan
- [x] `cargo test --lib guides::`
- [x] `cargo test --lib announcements::`
- [x] `cargo test --test starter_guides`
- [ ] Fresh state dir: first board open shows N1–N4 with the new titles
- [ ] `ctrl+r` on welcome moves it from NEEDS YOU to ON DECK
- [ ] Existing desk still gets What's new on upgrade path