### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ the GitHub release notes verbatim.
 
 ## Unreleased
 
-## v0.8.0
+## v0.8.1
 
 ### Breaking
 
@@ -18,7 +18,7 @@ the GitHub release notes verbatim.
 ### Added
 
 - Starter tour on first board open: four desk tasks (`N1` to `N4`) that teach the tabs, sections, status keys, the task page, and the CLI, each cleared for good with `ctrl+d`, `ctrl+f`, or `ctrl+x`. Agents never see them: `tsk list` hides `N` rows.
-- What's new on your desk: after an upgrade, one `N` row summarises the release, with a link to the changelog. A fresh install gets none.
+- What's new on your desk: after an upgrade, one `N` row can summarise the release with a link to the changelog. This release carries none, so a 0.7.x upgrader sees only the tour.
 - `tsk update` upgrades installer-managed copies in place; Homebrew copies print `brew update && brew upgrade tsk`. The board nudges once a day when a newer release is out (`TSK_NO_UPDATE_CHECK` disables).
 - `tsk setup` detects the coding agents on your machine and offers to install the tsk skill for each; `tsk setup agents --yes` does it unattended. The curl installer asks the same question once when Herdr is on PATH.
 - Added support for OMP with `tsk setup omp`, thanks @bnivanov.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tsk-tui"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "crossterm",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-tui"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "tsk: a task board for your terminal"
 license = "MIT"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -2,7 +2,7 @@
 
 id = "herdr-tsk"
 name = "herdr-tsk"
-version = "0.8.0"
+version = "0.8.1"
 description = "Queue board and quick capture inside herdr."
 min_herdr_version = "0.7.5"
 platforms = ["linux", "macos"]

--- a/scripts/parity-pty-smoke.py
+++ b/scripts/parity-pty-smoke.py
@@ -41,7 +41,8 @@ for width in (40, 78, 109, 110):
         # Keep this task-only fixture stable as guide and announcement catalogs grow.
         guide_ids = re.findall(r'catalog_id: "([^"]+)"', (repo / 'src/guides.rs').read_text())
         announcements = tomllib.loads((repo / 'src/announcements/catalog.toml').read_text())
-        newest_announcement = max(entry['id'] for entry in announcements['announcement'])
+        # A comment-only catalog means nothing to announce; the watermark stays at 0.
+        newest_announcement = max((entry['id'] for entry in announcements.get('announcement', [])), default=0)
         (state / 'delivery.json').write_text(json.dumps({
             'guides': guide_ids,
             'announcement_watermark': newest_announcement,

--- a/scripts/parity-pty-smoke.py
+++ b/scripts/parity-pty-smoke.py
@@ -83,6 +83,17 @@ for width in (40, 78, 109, 110):
             (output / f'pty-{width}-{name}.ansi').write_bytes(transcript)
             (output / f'pty-{width}-{name}.txt').write_text('\n'.join(screen.display))
 
+        def saved_task(number, ready):
+            # A settled screen does not mean the save has landed: the board repaints
+            # before it persists, and wide layouts repaint in several chunks. Poll.
+            deadline = time.monotonic() + 3
+            while True:
+                saved = json.loads((state / 'tsk.json').read_text())
+                task = next(t for t in saved['tasks'] if t['number'] == number)
+                if ready(task) or time.monotonic() >= deadline:
+                    return task
+                time.sleep(0.05)
+
         try:
             first = drain()
             deadline = time.monotonic() + 8
@@ -97,19 +108,16 @@ for width in (40, 78, 109, 110):
             key(b'\x1b[D', 'closed')
             key(b'\x1b[B', 'selected')
             key(b'\x13', 'started')
-            saved = json.loads((state / 'tsk.json').read_text())
-            assert next(t for t in saved['tasks'] if t['number'] == 13)['status'] == 'started'
+            assert saved_task(13, lambda t: t['status'] == 'started')['status'] == 'started'
             key(b'\r', 'page')
             assert 'plain note' in '\n'.join(screen.display)
             key(b'\t', 'step-selected')
             key(b'\r', 'step-toggled')
-            saved = json.loads((state / 'tsk.json').read_text())
-            task = next(t for t in saved['tasks'] if t['number'] == 13)
+            task = saved_task(13, lambda t: t['steps'][0]['done'])
             assert task['steps'][0]['done'] and task['status'] == 'started'
             key(b'\x01', 'step-add-editor')
             key(b'New step\r', 'step-added')
-            saved = json.loads((state / 'tsk.json').read_text())
-            assert len(next(t for t in saved['tasks'] if t['number'] == 13)['steps']) == 3
+            assert len(saved_task(13, lambda t: len(t['steps']) == 3)['steps']) == 3
             key(b'\x1b', 'step-add-canceled')
             key(b'\x1b', 'back')
             assert 'IN MOTION' in '\n'.join(screen.display)

--- a/site/src/version.mjs
+++ b/site/src/version.mjs
@@ -1,2 +1,2 @@
 // Crate and plugin version, shown in the landing and docs headers.
-export const VERSION = '0.8.0';
+export const VERSION = '0.8.1';

--- a/src/announcements.rs
+++ b/src/announcements.rs
@@ -23,6 +23,10 @@ pub fn catalog() -> Result<Vec<Announcement>, String> {
 /// Ids are positive and strictly increasing in file order, titles carry no link.
 pub fn parse_catalog(toml: &str) -> Result<Vec<Announcement>, String> {
     let document: DocumentMut = toml.parse().map_err(|error| format!("catalog: {error}"))?;
+    // A comment-only file is a valid empty catalog: a release with nothing to announce.
+    if document.is_empty() {
+        return Ok(Vec::new());
+    }
     if document.len() != 1 {
         return Err("catalog: only [[announcement]] tables are allowed".to_string());
     }
@@ -39,7 +43,9 @@ pub fn parse_catalog(toml: &str) -> Result<Vec<Announcement>, String> {
         entries.push(entry);
     }
     if entries.is_empty() {
-        return Err("catalog: no announcements".to_string());
+        return Err(
+            "catalog: an empty announcement array is a mistake, delete the key".to_string(),
+        );
     }
     Ok(entries)
 }
@@ -204,7 +210,6 @@ mod tests {
     #[test]
     fn the_bundled_catalog_parses_and_ends_with_a_changelog_link() {
         let entries = catalog().expect("bundled catalog");
-        assert_eq!(entries[0].id, 1);
         for entry in &entries {
             assert!(
                 entry
@@ -406,6 +411,10 @@ mod tests {
     fn a_bad_catalog_fails_to_parse() {
         let good = "[[announcement]]\nid = 1\ntitle = \"a\"\nnotes = \"b\"\n";
         assert_eq!(parse_catalog(good).map(|c| c.len()), Ok(1));
+        assert_eq!(
+            parse_catalog("# nothing to announce\n").map(|c| c.len()),
+            Ok(0)
+        );
         let bad = [
             ("not toml", "[[announcement]\n"),
             ("no entries", "announcement = []\n"),

--- a/src/announcements/catalog.toml
+++ b/src/announcements/catalog.toml
@@ -1,14 +1,6 @@
 # Maintainer catalog for `src/announcements.rs`. Append with the next id; ids
 # increase and are never reused. Changelog URLs go in `notes`, never in `title`.
-
-[[announcement]]
-id = 1
-title = "Guides and release notes on your desk"
-notes = """
-Your desk now carries `N` rows: starter guides on a first install, and a
-what's-new note like this one after an upgrade. They sit like tasks and leave
-like tasks: `ctrl+d`, `ctrl+f`, or `ctrl+x` clears one for good. `tsk list`
-never shows them to agents.
-
-Changelog: https://github.com/smarzban/herdr-tsk/releases
-"""
+# A comment-only file means this release has nothing to announce.
+#
+# id 1 ("Guides and release notes on your desk") was retired before it shipped, so the
+# starter tour is the only thing a 0.7.x upgrader sees. The next entry is id 2.

--- a/tests/starter_guides.rs
+++ b/tests/starter_guides.rs
@@ -105,25 +105,25 @@ fn full_board_open_seeds_the_guides_once_beside_existing_tasks() {
         )
         .expect("task");
     store.save(&seeded).expect("save");
-    let newest = announcements::catalog()
-        .expect("bundled catalog")
-        .last()
-        .expect("at least one entry")
-        .id;
+    // An existing desk gets the four starter tasks, plus one What's new row only when the
+    // bundled catalog has something to announce.
+    let bundled = announcements::catalog().expect("bundled catalog");
+    let newest = bundled.last().map(|entry| entry.id).unwrap_or(0);
+    let whats_new = usize::from(!bundled.is_empty());
 
     let _ = load_board_model().expect("first open");
     let state = store.load().expect("load");
     assert_eq!(
         notices(&state).len(),
-        5,
-        "four starter tasks plus What's new for an existing desk"
+        4 + whats_new,
+        "four starter tasks plus What's new for an existing desk when the catalog has entries"
     );
     assert_eq!(
         notices(&state)
             .iter()
             .filter(|task| task.title == announcements::TITLE)
             .count(),
-        1
+        whats_new
     );
     assert_eq!(
         state
@@ -139,7 +139,7 @@ fn full_board_open_seeds_the_guides_once_beside_existing_tasks() {
     assert_eq!(record.announcement_watermark, newest);
 
     let _ = load_board_model().expect("second open");
-    assert_eq!(notices(&store.load().expect("reload")).len(), 5);
+    assert_eq!(notices(&store.load().expect("reload")).len(), 4 + whats_new);
 }
 
 #[test]
@@ -148,7 +148,7 @@ fn a_fresh_full_board_open_records_the_bundled_announcements_without_seeding_the
     suppress_background_fetch();
     let env = StateDirEnv::set("announcements");
     let bundled = announcements::catalog().expect("bundled catalog");
-    let newest = bundled.last().expect("at least one entry").id;
+    let newest = bundled.last().map(|entry| entry.id).unwrap_or(0);
 
     let _ = load_board_model().expect("first open");
     let state = TaskStore::new(&env.dir).load().expect("load");


### PR DESCRIPTION
Follow-up to the v0.8.0 pre-release rehearsal, which showed every 0.7.x upgrader receiving five notice rows (four starter tasks plus announcement id 1).

- `src/announcements/catalog.toml`: id 1 retired, file is comment-only; the parser accepts an empty catalog as "nothing to announce" (an empty `announcement = []` array still errors). Next id is 2.
- `tests/starter_guides.rs`: expectations derived from the bundled catalog so they hold with or without entries.
- Version 0.8.0 to 0.8.1 in the four version files; `check-version v0.8.1` passes.
- `CHANGELOG.md`: the v0.8.0 section becomes v0.8.1 (v0.8.0 never went official); the What's new line is reworded.

Green bar exit 0 (198 s), packaging suite 52 passed.

After merge: tag `v0.8.1`, dispatch `Prepare release`, flip to pre-release, re-verify the upgrade path shows N1 to N4 only, then promote. The v0.8.0 pre-release stays as is until the owner decides to delete it.
