### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,27 @@
 # Changelog
 
-One `## vX.Y.Z` section per release, newest first, with `## Unreleased` on top. Inside a
-section the subsections are, in this order and only when non-empty: `### Breaking`,
-`### Added`, `### Changed`, `### Fixed`. Every user-visible change lands here in the PR
-that makes it, written for a user, not a contributor: omit demo alignment, CI wiring,
-review history, and other maintainer-only work. On release the version's section becomes
-the GitHub release notes verbatim.
+One `## vX.Y.Z` section per release, newest first, with `## Unreleased
 
-## Unreleased
+## v0.8.0
 
 ### Added
 
-- `tsk update` upgrades installer-managed copies; Homebrew copies print `brew update && brew upgrade tsk`.
-- `tsk setup omp` installs the agent skill for the active OMP profile and participates in detected-agent setup.
+- Starter tour on first board open: four desk tasks (`N1` to `N4`) that teach the tabs, sections, status keys, the task page, and the CLI, each cleared for good with `ctrl+d`, `ctrl+f`, or `ctrl+x`. Agents never see them: `tsk list` hides `N` rows.
+- What's new on your desk: after an upgrade, one `N` row summarises the release, with a link to the changelog. A fresh install gets none.
+- `tsk update` upgrades installer-managed copies in place; Homebrew copies print `brew update && brew upgrade tsk`. The board nudges once a day when a newer release is out (`TSK_NO_UPDATE_CHECK` disables).
+- `tsk setup` detects the coding agents on your machine and offers to install the tsk skill for each; `tsk setup agents --yes` does it unattended. The curl installer asks the same question once when Herdr is on PATH.
+- Added support for OMP with `tsk setup omp`, thanks @bnivanov.
+- Outside Git, the current directory is available as a project: `2` opens its board, quick-add files there once it is open. The desk stays the default for capture and the CLI.
 
 ### Changed
 
 - The agent skill (`tsk guide`, `tsk setup <agent>`) is rewritten around a quick-reference table and rules of engagement: agents hand work back with `review` and leave `done` to you. Skill version 1.1.0; rerun `tsk setup` to update installed copies.
+- Task store format 3. Older binaries refuse the new file; the first save writes `tsk.json.v2` beside it.
+
+### Fixed
+
+- On a wide board, clicking a task opens its details beside the board and keeps board focus; a double-click during column reflow opens the task you clicked, not a newly exposed control.
+- `prefix+t` opens or focuses one board per Herdr workspace, across tabs, and returns to the tab you pressed it from.
 
 ## v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ One `## vX.Y.Z` section per release, newest first, with `## Unreleased
 
 ## v0.8.0
 
+### Breaking
+
+- Task store format 3, migrated automatically on first open. Rolling back to 0.7.x afterwards refuses the file; restore the `tsk.json.v2` backup written beside it if you need to.
+
 ### Added
 
 - Starter tour on first board open: four desk tasks (`N1` to `N4`) that teach the tabs, sections, status keys, the task page, and the CLI, each cleared for good with `ctrl+d`, `ctrl+f`, or `ctrl+x`. Agents never see them: `tsk list` hides `N` rows.
@@ -16,7 +20,6 @@ One `## vX.Y.Z` section per release, newest first, with `## Unreleased
 ### Changed
 
 - The agent skill (`tsk guide`, `tsk setup <agent>`) is rewritten around a quick-reference table and rules of engagement: agents hand work back with `review` and leave `done` to you. Skill version 1.1.0; rerun `tsk setup` to update installed copies.
-- Task store format 3. Older binaries refuse the new file; the first save writes `tsk.json.v2` beside it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-One `## vX.Y.Z` section per release, newest first, with `## Unreleased
+One `## vX.Y.Z` section per release, newest first, with `## Unreleased` on top. Inside a
+section the subsections are, in this order and only when non-empty: `### Breaking`,
+`### Added`, `### Changed`, `### Fixed`. Every user-visible change lands here in the PR
+that makes it, written for a user, not a contributor: omit demo alignment, CI wiring,
+review history, and other maintainer-only work. On release the version's section becomes
+the GitHub release notes verbatim.
+
+## Unreleased
 
 ## v0.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tsk-tui"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "crossterm",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-tui"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "tsk: a task board for your terminal"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ In a wide pane, click a task or press `→` to open its details beside the board
 Press `Enter` for a full-screen task and `Esc` to return. For a standalone board,
 run `tsk` in your terminal.
 
+### Coming soon
+
+**From task to implementation.** The next phase brings agent execution into the
+board: assign a task to an agent, start implementation from tsk, and run the work
+in Herdr worktrees.
+
 ## Quickstart
 
 ### Install

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -2,7 +2,7 @@
 
 id = "herdr-tsk"
 name = "herdr-tsk"
-version = "0.7.0"
+version = "0.8.0"
 description = "Queue board and quick capture inside herdr."
 min_herdr_version = "0.7.5"
 platforms = ["linux", "macos"]

--- a/site/src/version.mjs
+++ b/site/src/version.mjs
@@ -1,2 +1,2 @@
 // Crate and plugin version, shown in the landing and docs headers.
-export const VERSION = '0.7.0';
+export const VERSION = '0.8.0';


### PR DESCRIPTION
Version bump PR per `AGENTS.md` "Cutting a release".

- `Cargo.toml`, `Cargo.lock`, `herdr-plugin.toml`, `site/src/version.mjs` → 0.8.0 (`scripts/release.py check-version v0.8.0` passes)
- `CHANGELOG.md`: Unreleased becomes `## v0.8.0` with the entries for #57, #65-#72, #74; fresh empty Unreleased above it
- README: "Coming soon" section for the agent-execution phase
- No board announcement this round: existing users receive the four starter tasks on this upgrade already

Green bar exit 0 (177 s), packaging suite 52 passed.

After merge: owner pushes tag `v0.8.0`, dispatches `Prepare release`, then the pre-release rehearsal from `AGENTS.md`.