### PR TITLE
Track verify-tsk live recipes for notices and quoted keys

### DIFF
--- a/.cursor/skills/verify-tsk/.gitignore
+++ b/.cursor/skills/verify-tsk/.gitignore
@@ -1,0 +1,3 @@
+.run
+evidence/
+.venv/

--- a/.cursor/skills/verify-tsk/SKILL.md
+++ b/.cursor/skills/verify-tsk/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: verify-tsk
+description: Drive tsk (terminal task board) as a user would — isolated TUI board plus tsk add/list/steps CLI. Use when proving a board, capture, status-verb, task-page, or CLI change against the real binary, not unit tests.
+---
+
+# Verify tsk
+
+tsk is a terminal task board. The user-facing product is the `tsk` binary: an interactive board (default argv) and headless `add` / `list` / `status` / `edit` / `steps`. This skill drives those surfaces against a disposable store. It does not drive `~/.tsk`, a herdr pane, or the marketing site in `site/`.
+
+Helpers live at `.cursor/skills/verify-tsk/scripts/control-tsk`. Every command below is run from the repo root. Feature recipes are in `features/`.
+
+## Launch
+
+Build once per checkout if `target/release/tsk` is missing or stale:
+
+```bash
+cargo build --release
+```
+
+Once per checkout, create the skill venv so board dumps decode cursor-addressed paint (same `pyte` pin as `scripts/parity-requirements.txt`):
+
+```bash
+python3 -m venv .cursor/skills/verify-tsk/.venv
+.cursor/skills/verify-tsk/.venv/bin/pip install -r scripts/parity-requirements.txt
+```
+
+Allocate an isolated run (state, config, non-git cwd, evidence dir). This is required before doctor, CLI, or the board:
+
+```bash
+./.cursor/skills/verify-tsk/scripts/control-tsk init
+./.cursor/skills/verify-tsk/scripts/control-tsk doctor
+```
+
+`init` writes `.cursor/skills/verify-tsk/.run` and prints JSON with `run_id`, `state_dir`, `config_dir`, `cwd`, `evidence_dir`, and `binary`. The store is `$state_dir/tsk.json`. Config holds a dismissed `walkthrough.json` so the board opens without the first-run card. The board's cwd is an empty non-git directory, so capture defaults to the desk rather than this repo.
+
+Ready for the TUI: home tabs paint `desk` · project · `projects`. The first full board open seeds four notice tasks (`N` ids) plus a possible `What's new` notice. They paint on the desk under NEEDS YOU / IN MOTION / ON DECK · desk, but `tsk list` never shows them. Selection starts on the Welcome notice (review). Empty-desk copy (`no open tasks here`) appears only after those notices are gone, or on a project board with no tasks. Standard size is 80×24. The harness cwd basename lands in slot 2 (not `select project`).
+
+Start or stop the board PTY only when the claim is about the TUI:
+
+```bash
+./.cursor/skills/verify-tsk/scripts/control-tsk board start
+./.cursor/skills/verify-tsk/scripts/control-tsk board quit
+```
+
+Teardown the run (keeps evidence, removes scratch state and the board process):
+
+```bash
+./.cursor/skills/verify-tsk/scripts/control-tsk cleanup
+```
+
+## Doctor
+
+Run whenever anything looks off:
+
+```bash
+./.cursor/skills/verify-tsk/scripts/control-tsk doctor
+```
+
+Doctor is read-only. It requires the release binary, real (non-symlink) state/config/cwd dirs, a dismissed walkthrough file, and a state dir that is not `~/.tsk`. Exit 0 means drive. Exit 2 means refuse.
+
+## Drive
+
+Prefer the CLI for store mutations. Prefer the board PTY for paint, keys, and peek/page flows. Never call internal Rust setters or edit `tsk.json` by hand and call that a product proof.
+
+CLI (injects `--state-dir` for mutating/list commands):
+
+```bash
+./.cursor/skills/verify-tsk/scripts/control-tsk cli -- add -t "verify title" --desk --json
+./.cursor/skills/verify-tsk/scripts/control-tsk cli -- list --desk --json
+./.cursor/skills/verify-tsk/scripts/control-tsk cli -- status T1 started
+./.cursor/skills/verify-tsk/scripts/control-tsk cli -- steps 1 add "first step"
+./.cursor/skills/verify-tsk/scripts/control-tsk store
+```
+
+Board keys use named chords from the product keymap (mutating verbs are Ctrl):
+
+```bash
+./.cursor/skills/verify-tsk/scripts/control-tsk board keys down
+./.cursor/skills/verify-tsk/scripts/control-tsk board keys j
+./.cursor/skills/verify-tsk/scripts/control-tsk board keys ctrl-s
+./.cursor/skills/verify-tsk/scripts/control-tsk board wait "IN MOTION"
+./.cursor/skills/verify-tsk/scripts/control-tsk board dump
+./.cursor/skills/verify-tsk/scripts/control-tsk board keys enter
+./.cursor/skills/verify-tsk/scripts/control-tsk board keys 'text:Verify quick add'
+./.cursor/skills/verify-tsk/scripts/control-tsk board keys ctrl-q
+```
+
+Named keys include `enter`, `esc`, `tab`, `up`/`down`/`left`/`right`, `ctrl-s`/`ctrl-d`/`ctrl-o`/`ctrl-b`/`ctrl-r`/`ctrl-e`/`ctrl-n`/`ctrl-x`/`ctrl-u`/`ctrl-f`/`ctrl-q`, single characters, and `text:<string>`. Quote `text:` when the string has spaces (`board keys 'text:Verify quick add'`); otherwise argv splits it and later words become unknown keys. Confirm the `▸` marker sits on the intended row before a mutating chord — first open selects Welcome, and a starter already paints `IN MOTION`, so `wait "IN MOTION"` is not start proof.
+
+Read `features/README.md`, then the matching feature file, before claiming a feature verified. A proof that takes one convenient entry point is incomplete when the map lists others.
+
+## Evidence
+
+Proof artifacts land under `.cursor/skills/verify-tsk/evidence/<run_id>/` and survive `cleanup`.
+
+Standards:
+
+- Exercise the real user path (CLI argv or board keys), not test-only hooks.
+- Capture the action and the resulting state. CLI runs write `cli-*.json` (command, stdout, stderr, exit). Board dumps write `board-screen.txt` plus `.ansi`.
+- Confirm side effects with `control-tsk store` or a second `list --json` after a mutation.
+- Never treat unit-test `TestBackend` goldens alone as product verification for a user-facing change this skill covers.
+
+## Cleanup
+
+```bash
+./.cursor/skills/verify-tsk/scripts/control-tsk cleanup
+```
+
+Cleanup stops the board and proxy this run started (by recorded pids), deletes the scratch tree under `/tmp`, and removes `.run`. It never deletes `evidence/<run_id>/`. Do not `pkill tsk`.
+
+## Helpers
+
+| Command | Purpose |
+| --- | --- |
+| `control-tsk init` | Create isolated state/config/cwd + evidence dir; write `.run` |
+| `control-tsk doctor` | Read-only health check |
+| `control-tsk cli -- …` | Run `target/release/tsk` with the run's env and `--state-dir` |
+| `control-tsk board start\|keys\|wait\|dump\|quit` | PTY board lifecycle |
+| `control-tsk store` | Print `$state_dir/tsk.json` |
+| `control-tsk cleanup` | Tear down instance; keep evidence |
+
+Override the binary with `TSK_BIN=/path/to/tsk` when needed. Live herdr pane smoke is out of scope here; when `HERDR_ENV` is unset, say live herdr smoke was not run.

--- a/.cursor/skills/verify-tsk/features/README.md
+++ b/.cursor/skills/verify-tsk/features/README.md
@@ -1,0 +1,50 @@
+# tsk verification map
+
+This directory is the maintained source for verifying user-facing tsk behavior. Read the index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Build `target/release/tsk` when missing or stale (`cargo build --release`).
+- Run `./.cursor/skills/verify-tsk/scripts/control-tsk init` so the store is a disposable directory, never `~/.tsk`.
+- Run `control-tsk doctor` and require `"ok": true`, the expected `binary`, and a non-home `state_dir`.
+- Prefer CLI recipes for store mutations. Start the board PTY only for paint and key claims.
+- Never drive an instance that was not started by this verification run.
+
+## Driving conventions
+
+- Start every recipe from the baseline state unless its preconditions say otherwise.
+- Prefer stable CLI flags (`--desk`, `--json`, `--state-dir`) and board prompt strings (`NEEDS YOU`, `IN MOTION`, `ON DECK · desk`, `/ search`) over coordinates. Do not wait for `desk` as destination proof: that word is on the tab row of every surface.
+- First `board start` on a fresh store seeds notice tasks. `j`/`k` until dump shows `▸` on the intended title. `tsk list` still omits notices.
+- Treat every command as literal. Keep quoted titles and flags unchanged.
+- Run CLI actions through `control-tsk cli --`.
+- Run board actions through `control-tsk board …`.
+- Restore or discard scratch state with `cleanup`. Do not remove proof artifacts during cleanup.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- CLI proof includes the command, stdout, stderr, and exit code (`evidence/.../cli-*.json`).
+- Board proof includes a screen dump (`board-screen.txt`) and a store read when the action mutates tasks.
+- Mutation proof includes a second read (`list --json` or `control-tsk store`).
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and the unmet precondition.
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with control-tsk` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable handles, required state, commands, and observable proof.
+
+## Features
+
+- [CLI add and list](./cli-add-list.md) covers desk creation, JSON list, and persistence.
+- [Board status verbs](./board-status-verbs.md) covers selecting a row, starting it, and marking it done.
+- [Quick add](./quick-add.md) covers the `+` capture line on the board.
+- [Task page](./task-page.md) covers opening a task and toggling a step.
+- [Desk and projects tabs](./desk-projects-tabs.md) covers `1` / `3` destinations and Enter on a project row.

--- a/.cursor/skills/verify-tsk/features/board-status-verbs.md
+++ b/.cursor/skills/verify-tsk/features/board-status-verbs.md
@@ -1,0 +1,40 @@
+# Board status verbs
+
+Board status verbs let a user move the selected task between ready, started, blocked, review, and done with Ctrl chords while watching the board update. This recipe proves start (`ctrl+s`) and done (`ctrl+d`).
+
+## Sub-features
+
+- `board-select` moves selection with arrows or `j`/`k` until `▸` sits on the seeded title.
+- `board-start` starts a ready task with `ctrl+s`.
+- `board-done` marks the selected task done with `ctrl+d`. Bare `d` opens the done drawer; it does not mark done.
+
+## How to get to it (user POV)
+
+- Open the board with `tsk` or Herdr prefix+t.
+- Select a ready task, then press `ctrl+s` to start. The row moves under **IN MOTION**.
+- Press `ctrl+d` to mark done. The row leaves the live lanes. Press `d` to open the drawer and see **DONE**.
+
+## Driving it with control-tsk
+
+Preconditions:
+
+- `control-tsk doctor` reports `"ok": true`.
+- A desk task titled `Verify board start` exists at status `ready` (seed with the CLI feature if needed).
+- Board is running at 80×24: `control-tsk board start`.
+
+- **Seed if empty.** Run `control-tsk cli -- add -t "Verify board start" --desk --json` when the store has no matching task.
+- **Confirm paint.** Run `control-tsk board wait "Verify board start"`. The decoded screen contains the title. First open also paints notice rows; Welcome (`N1`, review) is selected and a starter already sits under **IN MOTION**.
+- **Select the seeded row.** Run `control-tsk board dump` and `control-tsk board keys j` (or `k`) until `▸` is on `Verify board start`. Do not send `ctrl-s` while Welcome is selected (`ctrl+s` is a no-op on review).
+- **Start task.** Run `control-tsk board keys ctrl-s`.
+- **Store proof.** Run `control-tsk store` (or `cli -- list <number> --json` using the number from add). The matching task has `"status":"started"`.
+- **Screen proof.** Run `control-tsk board dump --path .cursor/skills/verify-tsk/evidence/$RUN_ID/board-start.txt`. The dump shows the title under **IN MOTION**, not merely that the header exists.
+- **Mark done.** Run `control-tsk board keys ctrl-d`. Store (or `list --done`) shows `"status":"done"`. The title is gone from NEEDS YOU / IN MOTION / ON DECK.
+- **Drawer.** Run `control-tsk board keys d` then `control-tsk board wait "DONE"`. Dump a `board-done.txt`. At 80×24 with notices filling the frame, the done row may sit below the fold; the **DONE** header plus store status is enough. Bare `d` toggles the drawer; `ctrl+d` does not open it.
+- **Quit board.** Run `control-tsk board quit`.
+
+## Gotchas
+
+- Mutating verbs need Ctrl. Bare `s` does nothing; bare `d` toggles the drawer.
+- A running board keeps the old binary until quit. Rebuild before `board start` when testing code changes.
+- `wait "IN MOTION"` is not start proof: a starter notice already occupies that lane.
+- Live Herdr pane smoke is a separate gate (`HERDR_ENV=1`) and is not covered here.

--- a/.cursor/skills/verify-tsk/features/cli-add-list.md
+++ b/.cursor/skills/verify-tsk/features/cli-add-list.md
@@ -1,0 +1,36 @@
+# CLI add and list
+
+CLI add and list let a user create a desk task from the terminal and confirm it from a second list read without opening the board.
+
+## Sub-features
+
+- `cli-add-desk` creates a desk task with a title.
+- `cli-list-desk` lists open desk tasks as JSON.
+- `cli-add-idempotent` reports an existing match instead of duplicating.
+
+## How to get to it (user POV)
+
+- Run `tsk add -t "<title>" --desk --json` (`--json` is an output flag, not a substitute for `--desk`).
+- Run `tsk list --desk --json`.
+- Agents also reach the same commands via `tsk guide` / the installed CLI skill.
+
+## Driving it with control-tsk
+
+Preconditions:
+
+- `control-tsk doctor` reports `"ok": true`.
+- No desk task is titled `Verify CLI add`.
+
+- **Create desk task.** Run `./.cursor/skills/verify-tsk/scripts/control-tsk cli -- add -t "Verify CLI add" --desk --json`. Exit code `0`. Stdout JSON has `"outcome":"created"`, a numeric `number`, and `"title":"Verify CLI add"` (`"project": null`).
+- **List desk tasks.** Run `./.cursor/skills/verify-tsk/scripts/control-tsk cli -- list --desk --json`. Exit code `0`. Stdout is a JSON array containing one object whose `title` is `Verify CLI add` and `status` is `ready`.
+- **Idempotent re-add.** Run the same add command again. Exit code `0`. Stdout JSON has `"outcome":"existing"` and the same `number`.
+- **Store proof.** Run `./.cursor/skills/verify-tsk/scripts/control-tsk store`. The printed `tsk.json` contains the task title and `status` `ready`.
+
+## Gotchas
+
+- Outside a git repo, bare `tsk add -t` already defaults to the desk. This harness cwd is non-git on purpose; still pass `--desk` so the recipe stays explicit.
+- Human list output is not stable for agents. Prefer `--json`.
+- Do not point `--state-dir` at `~/.tsk`.
+- A typo in `--project` silently creates a new scope. Use `--desk` for this recipe.
+- An existing match still wins if the same title/scope/thread is done or individually archived. Default `list --desk` then omits that row; keep the store empty of this title.
+- `tsk list` never shows notice (`N`) rows. A later board open can seed notices without changing this list.

--- a/.cursor/skills/verify-tsk/features/desk-projects-tabs.md
+++ b/.cursor/skills/verify-tsk/features/desk-projects-tabs.md
@@ -1,0 +1,34 @@
+# Desk and projects tabs
+
+Desk and projects tabs are the persistent destinations on every normal board surface. `1` opens desk, `3` opens the projects overview.
+
+## Sub-features
+
+- `tab-desk` focuses desk with `1`.
+- `tab-projects` focuses the projects index with `3`.
+- `tab-project-open` opens the selected index row with Enter (the harness cwd `here` row is present without a CLI-seeded project).
+
+## How to get to it (user POV)
+
+- Press `1` for desk, `3` for projects, or click the tab labels.
+- Press Enter (or double-click) on a projects-index row to open that project in slot 2.
+- Press `p` for the project picker (adjacent surface; not required for this recipe).
+
+## Driving it with control-tsk
+
+Preconditions:
+
+- `control-tsk doctor` reports `"ok": true`.
+- Board is running: `control-tsk board start`.
+
+- **Desk.** Run `control-tsk board keys 1`. Then `control-tsk board wait "ON DECK"` and dump. Expect underlined `desk`, slot 2 = cwd basename + `▾` (not `select project`), no `Overview` / `PROJECT` legend, idle footer ` desk` or notice rows under `ON DECK · desk`. Do not wait for `desk` alone: that word is on the tab row of every surface.
+- **Projects.** Run `control-tsk board keys 3`. Then `control-tsk board wait "/ search"` and dump. Expect `Overview ▾`; legend `PROJECT` + `NEEDS YOU` / `IN MOTION` / `READY`; one `cwd · here` row; status line = full cwd path; verbs `enter open · / search · ? help`. No `THREADS` at 80×24.
+- **Open project.** Run `control-tsk board keys enter`. Dump: slot 2 still cwd, `all ▾` instead of `Overview`, no `PROJECT` legend, empty project paints `ON DECK` (not `· desk`) and `no open tasks here — p rescope or + add`.
+- **Proof.** Dumps succeed without store corruption. `control-tsk store` still reads valid JSON if a store file exists.
+
+## Gotchas
+
+- Digits `1`/`2`/`3` are keyboard-only destinations applied outside the shared normal keymap table; they still work in this harness as literal key bytes.
+- Project rows are navigation, never task rows. Do not send status verbs on the projects index.
+- Slot 2 is empty (`select project`) only when there is no invocation directory. This harness cwd is a real non-git directory, so slot 2 shows that basename and the index has a `here` row.
+- Closed-overview `/ search` is on the verb bar. Do not expect the open-search help line `/ search · type · enter open · esc clear`.

--- a/.cursor/skills/verify-tsk/features/quick-add.md
+++ b/.cursor/skills/verify-tsk/features/quick-add.md
@@ -1,0 +1,37 @@
+# Quick add
+
+Quick add lets a user capture a title from the board's one-line `+` input without a form takeover, then see the new task selected on the list.
+
+## Sub-features
+
+- `quick-add-open` opens the title line with `+`.
+- `quick-add-save` saves with Enter and closes the line.
+- `quick-add-cancel` discards with Esc.
+
+## How to get to it (user POV)
+
+- On the board, press `+` (or click `+ add` in the footer).
+- Type a title and press Enter to save, or Esc to cancel.
+- Herdr prefix+a / `tsk capture` opens the expanded capture page; that path is adjacent, not this recipe.
+
+## Driving it with control-tsk
+
+Preconditions:
+
+- `control-tsk doctor` reports `"ok": true`.
+- Board is running: `control-tsk board start`.
+- No desk task is titled `Verify quick add`.
+
+- **Open line.** Run `control-tsk board keys +`. Then `control-tsk board wait "add to desk"`. Dump: the list is still visible; chrome includes `title…`, `add to desk`, and `enter save · tab details · esc close`.
+- **Type title.** Run `control-tsk board keys 'text:Verify quick add'` (one quoted argv token).
+- **Save.** Run `control-tsk board keys enter`.
+- **Proof.** Run `control-tsk cli -- list --desk --json`. Exit `0` and stdout contain `"title":"Verify quick add"`. Dump: the title is on the list with `▸`. There is no toast (`Title required` / `saved` / `captured` absent).
+- **Cancel path.** Open `+` again, type `'text:Discard me'`, press `esc`. `list --desk --json` must not gain `Discard me`.
+
+## Gotchas
+
+- Success has no status message. The new row (and selection) is the feedback.
+- Quote `text:` when the title has spaces. Unquoted `text:Verify quick add` sends only `Verify` and dies on `quick`.
+- Capture tokens `!p` / `!t` consume arguments from the title. Avoid them unless proving tokens.
+- Expanded Tab capture owns the whole frame; do not expect a side-by-side board at wide widths. Do not press Tab on this recipe.
+- Esc is labeled `close` on the verb bar.

--- a/.cursor/skills/verify-tsk/features/task-page.md
+++ b/.cursor/skills/verify-tsk/features/task-page.md
@@ -1,0 +1,37 @@
+# Task page
+
+The task page lets a user open one task full-frame (or beside the board when wide), read notes, and toggle steps without leaving the product surface.
+
+## Sub-features
+
+- `page-open` opens the selected task with Enter.
+- `page-step-toggle` toggles a stored step with Enter when the step is selected.
+- `page-close` returns with Esc.
+
+## How to get to it (user POV)
+
+- Select a task on the board and press Enter (or double-click). A single click peeks in a narrow pane and opens details beside the board at ≥110 columns; this harness has no mouse.
+- At ≥110 columns, `→` slides toward the page (first stop is split, not full-frame). This recipe uses 80×24 so Enter opens the page full-frame. Below 110, `→` peeks.
+- Press Esc to close.
+
+## Driving it with control-tsk
+
+Preconditions:
+
+- `control-tsk doctor` reports `"ok": true`.
+- A desk task titled `Verify task page` exists with notes `plain note` and one open step `first step` (seed via CLI).
+- Board is running at 80×24.
+
+- **Seed.** Run `control-tsk cli -- add -t "Verify task page" -n "plain note" --desk --json`, then `control-tsk cli -- steps <number> add "first step"`.
+- **Select.** Dump and `board keys j` until `▸` is on `Verify task page`. First open selects Welcome; bare Enter would open that notice.
+- **Open page.** Run `control-tsk board keys enter`.
+- **Confirm notes.** Run `control-tsk board wait "plain note"`.
+- **Toggle step.** Run `control-tsk board keys tab` then `enter`. Tab-first is required: Enter with no stored step selected closes the full page. Confirm with `control-tsk cli -- list <number> --json` that `steps[0]` has `"text":"first step"` and `"done": true`.
+- **Close.** Run `control-tsk board keys esc`, then `control-tsk board wait "ON DECK"`. Do not wait for `desk`: the page Scope line already paints it.
+
+## Gotchas
+
+- The page is view-first. `Tab` in view mode selects steps and **+ step**; it does not start title/notes edit. Use `ctrl+e` / `ctrl+n` to edit.
+- `Shift+Enter` is the whole-session save chord while editing. Do not confuse it with step Enter.
+- `list --desk --json` does not include `steps`. Direct `list <number> --json` does.
+- Below 110 columns there is peek on `→`; this recipe uses Enter for the page.

--- a/.cursor/skills/verify-tsk/scripts/control-tsk
+++ b/.cursor/skills/verify-tsk/scripts/control-tsk
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Drive an isolated tsk instance for verification. Never touches ~/.tsk."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import pathlib
+import pty
+import re
+import select
+import shutil
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+import uuid
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+REPO_ROOT = SKILL_ROOT.parents[2]
+RUN_FILE = SKILL_ROOT / ".run"
+EVIDENCE_ROOT = SKILL_ROOT / "evidence"
+VENV_SITE = (
+    SKILL_ROOT
+    / ".venv"
+    / "lib"
+    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+DEFAULT_BINARY = REPO_ROOT / "target" / "release" / "tsk"
+CSI_RE = re.compile(rb"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
+
+if VENV_SITE.is_dir():
+    sys.path.insert(0, str(VENV_SITE))
+
+try:
+    import pyte
+except ImportError:  # pragma: no cover - optional until skill venv is created
+    pyte = None  # type: ignore[assignment]
+
+
+def die(message: str, code: int = 1) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def decode_screen(raw: bytes, width: int, height: int) -> str:
+    """Decode a PTY transcript to a plain text frame.
+
+    Cursor-addressed paints leave titles as adjacent cells. Stripping CSI alone
+    joins words (`Verifyboardstart`). Prefer pyte when the skill venv is present.
+    """
+    if pyte is not None:
+        screen = pyte.Screen(width, height)
+        stream = pyte.ByteStream(screen)
+        stream.feed(raw)
+        return "\n".join(line.rstrip() for line in screen.display)
+    return strip_ansi(raw)
+
+
+def load_run() -> dict:
+    if not RUN_FILE.is_file():
+        die("no active run · control-tsk init first")
+    try:
+        return json.loads(RUN_FILE.read_text())
+    except json.JSONDecodeError as error:
+        die(f"corrupt .run: {error}")
+
+
+def save_run(data: dict) -> None:
+    RUN_FILE.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def binary_path(run: dict | None = None) -> pathlib.Path:
+    override = os.environ.get("TSK_BIN")
+    if override:
+        return pathlib.Path(override)
+    if run and run.get("binary"):
+        return pathlib.Path(run["binary"])
+    return DEFAULT_BINARY
+
+
+def strip_ansi(data: bytes) -> str:
+    cleaned = CSI_RE.sub(b"", data)
+    cleaned = cleaned.replace(b"\r", b"")
+    return cleaned.decode("utf-8", errors="replace")
+
+
+def ensure_dirs(path: pathlib.Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def write_walkthrough_dismissed(config_dir: pathlib.Path) -> None:
+    ensure_dirs(config_dir)
+    (config_dir / "walkthrough.json").write_text('{"dismissed":true}\n')
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    run_id = args.run_id or time.strftime("%Y%m%d-%H%M%S") + "-" + uuid.uuid4().hex[:8]
+    scratch = pathlib.Path(tempfile.mkdtemp(prefix=f"tsk-verify-{run_id}-"))
+    state_dir = scratch / "state"
+    config_dir = scratch / "config"
+    cwd = scratch / "cwd"
+    evidence_dir = EVIDENCE_ROOT / run_id
+    for path in (state_dir, config_dir, cwd, evidence_dir):
+        ensure_dirs(path)
+    write_walkthrough_dismissed(config_dir)
+    binary = binary_path()
+    if not binary.is_file():
+        die(f"missing binary {binary} · cargo build --release from repo root")
+    data = {
+        "run_id": run_id,
+        "scratch": str(scratch),
+        "state_dir": str(state_dir),
+        "config_dir": str(config_dir),
+        "cwd": str(cwd),
+        "evidence_dir": str(evidence_dir),
+        "binary": str(binary.resolve()),
+        "board_pid": None,
+        "board_master_fd": None,
+        "board_width": 80,
+        "board_height": 24,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    save_run(data)
+    print(json.dumps(data, indent=2))
+    return 0
+
+
+def cmd_doctor(_: argparse.Namespace) -> int:
+    run = load_run()
+    binary = binary_path(run)
+    problems: list[str] = []
+    if not binary.is_file():
+        problems.append(f"binary missing: {binary}")
+    for key in ("state_dir", "config_dir", "cwd", "evidence_dir"):
+        path = pathlib.Path(run[key])
+        if not path.is_dir():
+            problems.append(f"{key} missing: {path}")
+        if path.is_symlink():
+            problems.append(f"{key} is a symlink (tsk refuses): {path}")
+    home_tsk = pathlib.Path.home() / ".tsk"
+    if pathlib.Path(run["state_dir"]).resolve() == home_tsk.resolve():
+        problems.append("state_dir resolves to ~/.tsk · refuse")
+    if not (pathlib.Path(run["config_dir"]) / "walkthrough.json").is_file():
+        problems.append("walkthrough.json missing under config_dir")
+    pid = run.get("board_pid")
+    if pid:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            problems.append(f"board_pid {pid} is not running")
+            run["board_pid"] = None
+            save_run(run)
+    report = {
+        "ok": not problems,
+        "run_id": run["run_id"],
+        "binary": str(binary),
+        "state_dir": run["state_dir"],
+        "config_dir": run["config_dir"],
+        "cwd": run["cwd"],
+        "evidence_dir": run["evidence_dir"],
+        "board_pid": run.get("board_pid"),
+        "problems": problems,
+    }
+    print(json.dumps(report, indent=2))
+    return 0 if not problems else 2
+
+
+def cli_env(run: dict) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("HERDR_", "TSK_"))}
+    env.update(
+        {
+            "TSK_STATE_DIR": run["state_dir"],
+            "TSK_CONFIG_DIR": run["config_dir"],
+            "TSK_NO_UPDATE_CHECK": "1",
+            "TERM": "xterm-256color",
+            "HOME": run["scratch"],
+        }
+    )
+    return env
+
+
+def inject_state_dir(argv: list[str], state_dir: str) -> list[str]:
+    if any(arg == "--state-dir" or arg.startswith("--state-dir=") for arg in argv):
+        return argv
+    if not argv:
+        return argv
+    head, *rest = argv
+    if head in {
+        "add",
+        "list",
+        "status",
+        "edit",
+        "steps",
+        "trash",
+        "archive",
+        "unarchive",
+        "project",
+    }:
+        return [head, f"--state-dir={state_dir}", *rest]
+    return argv
+
+
+def cmd_cli(args: argparse.Namespace) -> int:
+    run = load_run()
+    binary = binary_path(run)
+    argv = inject_state_dir(list(args.argv), run["state_dir"])
+    completed = subprocess.run(
+        [str(binary), *argv],
+        cwd=run["cwd"],
+        env=cli_env(run),
+        text=True,
+        capture_output=True,
+    )
+    sys.stdout.write(completed.stdout)
+    sys.stderr.write(completed.stderr)
+    artifact = {
+        "command": [str(binary), *argv],
+        "cwd": run["cwd"],
+        "exit_code": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }
+    stamp = f"{time.strftime('%H%M%S')}-{time.time_ns() % 1_000_000:06d}"
+    path = pathlib.Path(run["evidence_dir"]) / f"cli-{stamp}.json"
+    path.write_text(json.dumps(artifact, indent=2) + "\n")
+    print(f"evidence: {path}", file=sys.stderr)
+    return completed.returncode
+
+
+def board_socket_path(run: dict) -> pathlib.Path:
+    return pathlib.Path(run["scratch"]) / "board.sock"
+
+
+def cmd_board_start(args: argparse.Namespace) -> int:
+    run = load_run()
+    if run.get("board_pid"):
+        die(f"board already running as pid {run['board_pid']}")
+    binary = binary_path(run)
+    width = args.width
+    height = args.height
+    master, slave = pty.openpty()
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", height, width, 0, 0))
+    child = subprocess.Popen(
+        [str(binary)],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        cwd=run["cwd"],
+        env=cli_env(run),
+        start_new_session=True,
+        preexec_fn=lambda: fcntl.ioctl(0, termios.TIOCSCTTY, 0),
+    )
+    os.close(slave)
+    run["board_pid"] = child.pid
+    run["board_width"] = width
+    run["board_height"] = height
+    run["board_master_fd"] = None
+    pid_file = pathlib.Path(run["scratch"]) / "board.pid"
+    master_file = pathlib.Path(run["scratch"]) / "board.master"
+    pid_file.write_text(str(child.pid))
+    # Keep the master fd open in this process only for the start call's wait;
+    # subsequent commands reopen via /dev/fd is impossible across processes.
+    # Persist master path by dup'ing into a stable file descriptor file is not portable.
+    # Instead write the master fd number into the run file and keep a long-lived daemon.
+    # Simpler: spawn a tiny board-proxy that owns the PTY for the run lifetime.
+    proxy = pathlib.Path(run["scratch"]) / "board-proxy.py"
+    proxy.write_text(
+        """#!/usr/bin/env python3
+import fcntl, json, os, pathlib, select, struct, sys, termios, time
+run_path = pathlib.Path(sys.argv[1])
+master = int(sys.argv[2])
+meta = pathlib.Path(sys.argv[3])
+ctl = pathlib.Path(sys.argv[4])
+out = pathlib.Path(sys.argv[5])
+ctl.mkdir(parents=True, exist_ok=True)
+out.mkdir(parents=True, exist_ok=True)
+buf = bytearray()
+seq = 0
+meta.write_text(json.dumps({"master": master, "pid": os.getpid()}) + "\\n")
+while True:
+    cmds = sorted(ctl.glob("cmd-*.json"))
+    for cmd_path in cmds:
+        try:
+            cmd = json.loads(cmd_path.read_text())
+        except Exception:
+            cmd_path.unlink(missing_ok=True)
+            continue
+        kind = cmd.get("kind")
+        if kind == "write":
+            os.write(master, bytes(cmd["data"]))
+        elif kind == "resize":
+            fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", cmd["height"], cmd["width"], 0, 0))
+        elif kind == "quit":
+            cmd_path.unlink(missing_ok=True)
+            os.close(master)
+            raise SystemExit(0)
+        cmd_path.unlink(missing_ok=True)
+        (out / f"ack-{cmd_path.name}").write_text("ok\\n")
+    ready, _, _ = select.select([master], [], [], 0.05)
+    if ready:
+        try:
+            chunk = os.read(master, 65536)
+        except OSError:
+            break
+        if not chunk:
+            break
+        buf.extend(chunk)
+        seq += 1
+        (out / "screen.raw").write_bytes(bytes(buf))
+        (out / "screen.seq").write_text(str(seq))
+"""
+    )
+    # Hand master to proxy child; close in parent after spawn.
+    proxy_log = pathlib.Path(run["scratch"]) / "board-proxy.log"
+    ctl_dir = pathlib.Path(run["scratch"]) / "board-ctl"
+    out_dir = pathlib.Path(run["scratch"]) / "board-out"
+    meta_path = pathlib.Path(run["scratch"]) / "board-proxy.json"
+    ensure_dirs(ctl_dir)
+    ensure_dirs(out_dir)
+    proxy_proc = subprocess.Popen(
+        [sys.executable, str(proxy), str(RUN_FILE), str(master), str(meta_path), str(ctl_dir), str(out_dir)],
+        pass_fds=(master,),
+        stdout=proxy_log.open("w"),
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    os.close(master)
+    run["board_proxy_pid"] = proxy_proc.pid
+    run["board_ctl"] = str(ctl_dir)
+    run["board_out"] = str(out_dir)
+    save_run(run)
+    # Wait until the first paint mentions desk chrome or empty-state copy.
+    deadline = time.monotonic() + 8
+    raw_path = out_dir / "screen.raw"
+    while time.monotonic() < deadline:
+        if raw_path.is_file():
+            text = decode_screen(raw_path.read_bytes(), width, height)
+            if "desk" in text or "NEEDS YOU" in text or "no open tasks" in text or "ON DECK" in text:
+                break
+        time.sleep(0.05)
+    else:
+        die("board did not paint within 8s · check board-proxy.log under scratch")
+    print(
+        json.dumps(
+            {
+                "board_pid": child.pid,
+                "board_proxy_pid": proxy_proc.pid,
+                "width": width,
+                "height": height,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def board_send(run: dict, payload: dict, timeout: float = 2.0, *, required: bool = True) -> bool:
+    ctl = pathlib.Path(run["board_ctl"])
+    out = pathlib.Path(run["board_out"])
+    name = f"cmd-{time.time_ns()}.json"
+    path = ctl / name
+    path.write_text(json.dumps(payload))
+    ack = out / f"ack-{name}"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ack.is_file():
+            ack.unlink(missing_ok=True)
+            return True
+        time.sleep(0.01)
+    if required:
+        die(f"board proxy did not ack {name}")
+    path.unlink(missing_ok=True)
+    return False
+
+
+def named_key(name: str) -> bytes:
+    table = {
+        "enter": b"\r",
+        "esc": b"\x1b",
+        "tab": b"\t",
+        "up": b"\x1b[A",
+        "down": b"\x1b[B",
+        "right": b"\x1b[C",
+        "left": b"\x1b[D",
+        "ctrl-s": b"\x13",
+        "ctrl-d": b"\x04",
+        "ctrl-o": b"\x0f",
+        "ctrl-b": b"\x02",
+        "ctrl-r": b"\x12",
+        "ctrl-e": b"\x05",
+        "ctrl-n": b"\x0e",
+        "ctrl-x": b"\x18",
+        "ctrl-u": b"\x15",
+        "ctrl-f": b"\x06",
+        "ctrl-q": b"\x11",
+        "ctrl-c": b"\x03",
+        "shift-enter": b"\x1b[13;2u",  # may not land; prefer literal \r with shift via text APIs
+    }
+    if name in table:
+        return table[name]
+    if name.startswith("text:"):
+        return name[len("text:") :].encode()
+    if len(name) == 1:
+        return name.encode()
+    die(
+        f"unknown key {name!r} · use named keys or text:<string> "
+        "(quote the token when the string has spaces: 'text:Verify quick add')"
+    )
+
+
+def cmd_board_keys(args: argparse.Namespace) -> int:
+    run = load_run()
+    if not run.get("board_pid"):
+        die("board not running · control-tsk board start")
+    for token in args.keys:
+        board_send(run, {"kind": "write", "data": list(named_key(token))})
+        time.sleep(0.05)
+    return 0
+
+
+def cmd_board_dump(args: argparse.Namespace) -> int:
+    run = load_run()
+    raw_path = pathlib.Path(run["board_out"]) / "screen.raw"
+    if not raw_path.is_file():
+        die("no screen capture yet")
+    raw = raw_path.read_bytes()
+    text = decode_screen(raw, int(run.get("board_width", 80)), int(run.get("board_height", 24)))
+    dest = pathlib.Path(args.path) if args.path else pathlib.Path(run["evidence_dir"]) / "board-screen.txt"
+    ensure_dirs(dest.parent)
+    dest.write_text(text + "\n")
+    ansi_dest = dest.with_suffix(".ansi")
+    ansi_dest.write_bytes(raw)
+    print(text)
+    print(f"evidence: {dest}", file=sys.stderr)
+    print(f"evidence: {ansi_dest}", file=sys.stderr)
+    return 0
+
+
+def cmd_board_wait(args: argparse.Namespace) -> int:
+    run = load_run()
+    raw_path = pathlib.Path(run["board_out"]) / "screen.raw"
+    deadline = time.monotonic() + args.timeout
+    needle = args.substring
+    width = int(run.get("board_width", 80))
+    height = int(run.get("board_height", 24))
+    while time.monotonic() < deadline:
+        if raw_path.is_file() and needle in decode_screen(raw_path.read_bytes(), width, height):
+            print(json.dumps({"found": needle, "ok": True}))
+            return 0
+        time.sleep(0.05)
+    die(f"timed out waiting for {needle!r}")
+
+
+def cmd_board_quit(_: argparse.Namespace) -> int:
+    run = load_run()
+    if not run.get("board_pid") and not run.get("board_proxy_pid"):
+        print(json.dumps({"ok": True, "note": "board not running"}))
+        return 0
+    board_send(run, {"kind": "write", "data": list(named_key("ctrl-q"))}, timeout=1.0, required=False)
+    time.sleep(0.2)
+    for key in ("board_pid", "board_proxy_pid"):
+        pid = run.get(key)
+        if not pid:
+            continue
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        alive = False
+        for key in ("board_pid", "board_proxy_pid"):
+            pid = run.get(key)
+            if not pid:
+                continue
+            try:
+                os.kill(pid, 0)
+                alive = True
+            except OSError:
+                run[key] = None
+        if not alive:
+            break
+        time.sleep(0.05)
+    for key in ("board_pid", "board_proxy_pid"):
+        pid = run.get(key)
+        if not pid:
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+        run[key] = None
+    board_send(run, {"kind": "quit"}, timeout=0.5, required=False)
+    save_run(run)
+    print(json.dumps({"ok": True}))
+    return 0
+
+
+def cmd_store_show(_: argparse.Namespace) -> int:
+    run = load_run()
+    path = pathlib.Path(run["state_dir"]) / "tsk.json"
+    if not path.is_file():
+        print(json.dumps({"exists": False, "path": str(path)}))
+        return 0
+    print(path.read_text())
+    return 0
+
+
+def cmd_cleanup(args: argparse.Namespace) -> int:
+    if RUN_FILE.is_file():
+        run = load_run()
+        if run.get("board_pid") or run.get("board_proxy_pid"):
+            cmd_board_quit(argparse.Namespace())
+            run = load_run()
+        scratch = pathlib.Path(run["scratch"])
+        evidence = pathlib.Path(run["evidence_dir"])
+        if scratch.is_dir() and not args.keep_scratch:
+            shutil.rmtree(scratch, ignore_errors=True)
+        RUN_FILE.unlink(missing_ok=True)
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "removed_scratch": str(scratch),
+                    "evidence_kept": str(evidence),
+                    "evidence_exists": evidence.is_dir(),
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(json.dumps({"ok": True, "note": "no active run"}))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="control-tsk", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init_p = sub.add_parser("init", help="allocate an isolated run")
+    init_p.add_argument("--run-id")
+    init_p.set_defaults(func=cmd_init)
+
+    doctor_p = sub.add_parser("doctor", help="read-only health check")
+    doctor_p.set_defaults(func=cmd_doctor)
+
+    cli_p = sub.add_parser("cli", help="run tsk CLI against the run store")
+    cli_p.add_argument("argv", nargs=argparse.REMAINDER)
+    cli_p.set_defaults(func=cmd_cli)
+
+    board = sub.add_parser("board", help="drive the TUI board in a PTY")
+    board_sub = board.add_subparsers(dest="board_command", required=True)
+
+    start_p = board_sub.add_parser("start")
+    start_p.add_argument("--width", type=int, default=80)
+    start_p.add_argument("--height", type=int, default=24)
+    start_p.set_defaults(func=cmd_board_start)
+
+    keys_p = board_sub.add_parser("keys")
+    keys_p.add_argument("keys", nargs="+")
+    keys_p.set_defaults(func=cmd_board_keys)
+
+    dump_p = board_sub.add_parser("dump")
+    dump_p.add_argument("--path")
+    dump_p.set_defaults(func=cmd_board_dump)
+
+    wait_p = board_sub.add_parser("wait")
+    wait_p.add_argument("substring")
+    wait_p.add_argument("--timeout", type=float, default=5.0)
+    wait_p.set_defaults(func=cmd_board_wait)
+
+    quit_p = board_sub.add_parser("quit")
+    quit_p.set_defaults(func=cmd_board_quit)
+
+    store_p = sub.add_parser("store", help="print tsk.json for the run")
+    store_p.set_defaults(func=cmd_store_show)
+
+    cleanup_p = sub.add_parser("cleanup", help="stop board and remove scratch; keep evidence")
+    cleanup_p.add_argument("--keep-scratch", action="store_true")
+    cleanup_p.set_defaults(func=cmd_cleanup)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.command == "cli":
+        # argparse.REMAINDER keeps a leading "--" when callers pass `cli -- …`
+        if args.argv and args.argv[0] == "--":
+            args.argv = args.argv[1:]
+        if not args.argv:
+            die("usage: control-tsk cli -- <tsk args…>")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds the project-local `verify-tsk` skill so a later agent can drive the isolated board/CLI harness from the repo.
- Recipes now match first-open notice seeding: select by `▸`, do not treat `wait "IN MOTION"` as start proof, quote `text:` titles with spaces, and drive done plus opening the cwd project row.

## Test plan
- [x] Live `control-tsk` pass over all five feature files (CLI add/list, status start+done, quick-add save/cancel, task-page step toggle, desk/projects/open)
- [x] Re-drove the unquoted `text:` harness error after the hint change
- [ ] `cargo fmt --check` (skill-only; no Rust change)
- [ ] `cargo clippy --all-targets -- -D warnings` (skill-only)
- [ ] `cargo test` (skill-only)
- [ ] Manual herdr open-board smoke (if host paths changed) — not in this skill's scope; `HERDR_ENV` unset
- [ ] `cd site && npm ci && npm test && npm run build` (if `site/` changed)