### PR TITLE
Release notes template: one-line Install section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,7 @@ Rehearsal traps, learned the hard way:
   path and setup, and says which of these it did not run.
 
 **Official release.** Replace the draft's skeleton and checklist with the version's
-`CHANGELOG.md` section verbatim (keep the Installation section), then promote the tested
+`CHANGELOG.md` section verbatim (keep the one-line Install section), then promote the tested
 assets, no rebuild: `gh release edit vX.Y.Z --prerelease=false --latest`. Confirm
 `https://github.com/smarzban/herdr-tsk/releases/latest` redirects to the new tag. Then,
 and only then, copy the generated `tsk.rb` to `Formula/tsk.rb` in `smarzban/homebrew-tap`

--- a/packaging/RELEASE-NOTES.md
+++ b/packaging/RELEASE-NOTES.md
@@ -1,4 +1,4 @@
-<!-- Release notes body. Before publishing, replace this comment and the Breaking/Added/Changed/Fixed skeleton with the matching `## vX.Y.Z` section of CHANGELOG.md, verbatim, dropping any empty subsection. Keep the Installation section. -->
+<!-- Release notes body. Before publishing, replace this comment and the Breaking/Added/Changed/Fixed skeleton with the matching `## vX.Y.Z` section of CHANGELOG.md, verbatim, dropping any empty subsection. Keep the Install section. -->
 
 ### Breaking
 
@@ -8,16 +8,9 @@
 
 ### Fixed
 
-## Installation
+## Install
 
-Download the archive for your platform and verify it against `SHA256SUMS` before extracting `tsk`.
-The Linux builds target musl (ARM64 and x86-64); macOS builds target Apple Silicon and Intel with a macOS 11 minimum deployment target.
-
-The attached `install.sh` installs the latest published stable release into `~/.local/bin` by default. Set `TSK_VERSION` to this release's tag to pin it, and `TSK_INSTALL_DIR` to choose another absolute directory. The installer adds PATH to Bash/Zsh startup files if needed, then prints instructions to reopen the terminal or run an export command. Other shells or protected startup files get manual instructions. When `herdr` is on PATH, an interactive install asks whether to run `tsk setup herdr` via the new binary; the wrap-up then points at the board (`prefix+t` after a successful setup, or `tsk setup herdr` / `tsk setup` when Herdr or agent-skill asks are declined / CI / no TTY). It never builds from main, uses sudo, or modifies task data.
-
-The generated `tsk.rb` is for the maintainer's Homebrew tap, not an application file to install by hand. Homebrew availability depends on the corresponding formula being published in `smarzban/homebrew-tap`.
-
-Run `tsk setup herdr` explicitly to register the embedded plugin assets with Herdr 0.9+, sharing the same installed binary for board and capture (the curl installer may offer this interactively when Herdr is already present; Homebrew prints this caveat instead). Setup adds prefix+t and prefix+a, asks before replacing conflicts, and requires an interactive terminal if any conflict exists. Reload Herdr configuration afterwards. Installing/upgrading alone does not relink a plugin unless you accept that prompt.
+`curl -fsSL https://gettsk.sh/install.sh | sh` or `brew install smarzban/tap/tsk`. Details, upgrades and uninstall: https://gettsk.sh/docs/install/
 
 ## Maintainer checklist before publishing
 


### PR DESCRIPTION
The Installation block in `packaging/RELEASE-NOTES.md` predates the site: four paragraphs of installer internals and tap caveats that duplicate https://gettsk.sh/docs/install/ and had already drifted (it described the pre-#78 wrap-up wording in the v0.8.2 notes). Now one line: the two install commands and a link. `AGENTS.md` release step reworded to match. Workflow test unaffected. The v0.8.2 release body is edited by hand to the same shape.