### PR TITLE
Fix wide-board clicks and workspace-local Herdr shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ For scriptable board work, use `tsk add`, `tsk list`, `tsk status`, `tsk edit`, 
   the binary.
 - Below 110 columns, row click peeks, clicking the same row again closes peek, and
   a fast double-click opens the page. At wide widths there is no peek: a board or rail
-  row click selects it in place (a rail click lands the board in stage A), and a fast
+  row click selects it and opens or updates the task beside the board in stage A, and a fast
   double-click opens the full task page.
 - Task page is view-first. Only `ctrl+e`, `ctrl+n`, or bare Tab enter edit mode,
   the one exception being a quick-add draft expanded with `Tab`, which opens
@@ -298,7 +298,15 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   unsupported, `TSK_STATE_DIR` is the escape hatch. State/config directory roots must be real
   directories, not symlinks; permission hardening refuses a symlink instead of chmodding its target.
 - Golden fixtures regenerate via `cargo test --test queue_board_render regenerate_golden_fixtures -- --ignored`; never hand-edit the `.txt` files.
-- Pane label matching is exact against `board_pane::BOARD_PANE_LABEL`; the manifest pane title must equal it.
+- `prefix+t` opens or focuses the board within the invoking Herdr workspace, across tabs.
+  `scripts/open-board.sh` scopes lookup with `HERDR_WORKSPACE_ID` and anchors creation to
+  `HERDR_PANE_ID` (Herdr rejects `--workspace` for split placement). It refuses missing context
+  or a failed pane listing, and never publishes shared reopen context on focus.
+  Existing boards preserve their view and edits; other workspaces keep their boards.
+  On reuse, `--find-board-tab` resolves the matching pane's tab; call `herdr tab focus` before
+  `plugin pane focus`. Herdr 0.9.0's plugin focus route does not navigate attached clients.
+  API `focused: true` alone is not visible-navigation evidence: confirm the displayed tab.
+  Pane label matching is exact against `board_pane::BOARD_PANE_LABEL`; the manifest pane title must equal it.
 - UI chrome lives in `src/ui/` (`board/` model·apply·commands·chrome·draw,
   `capture`, `mouse`, `input`, `render`).
 - `map_edit` and `map_board_form_key` share `map_form_edit_key`. Save-recovery

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,8 +299,9 @@ If `HERDR_ENV` is unset, say that live smoke was not run.
   directories, not symlinks; permission hardening refuses a symlink instead of chmodding its target.
 - Golden fixtures regenerate via `cargo test --test queue_board_render regenerate_golden_fixtures -- --ignored`; never hand-edit the `.txt` files.
 - `prefix+t` opens or focuses the board within the invoking Herdr workspace, across tabs.
-  `scripts/open-board.sh` scopes lookup with `HERDR_WORKSPACE_ID` and anchors creation to
-  `HERDR_PANE_ID` (Herdr rejects `--workspace` for split placement). It refuses missing context
+  `scripts/open-board.sh` scopes lookup with `HERDR_WORKSPACE_ID`, activates the invoking
+  `HERDR_TAB_ID` before creation, and anchors the split to `HERDR_PANE_ID` (Herdr rejects
+  `--workspace` for split placement). It refuses missing context
   or a failed pane listing, and never publishes shared reopen context on focus.
   Existing boards preserve their view and edits; other workspaces keep their boards.
   On reuse, `--find-board-tab` resolves the matching pane's tab; call `herdr tab focus` before

--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ your agent the task number when you're ready to work on it.
 
 ![The tsk board beside an agent working on the selected Redis-to-Postgres migration task](docs/images/board-in-herdr.png)
 
-In Herdr, **prefix+t** opens your board and **prefix+a** opens quick capture.
+In Herdr, **prefix+t** opens or focuses your workspace's board, even across tabs;
+other workspaces keep their own views of the same tasks. **prefix+a** opens quick capture.
 Click a task's `T` number to copy it, then paste it into your agent conversation.
 
 ### Room to think
 
 ![A wide tsk board with the selected task's notes and steps open alongside it](docs/images/wide-task-page.png)
 
-In a wide pane, `→` opens task details beside the board; `←` brings you back.
+In a wide pane, click a task or press `→` to open its details beside the board; `←` brings you back.
 Press `Enter` for a full-screen task and `Esc` to return. For a standalone board,
 run `tsk` in your terminal.
 

--- a/scripts/open-board.sh
+++ b/scripts/open-board.sh
@@ -6,8 +6,9 @@ set -uo pipefail
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 workspace_id="${HERDR_WORKSPACE_ID:-}"
 target_pane="${HERDR_PANE_ID:-}"
-if [ -z "$workspace_id" ] || [ -z "$target_pane" ]; then
-  printf 'tsk: cannot open board without a Herdr workspace and pane\n' >&2
+origin_tab="${HERDR_TAB_ID:-}"
+if [ -z "$workspace_id" ] || [ -z "$target_pane" ] || [ -z "$origin_tab" ]; then
+  printf 'tsk: cannot open board without a Herdr workspace, tab and pane\n' >&2
   exit 1
 fi
 
@@ -44,5 +45,10 @@ fi
 
 # Split placement requires a target pane, not a workspace argument. Anchor it to
 # the invoking pane so a focus change cannot redirect creation to another workspace.
+# Plugin open does not navigate attached clients either. Return to the invoking
+# tab before creation, including when a stale board was found in another tab.
+if ! "$herdr_bin" tab focus "$origin_tab"; then
+  exit 1
+fi
 # New panes still receive the host's invocation context.
 exec "$herdr_bin" plugin pane open --plugin herdr-tsk --entrypoint board --placement split --target-pane "$target_pane" --focus

--- a/scripts/open-board.sh
+++ b/scripts/open-board.sh
@@ -1,66 +1,48 @@
 #!/usr/bin/env bash
-# Idempotent open-or-focus for the Tasks board.
-#
-# - No tsk board pane yet  -> plugin pane open --placement split --focus
-# - tsk board pane exists  -> plugin pane focus <pane_id> (no second board)
-#
-# herdr actions run a command (no declarative "open this pane" field), so this shells
-# out via $HERDR_BIN_PATH (herdr injects it; fall back to `herdr` on PATH).
-# Existing board is recognized only by its manifest label from `pane list` JSON
-# (matches [[panes]] title in herdr-plugin.toml).
-#
-# Focus selection is done by tsk --find-board-pane (Rust), not python3,
-# so this works on hosts without python3.
-#
-# Manual check: invoke open-board twice; the second focus keeps a single tsk board.
+# Open or focus one Tasks board in the invoking workspace, across all its tabs.
+# Boards in other workspaces are independent views of the same task store.
 set -uo pipefail
 
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
-plugin_id="herdr-tsk"
-entrypoint="board"
+workspace_id="${HERDR_WORKSPACE_ID:-}"
+target_pane="${HERDR_PANE_ID:-}"
+if [ -z "$workspace_id" ] || [ -z "$target_pane" ]; then
+  printf 'tsk: cannot open board without a Herdr workspace and pane\n' >&2
+  exit 1
+fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Same relative layout as other herdr plugins: scripts/ next to target/release/.
 plugin_bin="${TSK_BIN:-$script_dir/../target/release/tsk}"
+if [ ! -x "$plugin_bin" ]; then
+  printf 'tsk: board launcher binary is unavailable: %s\n' "$plugin_bin" >&2
+  exit 1
+fi
 
-open_board() {
-  exec "$herdr_bin" plugin pane open \
-    --plugin "$plugin_id" \
-    --entrypoint "$entrypoint" \
-    --placement split \
-    --focus
-}
-
-# Extract first flag-safe pane_id whose label is tsk.
-# Uses tsk --find-board-pane (reads pane-list JSON on stdin).
-find_board_pane_id() {
-  local panes
-  panes="$("$herdr_bin" pane list 2>/dev/null || true)"
-  if [ -z "$panes" ]; then
-    return 1
+# Never search globally or treat a failed lookup as an empty workspace.
+if ! panes="$("$herdr_bin" pane list --workspace "$workspace_id")"; then
+  printf 'tsk: could not list panes in workspace %s\n' "$workspace_id" >&2
+  exit 1
+fi
+pane_id="$(printf '%s' "$panes" | "$plugin_bin" --find-board-pane || true)"
+if [ -n "$pane_id" ]; then
+  tab_id="$(printf '%s' "$panes" | "$plugin_bin" --find-board-tab || true)"
+  if [ -z "$tab_id" ]; then
+    printf 'tsk: could not locate the existing board tab\n' >&2
+    exit 1
   fi
-  if [ ! -x "$plugin_bin" ]; then
-    return 1
+  # Herdr 0.9.0 plugin pane focus updates server focus but does not navigate
+  # attached clients. Activate the tab through the public navigation route first.
+  if ! "$herdr_bin" tab focus "$tab_id"; then
+    exit 1
   fi
-  printf '%s' "$panes" | "$plugin_bin" --find-board-pane
-}
-
-pane_id="$(find_board_pane_id || true)"
-if [ -n "${pane_id:-}" ]; then
-  # A focused existing pane keeps its process environment, so hand the fresh host
-  # context to the board through the private one-shot request file before focusing it.
-  if [ -x "$plugin_bin" ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
-    if ! printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | "$plugin_bin" --resolve-context; then
-      printf 'tsk: could not hand off the board context, existing pane was not focused\n' >&2
-      exit 1
-    fi
-  fi
-  # Prefer the plugin-pane focus API (herdr >= 0.7). Fall back to open if focus fails
-  # (stale list race) so the keypress is never a silent no-op.
+  # Focus preserves the board's view and edits. Do not publish a shared reopen
+  # request: another workspace's board could consume it.
   if "$herdr_bin" plugin pane focus "$pane_id"; then
     exit 0
   fi
 fi
 
-# A new pane receives HERDR_PLUGIN_CONTEXT_JSON directly from herdr.
-open_board
+# Split placement requires a target pane, not a workspace argument. Anchor it to
+# the invoking pane so a focus change cannot redirect creation to another workspace.
+# New panes still receive the host's invocation context.
+exec "$herdr_bin" plugin pane open --plugin herdr-tsk --entrypoint board --placement split --target-pane "$target_pane" --focus

--- a/site/parity/board.spec.mjs
+++ b/site/parity/board.spec.mjs
@@ -150,6 +150,34 @@ test("110-column boundary and rail mouse return", async ({ page }, info) => {
   await expect(row(page, 13)).toHaveClass(/is-sel/);
 });
 
+for (const width of [110, 130]) {
+  test(`row double-click survives reflow at ${width} columns`, async ({
+    page,
+  }) => {
+    await open(page, width);
+    const result = await row(page, 13).evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      const x = rect.right - 4;
+      const y = rect.top + 4;
+      const click = () =>
+        document.elementFromPoint(x, y).dispatchEvent(
+          new MouseEvent("click", {
+            bubbles: true,
+            clientX: x,
+            clientY: y,
+            detail: 1,
+          }),
+        );
+      click();
+      const split = !!document.querySelector(".tsk-wide-split.is-split");
+      click();
+      return { split, full: !document.querySelector(".tsk-list") };
+    });
+    expect(result).toEqual({ split: true, full: true });
+    await expect(page.locator(".tsk-task-column")).toContainText("END");
+  });
+}
+
 test("landing column readout excludes board padding", async ({ page }) => {
   await open(page, 78);
   await page.evaluate(() => {

--- a/site/parity/board.spec.mjs
+++ b/site/parity/board.spec.mjs
@@ -157,7 +157,7 @@ for (const width of [110, 130]) {
     await open(page, width);
     const result = await row(page, 13).evaluate((el) => {
       const rect = el.getBoundingClientRect();
-      const x = rect.right - 4;
+      const x = Math.min(rect.right - 4, window.innerWidth - 8);
       const y = rect.top + 4;
       const click = () =>
         document.elementFromPoint(x, y).dispatchEvent(

--- a/site/public/board-demo.js
+++ b/site/public/board-demo.js
@@ -2077,8 +2077,48 @@ import { parseCapture } from "./capture.js";
   }
 
   let lastClick = { id: null, at: 0 };
+  const cancelReflowClick = () => {
+    delete lastClick.reflow;
+  };
+  frame.addEventListener("keydown", cancelReflowClick, true);
+  root.addEventListener("wheel", cancelReflowClick, { passive: true });
+  root.addEventListener("pointermove", (e) => {
+    if (e.buttons) cancelReflowClick();
+  });
+  root.addEventListener("pointerdown", (e) => {
+    const previous = lastClick.reflow;
+    if (
+      e.button !== 0 ||
+      (previous && (e.clientX !== previous.x || e.clientY !== previous.y))
+    )
+      cancelReflowClick();
+  });
+  root.addEventListener("pointercancel", cancelReflowClick);
+  window.addEventListener("resize", cancelReflowClick);
+  window.addEventListener("scroll", cancelReflowClick, true);
 
   root.addEventListener("click", (e) => {
+    const previous = lastClick.reflow;
+    cancelReflowClick();
+    // Reflow must not turn the second click into a newly exposed task control.
+    if (
+      previous &&
+      e.detail > 0 &&
+      state.stage === "split" &&
+      state.selectedId === lastClick.id &&
+      Date.now() - lastClick.at < 350 &&
+      e.clientX === previous.x &&
+      e.clientY === previous.y &&
+      frame.clientWidth === previous.width &&
+      !state.editField &&
+      !steps.editor &&
+      !steps.dirty
+    ) {
+      lastClick = { id: null, at: 0 };
+      openFullPage();
+      render();
+      return;
+    }
     // A stage A click inside the task column slides to G first, then the control runs.
     const filterControl = e.target.closest("[data-filter]");
     if (filterControl) {
@@ -2181,6 +2221,15 @@ import { parseCapture } from "./capture.js";
       const id = row.getAttribute("data-task");
       if ((steps.dirty || steps.editor) && id !== state.selectedId) return;
       const now = Date.now();
+      const reflow =
+        e.detail > 0 &&
+        isWideSplit() &&
+        (state.stage === "board" || state.stage === "rail") &&
+        !state.editField &&
+        !steps.editor &&
+        !steps.dirty
+          ? { x: e.clientX, y: e.clientY, width: frame.clientWidth }
+          : null;
       if (lastClick.id === id && now - lastClick.at < 350) {
         state.selectedId = id;
         state.peekId = null;
@@ -2195,7 +2244,7 @@ import { parseCapture } from "./capture.js";
         state.selectedId = id;
         state.peekId = state.peekId === id ? null : id;
       }
-      lastClick = { id, at: now };
+      lastClick = { id, at: now, reflow };
       render();
       return;
     }

--- a/site/public/board-demo.js
+++ b/site/public/board-demo.js
@@ -2186,7 +2186,8 @@ import { parseCapture } from "./capture.js";
         state.peekId = null;
         openFullPage();
       } else if (isWideSplit()) {
-        if (state.stage === "rail") state.stage = "split";
+        if (state.stage === "board" || state.stage === "rail")
+          state.stage = "split";
         state.selectedId = id;
         state.peekId = null;
         state.overlay = null;

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -4,10 +4,12 @@
 
 Install with `curl -fsSL https://gettsk.sh/install.sh | sh` or `brew install smarzban/tap/tsk`.
 If Herdr is on PATH, the curl installer asks to run `tsk setup herdr` on a TTY; when agent skill roots are detected it also asks once to install the tsk skill. The install wrap-up points at the board (and the Herdr board shortcut after a successful Herdr setup, or `tsk setup herdr` / `tsk setup` when those asks are skipped). Homebrew prints the Herdr setup command as a caveat.
+Herdr's board shortcut opens or focuses one board per workspace across its tabs, preserving its view and edits. Other workspaces stay untouched; boards share the same task store.
 Details: https://gettsk.sh/docs/install.md
 Inside Git, the repo root is the default project. Outside Git, tsk opens and captures on the desk while keeping the current directory available as a project.
 The board checks GitHub releases at most daily and shows a dim `vX.Y.Z available` on the status row; set `TSK_NO_UPDATE_CHECK` to disable.
 `N` tasks on the desk are human-only notices: four starter tasks on a first open, one `What's new in tsk` task after an upgrade. `tsk list` never shows them.
+At 110 usable columns or wider, clicking a task opens or updates its details beside the board with board focus; double-click opens it full screen. Narrow panes use click-to-peek.
 
 ## For agents
 

--- a/site/src/content/docs/docs/board.md
+++ b/site/src/content/docs/docs/board.md
@@ -13,7 +13,9 @@ Click to navigate, or use the keyboard. The footer shows actions for the current
 | **selected project** | `2` | Tasks in the selected project |
 | **projects** | `3` | Project overview |
 
-Launching inside a Git repository opens that project. Outside Git, tsk opens **desk** and puts the current directory in the middle project tab. Reopening from another directory updates that project tab while keeping **desk** active outside Git.
+Launching inside a Git repository opens that project. Outside Git, tsk opens **desk** and puts the current directory in the middle project tab.
+
+In Herdr, `prefix+t` opens or focuses a board in the current workspace. If one is already open in another tab there, Herdr switches to that tab and focuses its pane, preserving its view and edits. Otherwise, it opens a board beside your work. Boards in other workspaces stay untouched; all boards share the same tasks.
 
 The middle tab remembers your selected project. Press `2` to open it; if none is selected, `2` opens the project picker.
 
@@ -75,7 +77,7 @@ Your first board open seeds four desk tasks with `N` ids (not `T`). They teach t
 | Action | Result |
 | --- | --- |
 | Click a tab or selector | Change view or open its choices |
-| Click a task | Peek in narrow panes; select in wide panes |
+| Click a task | Peek in narrow panes; open or update details beside the board in wide panes |
 | Click the same task again in a narrow pane | Close its peek |
 | Double-click a task | Open it full screen |
 | Click its `T` or `N` number | Copy that id |
@@ -98,7 +100,7 @@ At **110 usable columns** or wider, use `→` and `←` to move through a four-s
 
 Press `Enter` from the board to open a task full screen. `Esc` returns to the view you left. From task focus, `Esc` returns focus to the board beside it.
 
-Click inside the task column to focus it. Click a rail row to bring back the split board. While editing, arrows move the text cursor instead.
+Click a task on the full-width board to open its details alongside it, keeping board focus. Click inside the task column to focus it. Click a rail row to bring back the split board. While editing, arrows move the text cursor instead.
 
 Narrowing the pane shows one surface; widening it restores the selected view. Each new session starts with the board alone.
 

--- a/site/src/content/docs/docs/capture.md
+++ b/site/src/content/docs/docs/capture.md
@@ -33,7 +33,7 @@ Scroll to reach steps below long notes. Typing brings the notes cursor back into
 | Where you add | Default destination |
 | --- | --- |
 | Project board | That project |
-| Desk or Projects | The launch/reopen repository inside Git; desk outside Git |
+| Desk or Projects | The board's launch repository inside Git; desk outside Git |
 | Herdr quick-capture popup | The focused pane's repository inside Git; desk outside Git |
 
 Use title tokens or the draft's scope control to change the destination. Archived projects cannot receive new tasks.

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -32,10 +32,10 @@ herdr server reload-config
 
 | Shortcut | Action |
 | --- | --- |
-| **prefix+t** | Open the board |
+| **prefix+t** | Open or focus the board in this workspace |
 | **prefix+a** | Quick capture |
 
-Use your configured Herdr prefix. [Herdr keyboard guide](https://herdr.dev/docs/keyboard/).
+Use your configured Herdr prefix. An existing board in this workspace is focused across tabs without resetting its view. If none exists here, a new board opens; other workspaces keep their boards. [Herdr keyboard guide](https://herdr.dev/docs/keyboard/).
 
 ## Agent skill
 

--- a/site/src/content/docs/docs/task-page.md
+++ b/site/src/content/docs/docs/task-page.md
@@ -7,7 +7,7 @@ Read notes and steps, then edit the task when you need to change it.
 
 ## Open
 
-Double-click a task or select it and press `Enter`.
+Double-click a task or select it and press `Enter`. A double-click follows the task you first clicked, even when the first click resizes the columns.
 
 At 110 usable columns or wider, click a task or press `→` to open details beside the board, keeping board focus. Use `→` and `←` to move between [board and task views](/docs/board/#wide-stage-slider). Press `Enter` from the board for full screen; `Esc` returns.
 

--- a/site/src/content/docs/docs/task-page.md
+++ b/site/src/content/docs/docs/task-page.md
@@ -9,7 +9,7 @@ Read notes and steps, then edit the task when you need to change it.
 
 Double-click a task or select it and press `Enter`.
 
-At 110 usable columns or wider, `→` opens details beside the board. Use `→` and `←` to move between [board and task views](/docs/board/#wide-stage-slider). Press `Enter` from the board for full screen; `Esc` returns.
+At 110 usable columns or wider, click a task or press `→` to open details beside the board, keeping board focus. Use `→` and `←` to move between [board and task views](/docs/board/#wide-stage-slider). Press `Enter` from the board for full screen; `Esc` returns.
 
 Click the task's `T` number to copy it. The page shows its status, notes, steps, project, thread, and dates. Long text wraps.
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -437,7 +437,7 @@ const softwareApplication = {
               </li>
               <li>
                 <span class="legend-n">4</span>
-                <div><b>Peek.</b> Below 110 columns, <kbd>→</kbd> or a click shows up to five wrapped note lines under the row. Wide, <kbd>→</kbd> slides the task page in instead. <kbd>Enter</kbd> opens the full page either way.</div>
+                <div><b>Peek.</b> Below 110 columns, <kbd>→</kbd> or a click shows up to five wrapped note lines under the row. Wide, a click or <kbd>→</kbd> opens the task page beside the board instead. <kbd>Enter</kbd> opens the full page either way.</div>
               </li>
               <li>
                 <span class="legend-n">5</span>
@@ -648,8 +648,8 @@ and ask me before installing.</pre>
                 <button type="button" class="copy" data-copy aria-label="Copy Herdr setup commands">copy</button>
               </div>
               <p class="install-note">
-                After installing, connect the same binary to Herdr (the curl installer may offer this when Herdr is already present). Press <code>prefix+t</code> to open
-                the board, or <code>prefix+a</code> to add a task. Setup asks before replacing conflicting shortcuts.
+                After installing, connect the same binary to Herdr (the curl installer may offer this when Herdr is already present). Press <code>prefix+t</code> to open or focus
+                this workspace's board across tabs, or <code>prefix+a</code> to add a task. Other workspaces keep their boards. Setup asks before replacing conflicting shortcuts.
               </p>
             </div>
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -393,6 +393,7 @@ fn run_board_loop(
         // felt reliable on the task page where Down is inert over notes.
         let mut drag_gesture = crate::ui::text_select::DragSelectGesture::new();
         let mut scrollbar_drag = false;
+        let mut reflow_click = ReflowRowClick::default();
         // Non-resize event that arrived during a resize debounce window; handled
         // after one settled-size paint so a key typed mid-drag is not dropped.
         let mut pending_event: Option<Event> = None;
@@ -453,6 +454,7 @@ fn run_board_loop(
                 }
                 event::read()?
             };
+            reflow_click.observe(&next);
             match next {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     // A key while the mouse button is held abandons the deferred click so
@@ -495,12 +497,14 @@ fn run_board_loop(
                     use crate::ui::text_select::{DragSelectOutcome, DragSelectPhase};
                     use crossterm::event::{MouseButton, MouseEventKind};
                     let area = terminal_area(terminal)?;
+                    let continuing_row = reflow_click.target(&model, area, mouse).is_some();
                     let task_focus_candidate =
                         wide_mouse_focus_intent(&model, &frame_hits, area, mouse);
                     let (quit, mode, scrollbar) = board_scrollbar_mouse_route(
                         area,
                         &mut model,
                         &frame_hits,
+                        &reflow_click,
                         mouse,
                         &mut scrollbar_drag,
                         |model, focus| {
@@ -520,6 +524,7 @@ fn run_board_loop(
                     match scrollbar {
                         ScrollbarMouse::Miss => {}
                         ScrollbarMouse::Intent(intent) => {
+                            reflow_click.clear();
                             drag_gesture.clear();
                             if handle_board_intent(
                                 &store,
@@ -534,6 +539,7 @@ fn run_board_loop(
                             continue;
                         }
                         ScrollbarMouse::Consumed => {
+                            reflow_click.clear();
                             drag_gesture.clear();
                             continue;
                         }
@@ -634,6 +640,7 @@ fn run_board_loop(
                                 map_responsive_board_mouse(&model, &frame_hits, area, mouse);
                             let focused = press_on_focused_surface(&model, area, pos);
                             if !focused
+                                && !continuing_row
                                 && !press_survives_off_focus(
                                     responsive_intent.as_ref(),
                                     mode,
@@ -664,6 +671,7 @@ fn run_board_loop(
                         area,
                         &mut model,
                         &frame_hits,
+                        &mut reflow_click,
                         click,
                         |model, focus| {
                             handle_board_intent(
@@ -1301,6 +1309,54 @@ fn press_survives_off_focus(
     slide_or_select || existing_mode_route || task_focus_candidate.is_some()
 }
 
+/// Keep a row gesture attached to its original cell and task across a column reflow.
+/// The reducer's existing clock authorizes continuation only after successful selection.
+#[derive(Default)]
+struct ReflowRowClick(Option<(Position, Rect, uuid::Uuid)>);
+
+impl ReflowRowClick {
+    fn clear(&mut self) {
+        self.0 = None;
+    }
+
+    fn observe(&mut self, event: &Event) {
+        use crossterm::event::{MouseButton, MouseEventKind};
+        match event {
+            Event::Mouse(mouse) if mouse.kind == MouseEventKind::Down(MouseButton::Left) => {
+                if self
+                    .0
+                    .is_some_and(|(pos, _, _)| pos != Position::new(mouse.column, mouse.row))
+                {
+                    self.clear();
+                }
+            }
+            Event::Mouse(mouse)
+                if matches!(
+                    mouse.kind,
+                    MouseEventKind::Up(MouseButton::Left) | MouseEventKind::Moved
+                ) => {}
+            _ => self.clear(), // keys, resize, wheel, drag, other buttons and focus changes
+        }
+    }
+
+    fn target(
+        &self,
+        model: &BoardModel,
+        area: Rect,
+        mouse: crossterm::event::MouseEvent,
+    ) -> Option<uuid::Uuid> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+        let (pos, frame, id) = self.0?;
+        (mouse.kind == MouseEventKind::Down(MouseButton::Left)
+            && pos == Position::new(mouse.column, mouse.row)
+            && frame == area
+            && model.wide_stage() == crate::ui::tier::WideStage::Split
+            && model.input_mode() == BoardInputMode::Normal
+            && model.pending_row_double_click(id))
+        .then_some(id)
+    }
+}
+
 /// Run the release-time task focus handoff before mapping the same click.
 ///
 /// The dispatcher is the real save-recovery-aware event-loop boundary in production and a
@@ -1309,9 +1365,25 @@ fn board_mouse_click_intent_after_focus<E>(
     area: Rect,
     model: &mut BoardModel,
     painted_hits: &crate::ui::render::QueueHitMap,
+    reflow_click: &mut ReflowRowClick,
     click: crossterm::event::MouseEvent,
     mut dispatch_focus: impl FnMut(&mut BoardModel, BoardIntent) -> Result<bool, E>,
 ) -> Result<(bool, Option<BoardIntent>), E> {
+    // Consume the second release before preview controls or reflowed rows can see it.
+    if let Some(id) = reflow_click.target(model, area, click) {
+        reflow_click.clear();
+        let intent = (model.selected_id() == Some(id))
+            .then(|| {
+                model
+                    .visible_ids()
+                    .iter()
+                    .position(|&visible| visible == id)
+                    .map(BoardIntent::FocusBoardAndSelectIndex)
+            })
+            .flatten();
+        return Ok((false, intent));
+    }
+    reflow_click.clear();
     if let Some(focus) = wide_mouse_focus_intent(model, painted_hits, area, click) {
         if dispatch_focus(model, focus)? {
             return Ok((true, None));
@@ -1326,7 +1398,21 @@ fn board_mouse_click_intent_after_focus<E>(
             .and_then(|intent| resolve_board_command(model, intent));
         return Ok((false, intent));
     }
-    Ok((false, board_mouse_intent(area, model, click)))
+    let intent = board_mouse_intent(area, model, click);
+    if matches!(
+        model.wide_stage(),
+        crate::ui::tier::WideStage::FullBoard | crate::ui::tier::WideStage::Rail
+    ) && matches!(
+        model.input_mode(),
+        BoardInputMode::Normal | BoardInputMode::TaskPage
+    ) {
+        if let Some(BoardIntent::FocusBoardAndSelectIndex(index)) = intent.as_ref() {
+            if let Some(&id) = model.visible_ids().get(*index) {
+                reflow_click.0 = Some((Position::new(click.column, click.row), area, id));
+            }
+        }
+    }
+    Ok((false, intent))
 }
 
 /// Route a scrollbar event, focusing and repainting a task preview before page dispatch.
@@ -1338,12 +1424,16 @@ fn board_scrollbar_mouse_route<E>(
     area: Rect,
     model: &mut BoardModel,
     painted_hits: &crate::ui::render::QueueHitMap,
+    reflow_click: &ReflowRowClick,
     mouse: crossterm::event::MouseEvent,
     dragging: &mut bool,
     mut dispatch_focus: impl FnMut(&mut BoardModel, BoardIntent) -> Result<bool, E>,
 ) -> Result<(bool, BoardInputMode, ScrollbarMouse), E> {
     use crossterm::event::{MouseButton, MouseEventKind};
 
+    if reflow_click.target(model, area, mouse).is_some() {
+        return Ok((false, model.input_mode(), ScrollbarMouse::Miss));
+    }
     let task_scrollbar_press = matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
         && matches!(
             scrollbar_hit_at(painted_hits, Position::new(mouse.column, mouse.row)),
@@ -2464,6 +2554,225 @@ mod tests {
         );
     }
 
+    fn dispatch_reflow_test_click(
+        domain: &mut DomainState,
+        model: &mut BoardModel,
+        reflow_click: &mut ReflowRowClick,
+        area: Rect,
+        click: MouseEvent,
+    ) {
+        reflow_click.observe(&Event::Mouse(click));
+        let hits = board_hit_map(area, model);
+        let continuing = reflow_click.target(model, area, click).is_some();
+        let (_, mode, scrollbar) = board_scrollbar_mouse_route(
+            area,
+            model,
+            &hits,
+            reflow_click,
+            click,
+            &mut false,
+            |model, focus| {
+                apply_intent(domain, model, focus, None)?;
+                Ok::<bool, DomainError>(false)
+            },
+        )
+        .expect("production Down scrollbar route");
+        assert!(matches!(scrollbar, ScrollbarMouse::Miss));
+        assert!(
+            continuing
+                || press_on_focused_surface(model, area, Position::new(click.column, click.row))
+                || press_survives_off_focus(
+                    map_responsive_board_mouse(model, &hits, area, click).as_ref(),
+                    mode,
+                    wide_mouse_focus_intent(model, &hits, area, click).as_ref()
+                )
+        );
+        reflow_click.observe(&Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            ..click
+        }));
+        let (quit, intent) = board_mouse_click_intent_after_focus(
+            area,
+            model,
+            &hits,
+            reflow_click,
+            click,
+            |model, focus| {
+                apply_intent(domain, model, focus, None)?;
+                Ok::<bool, DomainError>(false)
+            },
+        )
+        .expect("route click through production focus handoff");
+        assert!(!quit);
+        if let Some(intent) = intent {
+            apply_intent(domain, model, intent, None).expect("dispatch click");
+        }
+    }
+
+    #[test]
+    fn app_reflow_double_click_right_of_split_opens_original_task() {
+        for width in [110, 130] {
+            let (mut domain, mut model) =
+                board_fixture("original task", Some("notes ".repeat(500)));
+            let id = model.selected_id();
+            let mut reflow_click = ReflowRowClick::default();
+            let area = Rect::new(0, 0, width, 24);
+            let hits = board_hit_map(area, &model);
+            let row = hits
+                .regions
+                .iter()
+                .find(|hit| matches!(hit.target, crate::ui::render::QueueHitTarget::Task(_)))
+                .unwrap()
+                .area;
+            let click = left_click(width - 1, row.y);
+            let before = serde_json::to_value(&domain).unwrap();
+            dispatch_reflow_test_click(&mut domain, &mut model, &mut reflow_click, area, click);
+            assert_eq!(model.wide_stage(), crate::ui::tier::WideStage::Split);
+            dispatch_reflow_test_click(&mut domain, &mut model, &mut reflow_click, area, click);
+            assert_eq!(model.wide_stage(), crate::ui::tier::WideStage::FullTask);
+            assert_eq!(model.edit_target(), id);
+            assert_eq!(model.input_mode(), BoardInputMode::TaskPage);
+            assert_eq!(serde_json::to_value(&domain).unwrap(), before);
+        }
+    }
+
+    #[test]
+    fn app_reflow_double_click_keeps_task_below_wrapping_row() {
+        for width in [110, 130] {
+            let (mut domain, _) = board_fixture(&"a long preceding title ".repeat(4), None);
+            domain
+                .create(
+                    "another long task title ".repeat(4),
+                    None,
+                    TaskScope::Global,
+                    ProvenanceOrigin::Manual,
+                    None,
+                )
+                .unwrap();
+            let mut model = BoardModel::from_domain(&domain, None);
+            let id = model.visible_ids()[1];
+            let mut reflow_click = ReflowRowClick::default();
+            let area = Rect::new(0, 0, width, 24);
+            let hits = board_hit_map(area, &model);
+            let row = hits
+                .regions
+                .iter()
+                .find(|hit| {
+                    matches!(hit.target,
+                crate::ui::render::QueueHitTarget::Task(task) if task == id)
+                })
+                .unwrap()
+                .area;
+            let click = left_click(20, row.y);
+            dispatch_reflow_test_click(&mut domain, &mut model, &mut reflow_click, area, click);
+            let new_hits = board_hit_map(area, &model);
+            let moved = new_hits
+                .regions
+                .iter()
+                .find(|hit| {
+                    matches!(hit.target,
+                crate::ui::render::QueueHitTarget::Task(task) if task == id)
+                })
+                .unwrap()
+                .area;
+            assert!(moved.y > row.y, "fixture must cross the wrap boundary");
+            dispatch_reflow_test_click(&mut domain, &mut model, &mut reflow_click, area, click);
+            assert_eq!(model.wide_stage(), crate::ui::tier::WideStage::FullTask);
+            assert_eq!(model.edit_target(), Some(id));
+        }
+    }
+
+    #[test]
+    fn app_reflow_double_click_different_cell_keeps_live_task_controls() {
+        let (mut domain, mut model) = board_fixture("control routing", None);
+        let mut reflow = ReflowRowClick::default();
+        let area = Rect::new(0, 0, 130, 24);
+        let hits = board_hit_map(area, &model);
+        let row = hits
+            .regions
+            .iter()
+            .find(|hit| matches!(hit.target, crate::ui::render::QueueHitTarget::Task(_)))
+            .unwrap()
+            .area;
+        dispatch_reflow_test_click(
+            &mut domain,
+            &mut model,
+            &mut reflow,
+            area,
+            left_click(80, row.y),
+        );
+        let hits = board_hit_map(area, &model);
+        let control = hits
+            .regions
+            .iter()
+            .find(|hit| matches!(hit.target, crate::ui::render::QueueHitTarget::StepAdd))
+            .unwrap()
+            .area;
+        assert_ne!(control.as_position(), Position::new(80, row.y));
+        dispatch_reflow_test_click(
+            &mut domain,
+            &mut model,
+            &mut reflow,
+            area,
+            click_at(control),
+        );
+        assert_eq!(model.wide_stage(), crate::ui::tier::WideStage::Rail);
+        assert_eq!(model.input_mode(), BoardInputMode::EditStep);
+    }
+
+    #[test]
+    fn app_reflow_double_click_cancels_for_other_gestures() {
+        for event in [
+            Event::Key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
+            Event::Resize(120, 24),
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Drag(MouseButton::Left),
+                ..left_click(21, 6)
+            }),
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                ..left_click(20, 6)
+            }),
+            Event::Mouse(left_click(21, 6)),
+        ] {
+            let (mut domain, mut model) = board_fixture("cancel gesture", None);
+            let area = Rect::new(0, 0, 130, 24);
+            let row = board_hit_map(area, &model)
+                .regions
+                .into_iter()
+                .find(|hit| matches!(hit.target, crate::ui::render::QueueHitTarget::Task(_)))
+                .unwrap()
+                .area;
+            let click = left_click(20, row.y);
+            let mut reflow = ReflowRowClick::default();
+            dispatch_reflow_test_click(&mut domain, &mut model, &mut reflow, area, click);
+            assert!(reflow.target(&model, area, click).is_some());
+            assert!(reflow
+                .target(&model, Rect::new(0, 0, 129, 24), click)
+                .is_none());
+            reflow.observe(&event);
+            assert!(reflow.target(&model, area, click).is_none(), "{event:?}");
+        }
+    }
+
+    #[test]
+    fn app_reflow_double_click_does_not_arm_on_task_number_copy() {
+        let (mut domain, _) = board_fixture("copy number", None);
+        domain.assign_numbers_for_persistence();
+        let mut model = BoardModel::from_domain(&domain, None);
+        let area = Rect::new(0, 0, 130, 24);
+        let number = board_hit_map(area, &model)
+            .regions
+            .into_iter()
+            .find(|hit| matches!(hit.target, crate::ui::render::QueueHitTarget::TaskNumber(_)))
+            .unwrap()
+            .area;
+        let mut reflow = ReflowRowClick::default();
+        dispatch_reflow_test_click(&mut domain, &mut model, &mut reflow, area, click_at(number));
+        assert!(reflow.0.is_none());
+        assert_eq!(model.wide_stage(), crate::ui::tier::WideStage::FullBoard);
+    }
+
     #[test]
     fn app_mouse_click_moves_stage_a_to_g_before_dispatching_same_control() {
         let (mut domain, mut model) = board_fixture("mouse stage", None);
@@ -2482,13 +2791,19 @@ mod tests {
             })
             .expect("task-side add-step control in the preview");
         let click = click_at(control.area);
-        let (quit, intent) =
-            board_mouse_click_intent_after_focus(area, &mut model, &hits, click, |model, focus| {
+        let (quit, intent) = board_mouse_click_intent_after_focus(
+            area,
+            &mut model,
+            &hits,
+            &mut ReflowRowClick::default(),
+            click,
+            |model, focus| {
                 assert_eq!(focus, BoardIntent::StageRight);
                 apply_intent(&mut domain, model, focus, None)?;
                 Ok::<bool, DomainError>(false)
-            })
-            .expect("route click");
+            },
+        )
+        .expect("route click");
 
         assert!(!quit);
         assert_eq!(model.wide_stage(), crate::ui::tier::WideStage::Rail);
@@ -2619,6 +2934,7 @@ mod tests {
             wide,
             &mut model,
             &preview_hits,
+            &ReflowRowClick::default(),
             click_at(bottom.1),
             &mut dragging,
             |model, focus| {

--- a/src/board_pane.rs
+++ b/src/board_pane.rs
@@ -20,6 +20,13 @@ pub fn find_board_pane_from_stdin() -> io::Result<Option<String>> {
     Ok(find_board_pane_id(&buf))
 }
 
+/// Read pane-list JSON from stdin and find the first Tasks pane's tab.
+pub fn find_board_tab_from_stdin() -> io::Result<Option<String>> {
+    let mut buf = String::new();
+    io::stdin().read_to_string(&mut buf)?;
+    Ok(find_board_tab_id(&buf))
+}
+
 /// Parse herdr `pane list` JSON and return the first flag-safe Tasks pane_id.
 ///
 /// Matches panes whose `label` equals `"tsk"`.
@@ -29,6 +36,21 @@ pub fn find_board_pane_from_stdin() -> io::Result<Option<String>> {
 /// and match `[A-Za-z0-9_.:-]+` so they are safe to pass as a CLI argument to
 /// `plugin pane focus`.
 pub fn find_board_pane_id(json: &str) -> Option<String> {
+    find_board_pane(json)?
+        .get("pane_id")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// Return the tab belonging to the same pane chosen by [`find_board_pane_id`].
+/// Missing or unsafe tab ids refuse rather than selecting a different board.
+pub fn find_board_tab_id(json: &str) -> Option<String> {
+    let pane = find_board_pane(json)?;
+    let tab_id = pane.get("tab_id")?.as_str()?;
+    is_flag_safe_pane_id(tab_id).then(|| tab_id.to_owned())
+}
+
+fn find_board_pane(json: &str) -> Option<Value> {
     let data: Value = serde_json::from_str(json).ok()?;
     let panes = data
         .get("result")
@@ -42,7 +64,7 @@ pub fn find_board_pane_id(json: &str) -> Option<String> {
         }
         let pid = pane.get("pane_id").and_then(|v| v.as_str()).unwrap_or("");
         if is_flag_safe_pane_id(pid) {
-            return Some(pid.to_string());
+            return Some(pane.clone());
         }
     }
     None
@@ -109,6 +131,42 @@ mod tests {
             }
         }"#;
         assert_eq!(find_board_pane_id(json), None);
+    }
+
+    #[test]
+    fn board_tab_comes_from_the_first_safe_matching_pane() {
+        let json = r#"{"result":{"panes":[
+            {"pane_id":"w0:p1","tab_id":"w0:t1","label":"shell"},
+            {"pane_id":"--evil","tab_id":"w0:t1","label":"tsk"},
+            {"pane_id":"w0:p2","tab_id":"w0:t2","label":"tsk"},
+            {"pane_id":"w0:p3","tab_id":"w0:t3","label":"tsk"}
+        ]}}"#;
+        assert_eq!(find_board_pane_id(json).as_deref(), Some("w0:p2"));
+        assert_eq!(find_board_tab_id(json).as_deref(), Some("w0:t2"));
+    }
+
+    #[test]
+    fn missing_or_unsafe_board_tab_never_borrows_another_panes_tab() {
+        for tab in [
+            Value::Null,
+            Value::from(""),
+            Value::from("--evil"),
+            Value::from("bad id"),
+            Value::from("w0:t2\nextra"),
+        ] {
+            let json = serde_json::json!({"result":{"panes":[
+                {"pane_id":"w0:p2","tab_id":tab,"label":"tsk"},
+                {"pane_id":"w0:p3","tab_id":"w0:t3","label":"tsk"}
+            ]}})
+            .to_string();
+            assert_eq!(find_board_pane_id(&json).as_deref(), Some("w0:p2"));
+            assert_eq!(find_board_tab_id(&json), None);
+        }
+        assert_eq!(find_board_tab_id("not json"), None);
+        assert_eq!(
+            find_board_tab_id(r#"{"result":{"panes":[{"pane_id":"w0:p2","label":"tsk"}]}}"#),
+            None
+        );
     }
 
     #[test]

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -17,6 +17,7 @@ pub enum Surface {
     Setup,
     Guide,
     FindBoardPane,
+    FindBoardTab,
     ResolveContext,
     GlobalHelp,
     Usage,
@@ -24,7 +25,7 @@ pub enum Surface {
 
 /// Select a process surface from argv-style arguments, including argv0.
 ///
-/// Only `--find-board-pane` and `--help` are global flags, and only before the first
+/// Global help and internal launcher flags are recognized only before the first
 /// positional argument. A capture-mode environment value applies when there is no
 /// subcommand or global flag.
 pub fn route<S: AsRef<str>>(
@@ -40,6 +41,7 @@ pub fn route<S: AsRef<str>>(
         if arg.starts_with('-') {
             let surface = match arg {
                 "--find-board-pane" => Surface::FindBoardPane,
+                "--find-board-tab" => Surface::FindBoardTab,
                 "--resolve-context" => Surface::ResolveContext,
                 "--help" => Surface::GlobalHelp,
                 _ => return Surface::Usage,
@@ -113,6 +115,18 @@ mod tests {
     fn find_board_pane_with_extra_argument_is_usage() {
         assert_eq!(
             route(["tsk", "--find-board-pane", "extra"], None),
+            Surface::Usage
+        );
+    }
+
+    #[test]
+    fn find_board_tab_is_a_hidden_global_surface() {
+        assert_eq!(
+            route(["tsk", "--find-board-tab"], Some("capture")),
+            Surface::FindBoardTab
+        );
+        assert_eq!(
+            route(["tsk", "--find-board-tab", "extra"], None),
             Surface::Usage
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@ use tsk_tui::cli::router::{route, Surface};
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
     match route(&args, std::env::var(tsk_tui::app::MODE_ENV).ok().as_deref()) {
-        Surface::FindBoardPane => find_board_pane_main(),
+        Surface::FindBoardPane => find_board_main(false),
+        Surface::FindBoardTab => find_board_main(true),
         Surface::ResolveContext => resolve_context_main(),
         Surface::GlobalHelp => {
             println!(
@@ -96,9 +97,14 @@ fn headless_main(args: Vec<String>) -> ExitCode {
     ExitCode::from(output.code)
 }
 
-/// Read herdr `pane list` JSON from stdin; print first Tasks pane_id or exit 1.
-fn find_board_pane_main() -> ExitCode {
-    match tsk_tui::find_board_pane_from_stdin() {
+/// Read herdr `pane list` JSON; print the first Tasks pane or its tab, or exit 1.
+fn find_board_main(tab: bool) -> ExitCode {
+    let result = if tab {
+        tsk_tui::board_pane::find_board_tab_from_stdin()
+    } else {
+        tsk_tui::find_board_pane_from_stdin()
+    };
+    match result {
         Ok(Some(id)) => {
             if writeln!(io::stdout(), "{id}").is_err() {
                 return ExitCode::from(1);
@@ -107,7 +113,12 @@ fn find_board_pane_main() -> ExitCode {
         }
         Ok(None) => ExitCode::from(1),
         Err(err) => {
-            eprintln!("tsk --find-board-pane: {err}");
+            let flag = if tab {
+                "--find-board-tab"
+            } else {
+                "--find-board-pane"
+            };
+            eprintln!("tsk {flag}: {err}");
             ExitCode::from(1)
         }
     }

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -2193,7 +2193,8 @@ fn open_task_page_on(domain: &DomainState, model: &mut BoardModel, id: Uuid) {
 }
 
 /// The row double-click window: a second click on the same row within it opens the page.
-const ROW_DOUBLE_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(400);
+pub(super) const ROW_DOUBLE_CLICK_WINDOW: std::time::Duration =
+    std::time::Duration::from_millis(400);
 
 /// Keep the quick-add line's visible destination truthful while `!p` tokens are typed.
 ///

--- a/src/ui/board/apply.rs
+++ b/src/ui/board/apply.rs
@@ -733,11 +733,11 @@ fn apply_board_intent(
             if !model.select_index(idx) {
                 return Ok(IntentOutcome::None);
             }
-            // A left-side click takes focus left: a rail click in G selects the row and lands
-            // the board in A. In 0 and A the click selects in place. A second click on the
-            // same row inside the double-click window opens the full task page.
+            // A row click opens or retargets the task beside the board, with board focus.
+            // A second click on the same row inside the double-click window opens the
+            // full task page.
             model.detail_open = None;
-            if model.wide_stage == WideStage::Rail {
+            if matches!(model.wide_stage, WideStage::FullBoard | WideStage::Rail) {
                 model.wide_stage = WideStage::Split;
             }
             if let Some(id) = model.selected_id() {

--- a/src/ui/board/model.rs
+++ b/src/ui/board/model.rs
@@ -2034,6 +2034,13 @@ impl BoardModel {
         resolve_responsive(area.width, area.height, self.wide_stage)
     }
 
+    /// Only a successfully applied row click can authorize gesture continuation.
+    pub(crate) fn pending_row_double_click(&self, id: Uuid) -> bool {
+        self.last_row_click.is_some_and(|(at, last)| {
+            last == id && at.elapsed() <= super::apply::ROW_DOUBLE_CLICK_WINDOW
+        })
+    }
+
     /// Session-only wide-slider stage. The board always opens in `FullBoard`.
     pub fn wide_stage(&self) -> WideStage {
         self.wide_stage

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -118,7 +118,7 @@ pub enum BoardIntent {
     SelectPrev,
     /// Select visible list row by index (mouse row click).
     SelectIndex(usize),
-    /// Select a wide-split board row and return board focus without peek or double-click.
+    /// Select a wide board row and show its task beside the board; double-click opens full.
     FocusBoardAndSelectIndex(usize),
     /// Copy the presentation-only `T<number>` identifier for one persisted task.
     CopyTaskNumber(uuid::Uuid),

--- a/src/ui/mouse.rs
+++ b/src/ui/mouse.rs
@@ -458,9 +458,8 @@ pub fn map_responsive_board_mouse(
                 | BoardInputMode::EditScope
                 | BoardInputMode::FormScopeDropdown
         );
-    // A board-row click selects in place; a rail-row click selects and lands the board in A
-    // (the reducer moves the stage). The reducer retargets the pane or page and refuses while
-    // a dirty draft is bound elsewhere.
+    // A task-row click opens or retargets the task beside the board in A (the reducer
+    // moves the stage). The reducer refuses while a dirty draft is bound elsewhere.
     if responsive.board.contains(pos) && (view_mode || clean_or_dirty_task_editor) {
         if let Some(QueueHitTarget::Task(id)) = hit_at(hits, pos) {
             if clean_or_dirty_task_editor && model.edit_target() == Some(id) {

--- a/tests/host_scripts.rs
+++ b/tests/host_scripts.rs
@@ -61,10 +61,12 @@ if [ "$1" = pane ] && [ "$2" = list ]; then
   fi
 elif [ "$1" = tab ] && [ "$2" = focus ]; then
   [ "${STUB_MODE:-}" != tab-focus-failure ] || exit 1
+  printf '%s' "$3" > "$STUB_ROOT/visible-tab"
 elif [ "$1" = plugin ] && [ "$2" = pane ] && [ "$3" = focus ]; then
   [ "${STUB_MODE:-}" != focus-failure ] || exit 1
 elif [ "$1" = plugin ] && [ "$2" = pane ] && [ "$3" = open ]; then
   touch "$STUB_ROOT/opened"
+  printf '%s' 'w0:t1' > "$STUB_ROOT/opened-tab"
   printf '%s' "${HERDR_PLUGIN_CONTEXT_JSON:-}" > "$STUB_ROOT/open-context.json"
 fi
 "#,
@@ -86,6 +88,16 @@ fi
         workspace: Option<&str>,
         pane: Option<&str>,
     ) -> std::process::Output {
+        self.run_with_tab(mode, workspace, pane, Some("w0:t1"))
+    }
+
+    fn run_with_tab(
+        &self,
+        mode: &str,
+        workspace: Option<&str>,
+        pane: Option<&str>,
+        tab: Option<&str>,
+    ) -> std::process::Output {
         let mut command = Command::new("bash");
         command
             .arg(open_board_path())
@@ -96,6 +108,7 @@ fi
             .env("STUB_ROOT", &self.root)
             .env("STUB_MODE", mode)
             .env_remove("HERDR_PANE_ID")
+            .env_remove("HERDR_TAB_ID")
             .env(
                 "HERDR_PLUGIN_CONTEXT_JSON",
                 r#"{"focused_pane_cwd":"/tmp"}"#,
@@ -106,6 +119,9 @@ fi
         }
         if let Some(pane) = pane {
             command.env("HERDR_PANE_ID", pane);
+        }
+        if let Some(tab) = tab {
+            command.env("HERDR_TAB_ID", tab);
         }
         command.output().expect("launcher")
     }
@@ -190,13 +206,18 @@ fn open_board_tab_focus_failure_does_not_focus_or_duplicate_the_board() {
 }
 
 #[test]
-fn open_board_stale_focus_falls_back_to_open_in_the_same_workspace() {
+fn open_board_stale_focus_falls_back_to_a_visible_board_in_the_invoking_tab() {
     let launcher = Launcher::new();
     let output = launcher.run("focus-failure", Some("w0"));
     assert!(output.status.success(), "{output:?}");
     let calls = launcher.calls();
+    assert_eq!(
+        read(&launcher.root.join("visible-tab")),
+        read(&launcher.root.join("opened-tab")),
+        "the replacement must be visible, not merely focused on the server"
+    );
     assert!(
-        calls.contains("plugin pane focus w0:p2\nplugin pane open "),
+        calls.contains("plugin pane focus w0:p2\ntab focus w0:t1\nplugin pane open "),
         "{calls}"
     );
     let open = calls
@@ -225,6 +246,17 @@ fn open_board_refuses_missing_pane_without_using_host_focus() {
         let output = launcher.run_with_pane("absent", Some("w0"), pane);
         assert!(!output.status.success(), "{output:?}");
         assert!(String::from_utf8_lossy(&output.stderr).contains("pane"));
+        assert!(launcher.calls().is_empty());
+    }
+}
+
+#[test]
+fn open_board_refuses_missing_invoking_tab_before_navigation() {
+    for tab in [None, Some("")] {
+        let launcher = Launcher::new();
+        let output = launcher.run_with_tab("focus-failure", Some("w0"), Some("w0:p1"), tab);
+        assert!(!output.status.success(), "{output:?}");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("tab"));
         assert!(launcher.calls().is_empty());
     }
 }

--- a/tests/host_scripts.rs
+++ b/tests/host_scripts.rs
@@ -26,100 +26,215 @@ fn read(path: &Path) -> String {
     fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
 }
 
-#[test]
-fn open_board_exercises_context_handoff_before_focus_and_new_pane_paths() {
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let root = std::env::temp_dir().join(format!(
-        "tsk-host-launcher-{}-{}",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    ));
-    fs::create_dir_all(&root).expect("temp root");
-    let stub = root.join("herdr");
-    let log = root.join("calls.log");
-    fs::write(
-        &stub,
-        r#"#!/bin/sh
-printf '%s\n' "$*" >> "$STUB_LOG"
+struct Launcher {
+    root: PathBuf,
+}
+
+impl Launcher {
+    fn new() -> Self {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "tsk-host-launcher-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(root.join("state")).expect("temp root");
+        let stub = root.join("herdr");
+        fs::write(
+            &stub,
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$STUB_ROOT/calls.log"
 if [ "$1" = pane ] && [ "$2" = list ]; then
-  if [ "${STUB_MODE:-existing}" = existing ]; then
-    printf '%s' '{"result":{"panes":[{"pane_id":"w0:p1","label":"tsk"}]}}'
-  else
-    printf '%s' '{"result":{"panes":[]}}'
+  [ "${STUB_MODE:-}" != list-failure ] || exit 1
+  if [ "${STUB_MODE:-}" = missing-tab ]; then
+    printf '%s' '{"result":{"panes":[{"pane_id":"w0:p2","label":"tsk"}]}}'
+    exit 0
   fi
-fi
-if [ "$1" = plugin ] && [ "$2" = pane ] && [ "$3" = focus ] && [ ! -f "$STUB_STATE/reopen.json" ]; then
-  exit 1
+  if [ "$3" = --workspace ] && [ "$4" = w0 ]; then
+    if [ "${STUB_MODE:-}" = existing ] || [ "${STUB_MODE:-}" = focus-failure ] || [ "${STUB_MODE:-}" = tab-focus-failure ] || [ -f "$STUB_ROOT/opened" ]; then
+      printf '%s' '{"result":{"panes":[{"pane_id":"w0:p2","workspace_id":"w0","tab_id":"w0:t2","label":"tsk"}]}}'
+    else
+      printf '%s' '{"result":{"panes":[]}}'
+    fi
+  else
+    printf '%s' '{"result":{"panes":[{"pane_id":"w9:p1","workspace_id":"w9","tab_id":"w9:t1","label":"tsk"},{"pane_id":"w0:p2","workspace_id":"w0","tab_id":"w0:t2","label":"tsk"}]}}'
+  fi
+elif [ "$1" = tab ] && [ "$2" = focus ]; then
+  [ "${STUB_MODE:-}" != tab-focus-failure ] || exit 1
+elif [ "$1" = plugin ] && [ "$2" = pane ] && [ "$3" = focus ]; then
+  [ "${STUB_MODE:-}" != focus-failure ] || exit 1
+elif [ "$1" = plugin ] && [ "$2" = pane ] && [ "$3" = open ]; then
+  touch "$STUB_ROOT/opened"
+  printf '%s' "${HERDR_PLUGIN_CONTEXT_JSON:-}" > "$STUB_ROOT/open-context.json"
 fi
 "#,
-    )
-    .expect("stub");
-    let mut permissions = fs::metadata(&stub).expect("stub metadata").permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&stub, permissions).expect("stub executable");
-    let state = root.join("state");
-    fs::create_dir_all(&state).expect("state");
-    let run = |mode: &str| {
-        Command::new("bash")
+        )
+        .expect("stub");
+        let mut permissions = fs::metadata(&stub).expect("stub metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&stub, permissions).expect("stub executable");
+        Self { root }
+    }
+
+    fn run(&self, mode: &str, workspace: Option<&str>) -> std::process::Output {
+        self.run_with_pane(mode, workspace, Some("w0:p1"))
+    }
+
+    fn run_with_pane(
+        &self,
+        mode: &str,
+        workspace: Option<&str>,
+        pane: Option<&str>,
+    ) -> std::process::Output {
+        let mut command = Command::new("bash");
+        command
             .arg(open_board_path())
-            .env("HERDR_BIN_PATH", &stub)
+            .env("HERDR_BIN_PATH", self.root.join("herdr"))
             .env("TSK_BIN", env!("CARGO_BIN_EXE_tsk"))
-            .env("TSK_STATE_DIR", &state)
-            .env("STUB_LOG", &log)
-            .env("STUB_STATE", &state)
+            .env("TSK_STATE_DIR", self.root.join("state"))
+            .env("TSK_CONFIG_DIR", self.root.join("state"))
+            .env("STUB_ROOT", &self.root)
             .env("STUB_MODE", mode)
+            .env_remove("HERDR_PANE_ID")
             .env(
                 "HERDR_PLUGIN_CONTEXT_JSON",
                 r#"{"focused_pane_cwd":"/tmp"}"#,
             )
-            .output()
-            .expect("launcher")
-    };
-    let existing = run("existing");
-    assert!(
-        existing.status.success(),
-        "existing launcher: {:?}",
-        existing
-    );
-    let calls = read(&log);
-    assert!(calls.contains("pane list"));
-    assert!(calls.contains("plugin pane focus w0:p1"));
-    assert!(
-        !calls.lines().any(|line| line == "plugin pane open"),
-        "existing pane must not be reopened"
-    );
-    assert!(calls.find("pane list").unwrap() < calls.find("plugin pane focus").unwrap());
-    assert!(state.join("reopen.json").exists(), "context was published");
+            .env_remove("HERDR_WORKSPACE_ID");
+        if let Some(workspace) = workspace {
+            command.env("HERDR_WORKSPACE_ID", workspace);
+        }
+        if let Some(pane) = pane {
+            command.env("HERDR_PANE_ID", pane);
+        }
+        command.output().expect("launcher")
+    }
 
-    let absent = run("absent");
-    assert!(absent.status.success(), "new-pane launcher: {:?}", absent);
-    let calls = read(&log);
-    assert!(calls.contains("plugin pane open"));
+    fn calls(&self) -> String {
+        fs::read_to_string(self.root.join("calls.log")).unwrap_or_default()
+    }
+}
 
-    let before = calls.lines().count();
-    let failed = Command::new("bash")
-        .arg(open_board_path())
-        .env("HERDR_BIN_PATH", &stub)
-        .env("TSK_BIN", env!("CARGO_BIN_EXE_tsk"))
-        .env("TSK_STATE_DIR", &state)
-        .env("STUB_LOG", &log)
-        .env("STUB_STATE", &state)
-        .env("STUB_MODE", "existing")
-        .env("HERDR_PLUGIN_CONTEXT_JSON", "not json")
-        .output()
-        .expect("failing launcher");
-    assert!(!failed.status.success());
-    let after = read(&log);
+impl Drop for Launcher {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn open_board_focuses_current_workspace_board_even_in_another_tab() {
+    let launcher = Launcher::new();
+    let output = launcher.run("existing", Some("w0"));
+    assert!(output.status.success(), "{output:?}");
     assert_eq!(
-        after.lines().count(),
-        before + 1,
-        "failed handoff must not focus"
+        launcher.calls(),
+        "pane list --workspace w0\ntab focus w0:t2\nplugin pane focus w0:p2\n"
     );
-    assert!(!after
+    assert!(
+        !launcher.root.join("state/reopen.json").exists(),
+        "focusing must preserve the board view, not publish shared context"
+    );
+}
+
+#[test]
+fn open_board_opens_locally_when_only_other_workspaces_have_boards() {
+    let launcher = Launcher::new();
+    let output = launcher.run("absent", Some("w0"));
+    assert!(output.status.success(), "{output:?}");
+    let calls = launcher.calls();
+    assert!(calls.starts_with("pane list --workspace w0\n"), "{calls}");
+    assert!(calls.contains("plugin pane open "), "{calls}");
+    assert!(calls.contains("--workspace w0"), "{calls}");
+    assert!(calls.contains("--placement split"), "{calls}");
+    assert!(calls.contains("--focus"), "{calls}");
+    let open = calls
         .lines()
-        .skip(before)
-        .any(|line| line == "plugin pane focus w0:p1"));
-    let _ = fs::remove_dir_all(root);
+        .find(|line| line.starts_with("plugin pane open "))
+        .expect("open call");
+    assert!(open.contains("--target-pane w0:p1"), "{open}");
+    assert!(
+        !open.contains("--workspace"),
+        "split placement rejects workspace_id: {open}"
+    );
+    assert!(!calls.contains("plugin pane focus"), "{calls}");
+    assert_eq!(
+        read(&launcher.root.join("open-context.json")),
+        r#"{"focused_pane_cwd":"/tmp"}"#
+    );
+    // The next invocation finds the local pane, never creates a second one.
+    let output = launcher.run("absent", Some("w0"));
+    assert!(output.status.success(), "{output:?}");
+    let calls = launcher.calls();
+    assert_eq!(calls.matches("plugin pane open ").count(), 1, "{calls}");
+    assert!(calls.ends_with("plugin pane focus w0:p2\n"), "{calls}");
+}
+
+#[test]
+fn open_board_missing_tab_refuses_without_creating_a_duplicate() {
+    let launcher = Launcher::new();
+    let output = launcher.run("missing-tab", Some("w0"));
+    assert!(!output.status.success(), "{output:?}");
+    assert_eq!(launcher.calls(), "pane list --workspace w0\n");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("board tab"));
+}
+
+#[test]
+fn open_board_tab_focus_failure_does_not_focus_or_duplicate_the_board() {
+    let launcher = Launcher::new();
+    let output = launcher.run("tab-focus-failure", Some("w0"));
+    assert!(!output.status.success(), "{output:?}");
+    assert_eq!(
+        launcher.calls(),
+        "pane list --workspace w0\ntab focus w0:t2\n"
+    );
+}
+
+#[test]
+fn open_board_stale_focus_falls_back_to_open_in_the_same_workspace() {
+    let launcher = Launcher::new();
+    let output = launcher.run("focus-failure", Some("w0"));
+    assert!(output.status.success(), "{output:?}");
+    let calls = launcher.calls();
+    assert!(
+        calls.contains("plugin pane focus w0:p2\nplugin pane open "),
+        "{calls}"
+    );
+    let open = calls
+        .lines()
+        .find(|line| line.starts_with("plugin pane open "))
+        .expect("open call");
+    assert!(open.contains("--target-pane w0:p1"), "{open}");
+    assert!(!open.contains("--workspace"), "{open}");
+}
+
+#[test]
+fn open_board_refuses_missing_workspace_without_global_lookup() {
+    for workspace in [None, Some("")] {
+        let launcher = Launcher::new();
+        let output = launcher.run("existing", workspace);
+        assert!(!output.status.success(), "{output:?}");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("workspace"));
+        assert!(launcher.calls().is_empty());
+    }
+}
+
+#[test]
+fn open_board_refuses_missing_pane_without_using_host_focus() {
+    for pane in [None, Some("")] {
+        let launcher = Launcher::new();
+        let output = launcher.run_with_pane("absent", Some("w0"), pane);
+        assert!(!output.status.success(), "{output:?}");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("pane"));
+        assert!(launcher.calls().is_empty());
+    }
+}
+
+#[test]
+fn open_board_list_failure_does_not_create_a_duplicate() {
+    let launcher = Launcher::new();
+    let output = launcher.run("list-failure", Some("w0"));
+    assert!(!output.status.success(), "{output:?}");
+    assert_eq!(launcher.calls(), "pane list --workspace w0\n");
 }
 
 /// Non-comment, non-empty lines of a shell script (strip `# ...` full-line comments).

--- a/tests/wide_task_split.rs
+++ b/tests/wide_task_split.rs
@@ -1366,7 +1366,7 @@ fn click_map(model: &BoardModel, hits: &QueueHitMap, x: u16, y: u16) -> Option<B
 }
 
 #[test]
-fn board_row_click_selects_without_changing_stage_or_peeking() {
+fn board_row_click_opens_or_retargets_split_without_peeking() {
     for stage in [WideStage::FullBoard, WideStage::Split] {
         let (mut domain, mut model) = fixture();
         to_stage(&mut domain, &mut model, stage);
@@ -1383,18 +1383,34 @@ fn board_row_click_selects_without_changing_stage_or_peeking() {
         assert!(matches!(intent, BoardIntent::FocusBoardAndSelectIndex(_)));
         go(&mut domain, &mut model, intent);
         assert_ne!(model.selected_id(), selected);
-        assert_eq!(model.wide_stage(), stage, "{stage:?}: stage unchanged");
+        assert_eq!(model.wide_stage(), WideStage::Split, "{stage:?}");
+        assert_eq!(model.focused_surface(), FocusedSurface::Board);
+        assert_eq!(model.input_mode(), BoardInputMode::Normal);
         assert_eq!(model.detail_open(), None, "no peek at wide widths");
         let (after, _) = render(&model, 130, 24);
         assert_ne!(rows, after);
-        if stage == WideStage::Split {
-            let header = column_text(&after, geometry.task_content(), 1);
-            assert!(
-                header.contains("T15 Renew domain"),
-                "pane retargets: {header}"
-            );
-        }
+        let split = resolve_responsive(130, 24, WideStage::Split);
+        let header = column_text(&after, split.task_content(), 1);
+        assert!(
+            header.contains("T15 Renew domain"),
+            "pane retargets: {header}"
+        );
     }
+}
+
+#[test]
+fn full_board_click_on_selected_task_opens_split() {
+    let (mut domain, mut model) = fixture();
+    let selected = model.selected_id().expect("selected task");
+    let geometry = resolve_responsive(130, 24, WideStage::FullBoard);
+    let (_, hits) = render(&model, 130, 24);
+    let row = row_hit(&hits, geometry.board, |id| id == selected);
+    let intent = click_map(&model, &hits, row.x, row.y).expect("row click");
+    go(&mut domain, &mut model, intent);
+    assert_eq!(model.wide_stage(), WideStage::Split);
+    assert_eq!(model.selected_id(), Some(selected));
+    assert_eq!(model.focused_surface(), FocusedSurface::Board);
+    assert_eq!(model.detail_open(), None);
 }
 
 #[test]
@@ -1509,13 +1525,19 @@ fn row_double_click_opens_the_full_page_and_records_the_origin() {
         let selected = model.selected_id();
         let row = row_hit(&hits, geometry.board, |id| Some(id) != selected);
         let intent = click_map(&model, &hits, row.x, row.y).expect("row click");
-        go(&mut domain, &mut model, intent.clone());
-        let after_first = if stage == WideStage::Rail {
-            WideStage::Split
-        } else {
-            stage
-        };
+        go(&mut domain, &mut model, intent);
+        let after_first = WideStage::Split;
         assert_eq!(model.wide_stage(), after_first, "{stage:?}: first click");
+        let (_, hits) = render(&model, 130, 24);
+        // Rail rows can reflow vertically when the board expands. Keep that existing
+        // case task-based; full-board and split double-clicks use the same coordinates.
+        let row = if stage == WideStage::Rail {
+            let split = resolve_responsive(130, 24, WideStage::Split);
+            row_hit(&hits, split.board, |id| Some(id) == model.selected_id())
+        } else {
+            row
+        };
+        let intent = click_map(&model, &hits, row.x, row.y).expect("second row click");
         go(&mut domain, &mut model, intent);
         assert_eq!(
             model.wide_stage(),


### PR DESCRIPTION
## Summary

- Clicking a task on the full-width wide board opens its details alongside the board, retaining board focus. Double-click keeps the original task through column reflow and opens the full task page, rather than activating newly exposed controls. The website demo follows the same behavior.
- `prefix+t` opens or focuses one board per workspace, across tabs. Activate the board's tab before focusing its pane so Herdr 0.9.0 visibly navigates the attached client. Preserve the board's view and unsaved edits, leave other workspaces alone, and return to the invoking tab before creating a replacement after stale-pane focus failure.

Includes regression tests, documentation, and matching website demo behavior. Preserves the newer outside-Git desk defaults from main.

## Test plan

- [x] Before/after regressions reproduced both mouse reflow failures and stale-board visibility failure. Focused app gesture tests (5) and launcher tests (17) pass.
- [x] Website build and tests (42), plus browser double-click regressions at 110 and 130 columns (2).
- [x] Live rebuilt Herdr double-click smoke for right-column clicks and vertically reflowing rows, isolated store unchanged. Prior cross-workspace smoke completed and owner confirmed the actual `prefix+t` visibly switches to the existing tsk tab.
- [x] Full Rust green bar and packaging tests passed in PR CI on Linux and macOS. Site CI also passed. The redundant local full run was cancelled at the owner's request, not counted as a complete local pass.

Temporary smoke workspaces were removed. Daily task data and plugin registration were not changed. Live stale-board failure-injection smoke was blocked by local command policy; its targeted launcher visibility regression passes.

`npm ci` reports two high-severity advisories in unchanged dependencies; this PR makes no dependency changes.
