### PR TITLE
Release workflow: name releases after the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,4 +122,4 @@ jobs:
       - name: Refuse a moved tag
         run: test "$(gh api "repos/$GITHUB_REPOSITORY/commits/refs%2Ftags%2F$TAG" --jq .sha)" = "$RELEASE_COMMIT"
       - name: Create draft only (refuses an existing release)
-        run: gh release create "$TAG" dist-release/* --verify-tag --draft --title "tsk $TAG" --notes-file packaging/RELEASE-NOTES.md
+        run: gh release create "$TAG" dist-release/* --verify-tag --draft --notes-file packaging/RELEASE-NOTES.md

--- a/tests/packaging/test_workflow.py
+++ b/tests/packaging/test_workflow.py
@@ -60,7 +60,7 @@ class WorkflowTests(unittest.TestCase):
         commands = re.findall(r"^        run: (gh release create[^\n]+)$", source, re.M)
         self.assertEqual(len(commands), 1, "release creation must use the reviewed handoff")
         # Do not execute arbitrary future workflow shell in the test environment.
-        self.assertEqual(commands[0], 'gh release create "$TAG" dist-release/* --verify-tag --draft --title "tsk $TAG" --notes-file packaging/RELEASE-NOTES.md')
+        self.assertEqual(commands[0], 'gh release create "$TAG" dist-release/* --verify-tag --draft --notes-file packaging/RELEASE-NOTES.md')
         self.assertEqual(source.count("gh release "), 1)
         triggers = source.split("on:\n", 1)[1].split("\npermissions:", 1)[0]
         self.assertEqual(re.findall(r"^  ([a-z_]+):", triggers, re.M), ["workflow_dispatch"])
@@ -86,7 +86,7 @@ class WorkflowTests(unittest.TestCase):
             arguments = json.loads(capture.read_text())
             self.assertEqual(arguments[:3], ["release", "create", "v1.2.3"])
             self.assertEqual(set(arguments[3:3 + len(names)]), {f"dist-release/{name}" for name in names})
-            self.assertEqual(arguments[3 + len(names):], ["--verify-tag", "--draft", "--title", "tsk v1.2.3", "--notes-file", "packaging/RELEASE-NOTES.md"])
+            self.assertEqual(arguments[3 + len(names):], ["--verify-tag", "--draft", "--notes-file", "packaging/RELEASE-NOTES.md"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Drops `--title "tsk $TAG"` from `gh release create`; GitHub falls back to the tag name, which is how v0.7.0 was named and how every other place in the repo refers to a release. The three 0.8.x releases are renamed by hand to match. Workflow test updated.